### PR TITLE
chore: set package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-metricsdrilldown-app",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bsull/augurs": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",
     "dev": "webpack -w -c ./webpack.config.ts --env development",


### PR DESCRIPTION
## Related issues

This supports #20.

## What is this doing?

Switching the version back to 1.0.0. In gcs, we already have an artifact directory for `1.0.0`, and I believe that switching the version back to `1.0.0` will avoid headaches with respect to deploying to cloud.

The 1.0.0 version also makes sense semantically, given the GA status of this project as it existed in `grafana/grafana`.