### PR TITLE
Chore: Add bundle stats back to scaffolding

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -27,14 +27,7 @@ jobs:
           NODE_VERSION=$(node -p "require('./package.json').engines.node.replace('>=', '')")
           echo "version=$NODE_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Generate bundle stats
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: grafana/plugin-actions/bundle-size@main
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-
       - name: Compare bundle stats
-        if: github.event_name == 'pull_request'
         uses: grafana/plugin-actions/bundle-size@main
         with:
           node-version: ${{ steps.node-version.outputs.version }}


### PR DESCRIPTION
Removed bundle stats from https://github.com/grafana/explore-metrics/pull/30 because it was failing the CI step. Adding it back here