### PR TITLE
fix: only run `bundle-stats` workflow on PRs

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
This reverts to the triggers from the original `.github/workflows/bundle-stats.yml` as provided by the `@grafana/create-plugin` scaffolding.