### PR TITLE
Chore: Update error message when no labels found

### DIFF
--- a/src/Breakdown/LabelBreakdownScene.tsx
+++ b/src/Breakdown/LabelBreakdownScene.tsx
@@ -267,7 +267,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
         : buildNormalLayout(this._query!, this.onBreakdownLayoutChange, this.state.search);
     } else if (!variable.state.loading) {
       stateUpdate.body = undefined;
-      stateUpdate.blockingMessage = 'Unable to retrieve label options for currently selected metric.';
+      stateUpdate.blockingMessage = 'There are no labels found for this metric.';
     }
 
     this.clearBreakdownPanelAxisValues();


### PR DESCRIPTION
Update error message to clearly state there are no labels (instead of implying Grafana had an error retrieving the labels)

Fixes https://github.com/grafana/metrics-drilldown/issues/73