### PR TITLE
ci: wait for e2e before uploading to gcs

### DIFF
--- a/.github/workflows/update-latest-main.yml
+++ b/.github/workflows/update-latest-main.yml
@@ -229,7 +229,7 @@ jobs:
 
   upload-to-gcs:
     runs-on: ubuntu-latest
-    needs: build-latest-version
+    needs: [build-latest-version, playwright-tests]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Related issues

This PR supports #20.

## What does this do?

As seen in https://github.com/grafana/metrics-drilldown/actions/runs/13210132759, we aren't yet waiting for the e2e tests to pass before uploading to GCS. We should do that.