### PR TITLE
add config option to use regex operators

### DIFF
--- a/src/DataTrail.tsx
+++ b/src/DataTrail.tsx
@@ -650,6 +650,8 @@ function getVariableSet(
         layout: 'vertical',
         defaultKeys: [],
         applyMode: 'manual',
+        supportsMultiValueOperators: true,
+        allowCustomValue: true,
       }),
       new AdHocFiltersVariable({
         name: VAR_FILTERS,
@@ -663,6 +665,7 @@ function getVariableSet(
         applyMode: 'manual',
         // since we only support prometheus datasources, this is always true
         supportsMultiValueOperators: true,
+        allowCustomValue: true,
       }),
       ...getVariablesWithOtelJoinQueryConstant(otelJoinQuery ?? ''),
       new ConstantVariable({
@@ -686,6 +689,7 @@ function getVariableSet(
         applyMode: 'manual',
         // since we only support prometheus datasources, this is always true
         supportsMultiValueOperators: true,
+        allowCustomValue: true,
         // skipUrlSync: true
       }),
       // Legacy variable needed for bookmarking which is necessary because


### PR DESCRIPTION
Fixes https://github.com/grafana/metrics-drilldown/issues/76

There was a change in Scenes recently that removed regex operators in the adhoc filters variable if the config option "allowCustomValue" was not defined.

https://github.com/grafana/scenes/pull/1031

This change fixes that and ensures similar operators across all adhoc variable filters in the app.