### PR TITLE
fix: avoid redundant ci runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Related issues

This PR supports #20.

## What does this do?

Avoids running the CI job unnecessarily. We already run CI implicitly in `.github/workflows/deploy-main.yml` (via [`grafana/plugin-ci-workflows/.github/workflows/cd.yml@main`](https://github.com/grafana/plugin-ci-workflows/blob/main/.github/workflows/cd.yml)).