### PR TITLE
fix: configure shared URL for app plugin

### DIFF
--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -24,6 +24,7 @@ services:
       GF_LOG_LEVEL: debug
       GF_DATAPROXY_LOGGING: 1
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-metricsdrilldown-app
+      GF_SERVER_ROOT_URL: http://localhost:3001
 
   prometheus:
     image: prom/prometheus:v3.1.0

--- a/src/ShareTrailButton.tsx
+++ b/src/ShareTrailButton.tsx
@@ -2,6 +2,7 @@ import { config } from '@grafana/runtime';
 import { ToolbarButton } from '@grafana/ui';
 import React, { useState } from 'react';
 
+import { PLUGIN_BASE_URL } from './constants';
 import { type DataTrail } from './DataTrail';
 import { reportExploreMetrics } from './interactions';
 import { getUrlForTrail } from './utils';
@@ -17,7 +18,7 @@ export const ShareTrailButton = ({ trail }: ShareTrailButtonState) => {
     if (navigator.clipboard) {
       reportExploreMetrics('selected_metric_action_clicked', { action: 'share_url' });
       const appUrl = config.appUrl.endsWith('/') ? config.appUrl.slice(0, -1) : config.appUrl;
-      const url = appUrl + getUrlForTrail(trail);
+      const url = `${appUrl}${PLUGIN_BASE_URL}/${getUrlForTrail(trail)}`;
       navigator.clipboard.writeText(url);
       setTooltip('Copied!');
       setTimeout(() => {


### PR DESCRIPTION
## Related issue

This PR fixes #68.

## What does this change?

- Shared URLs now contain the appropriate app URL prefix
- The Grafana server that we run with `npm run server` is now configured to have its internal [`root_url`](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#root_url) match the external port that we've assigned to it