### PR TITLE
fix: use correct access mechanism

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v2'
         with:
-          credentials_json: ${{ steps.get-secrets.outputs.GCP_UPLOAD_ARTIFACTS_KEY }}
+          credentials_json: '${{ env.GCP_UPLOAD_ARTIFACTS_KEY }}'
 
       - id: 'create-latest'
         run: cp ${{ steps.build-plugin.outputs.archive }} ${{ steps.metadata.outputs.archive }}

--- a/.github/workflows/update-main.yml
+++ b/.github/workflows/update-main.yml
@@ -66,7 +66,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v2'
         with:
-          credentials_json: ${{ steps.get-secrets.outputs.GCP_UPLOAD_ARTIFACTS_KEY }}
+          credentials_json: '${{ env.GCP_UPLOAD_ARTIFACTS_KEY }}'
 
       - id: 'upload-to-gcs'
         name: 'Upload assets to main'


### PR DESCRIPTION
## Relates issues

This PR supports #20

## What does it do?

Fixes the syntax for using secrets fetched with https://github.com/grafana/shared-workflows/tree/main/actions/get-vault-secrets.