### PR TITLE
Chore: Update copy and comments to refer to Metrics Drilldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Explore Metrics
+# Metrics Drilldown
 
-[Explore Metrics](https://grafana.com/docs/grafana/latest/explore/simplified-exploration/metrics) is not yet an externalized app. The code is part of `grafana/grafana` (in [`public/app/features/trails`](https://github.com/grafana/grafana/tree/main/public/app/features/trails)). This repository is a placeholder for future development. For more details, see: [DesignDoc: Externalizing Explore Metrics](https://docs.google.com/document/d/1M0i2XJ-lseb8gtCqk02vxxNUsWk5P7dbUP8449qJ9Rw/edit?usp=sharing).
+[Metrics Drilldown](https://grafana.com/docs/grafana/latest/explore/simplified-exploration/metrics) is not yet an externalized app. The code is part of `grafana/grafana` (in [`public/app/features/trails`](https://github.com/grafana/grafana/tree/main/public/app/features/trails)). This repository is a placeholder for future development. For more details, see: [DesignDoc: Externalizing Metrics Drilldown](https://docs.google.com/document/d/1M0i2XJ-lseb8gtCqk02vxxNUsWk5P7dbUP8449qJ9Rw/edit?usp=sharing).
 
 ## What are Grafana app plugins?
 

--- a/src/Integrations/dashboardIntegration.ts
+++ b/src/Integrations/dashboardIntegration.ts
@@ -117,7 +117,7 @@ function createCommonEmbeddedTrailStateProps(item: QueryMetric, dashboard: Dashb
 
   const commonProps = {
     scene: embeddedTrail,
-    title: 'Metrics Drilldown',
+    title: 'Metrics drilldown',
   };
 
   return commonProps;

--- a/src/Integrations/dashboardIntegration.ts
+++ b/src/Integrations/dashboardIntegration.ts
@@ -69,7 +69,7 @@ export async function addDataTrailPanelAction(
 
   if (subMenu.length > 0) {
     items.push({
-      text: 'Metrics Drilldown',
+      text: 'Metrics drilldown',
       iconClassName: 'code-branch',
       subMenu: getUnique(subMenu),
     });

--- a/src/Integrations/dashboardIntegration.ts
+++ b/src/Integrations/dashboardIntegration.ts
@@ -69,7 +69,7 @@ export async function addDataTrailPanelAction(
 
   if (subMenu.length > 0) {
     items.push({
-      text: 'Explore metrics',
+      text: 'Metrics Drilldown',
       iconClassName: 'code-branch',
       subMenu: getUnique(subMenu),
     });
@@ -117,7 +117,7 @@ function createCommonEmbeddedTrailStateProps(item: QueryMetric, dashboard: Dashb
 
   const commonProps = {
     scene: embeddedTrail,
-    title: 'Explore metrics',
+    title: 'Metrics Drilldown',
   };
 
   return commonProps;

--- a/src/MetricSelect/AddToExplorationsButton.tsx
+++ b/src/MetricSelect/AddToExplorationsButton.tsx
@@ -84,7 +84,7 @@ export class AddToExplorationButton extends SceneObjectBase<AddToExplorationButt
       return;
     }
     const ctx = {
-      origin: 'Explore Metrics',
+      origin: 'Metrics Drilldown',
       type: 'timeseries',
       queries,
       timeRange: { ...timeRange.state.value },

--- a/src/MetricSelect/MetricSelectScene.tsx
+++ b/src/MetricSelect/MetricSelectScene.tsx
@@ -577,7 +577,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
                 },
                 ...Array.from(rootGroup?.groups.keys() ?? []).map((g) => ({ label: `${g}_`, value: g })),
               ]}
-              className="explore-metrics-metric-prefix-select"
+              className="metrics-drilldown-metric-prefix-select"
             />
           </Field>
           {!metric && hasOtelResources && (

--- a/src/MetricSelect/api.ts
+++ b/src/MetricSelect/api.ts
@@ -57,7 +57,7 @@ export async function getMetricNamesWithoutScopes(
     ...(limit ? { limit } : {}),
   };
 
-  const response = await getBackendSrv().get<SuggestionsResponse>(url, params, 'explore-metrics-names');
+  const response = await getBackendSrv().get<SuggestionsResponse>(url, params, 'metrics-drilldown-names');
 
   if (limit && response.warnings?.includes(LIMIT_REACHED)) {
     return { ...response, limitReached: true, missingOtelTargets };
@@ -82,7 +82,7 @@ export async function getMetricNamesWithScopes(
     filters,
     '__name__',
     limit,
-    'explore-metrics-names'
+    'metrics-drilldown-names'
   );
 
   if (jobs.length > 0 && instances.length > 0) {

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
-# Explore-Metrics
+# Metrics-Drilldown
 
-Explore Metrics provides a query-less experience for browsing Prometheus-compatible metrics. Quickly find related metrics without writing PromQL queries.
+Metrics Drilldown provides a query-less experience for browsing Prometheus-compatible metrics. Quickly find related metrics without writing PromQL queries.
 
 ## Requirements
 
@@ -8,7 +8,7 @@ Requires Grafana 11.3.0 or newer.
 
 ## Getting Started
 
-See the [docs](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/metrics/#standalone-experience) for more info using Explore Metrics.
+See the [docs](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/metrics/#standalone-experience) for more info using Metrics Drilldown.
 
 ## Documentation
 
@@ -27,4 +27,4 @@ If your issue is a bug, please open one [here](https://github.com/grafana/metric
 ### Changes
 
 We do not have a formal proposal process for changes or feature requests. If you have a change you would like to see in
-Explore Metrics, please [file an issue](https://github.com/grafana/metrics-drilldown/issues/new) with the necessary details.
+Metrics Drilldown, please [file an issue](https://github.com/grafana/metrics-drilldown/issues/new) with the necessary details.

--- a/src/helpers/MetricDatasourceHelper.ts
+++ b/src/helpers/MetricDatasourceHelper.ts
@@ -162,7 +162,7 @@ export class MetricDatasourceHelper {
   }
 
   /**
-   * Used for additional filtering for adhoc vars labels in Explore metrics.
+   * Used for additional filtering for adhoc vars labels in Metrics Drilldown.
    * @param options
    * @returns
    */
@@ -178,7 +178,7 @@ export class MetricDatasourceHelper {
   }
 
   /**
-   * Used for additional filtering for adhoc vars label values in Explore metrics.
+   * Used for additional filtering for adhoc vars label values in Metrics Drilldown.
    * @param options
    * @returns
    */

--- a/src/otel/api.test.ts
+++ b/src/otel/api.test.ts
@@ -30,10 +30,10 @@ jest.mock('@grafana/runtime', () => ({
         requestId?: string,
         options?: Partial<BackendSrvRequest>
       ) => {
-        // explore-metrics-otel-resources
+        // metrics-drilldown-otel-resources
         if (
-          requestId === 'explore-metrics-otel-check-total-count(target_info{}) by (job, instance)' ||
-          requestId === 'explore-metrics-otel-check-total-count(metric) by (job, instance)'
+          requestId === 'metrics-drilldown-otel-check-total-count(target_info{}) by (job, instance)' ||
+          requestId === 'metrics-drilldown-otel-check-total-count(metric) by (job, instance)'
         ) {
           return Promise.resolve({
             data: {
@@ -43,17 +43,17 @@ jest.mock('@grafana/runtime', () => ({
               ],
             },
           });
-        } else if (requestId === 'explore-metrics-otel-resources-deployment-env') {
+        } else if (requestId === 'metrics-drilldown-otel-resources-deployment-env') {
           return Promise.resolve({ data: ['env1', 'env2'] });
         } else if (
           requestId ===
-          'explore-metrics-otel-resources-metric-job-instance-metric{job=~"job1|job2",instance=~"instance1|instance2"}'
+          'metrics-drilldown-otel-resources-metric-job-instance-metric{job=~"job1|job2",instance=~"instance1|instance2"}'
         ) {
           // part of getFilteredResourceAttributes to get metric labels. We prioritize metric labels over resource attributes so we use these to filter
           return Promise.resolve({ data: ['promotedResourceAttribute'] });
         } else if (
           requestId ===
-          'explore-metrics-otel-resources-metric-job-instance-target_info{job=~"job1|job2",instance=~"instance1|instance2"}'
+          'metrics-drilldown-otel-resources-metric-job-instance-target_info{job=~"job1|job2",instance=~"instance1|instance2"}'
         ) {
           // part of getFilteredResourceAttributes to get instance labels
           return Promise.resolve({ data: ['promotedResourceAttribute', 'resourceAttribute'] });

--- a/src/otel/api.ts
+++ b/src/otel/api.ts
@@ -55,7 +55,7 @@ export async function totalOtelResources(
   const responseTotal = await getBackendSrv().get<OtelResponse>(
     url,
     paramsTotalTargets,
-    `explore-metrics-otel-check-total-${query}`
+    `metrics-drilldown-otel-check-total-${query}`
   );
 
   let jobs: string[] = [];
@@ -126,7 +126,7 @@ export async function getDeploymentEnvironmentsWithoutScopes(
   const response = await getBackendSrv().get<LabelResponse>(
     url,
     params,
-    'explore-metrics-otel-resources-deployment-env'
+    'metrics-drilldown-otel-resources-deployment-env'
   );
 
   // exclude __name__ or previously chosen filters
@@ -161,7 +161,7 @@ export async function getDeploymentEnvironmentsWithScopes(
     ],
     'deployment_environment',
     undefined,
-    'explore-metrics-otel-resources-deployment-env'
+    'metrics-drilldown-otel-resources-deployment-env'
   );
   // exclude __name__ or previously chosen filters
   return response.data.data;
@@ -229,7 +229,7 @@ export async function getFilteredResourceAttributes(
   const metricResponse = await getBackendSrv().get<LabelResponse>(
     url,
     metricParams,
-    `explore-metrics-otel-resources-metric-job-instance-${metricMatchParam}`
+    `metrics-drilldown-otel-resources-metric-job-instance-${metricMatchParam}`
   );
   // the metric labels here
   const metricLabels = metricResponse.data ?? [];
@@ -248,7 +248,7 @@ export async function getFilteredResourceAttributes(
   const targetInfoResponse = await getBackendSrv().get<LabelResponse>(
     url,
     targetInfoParams,
-    `explore-metrics-otel-resources-metric-job-instance-${targetInfoMatchParam}`
+    `metrics-drilldown-otel-resources-metric-job-instance-${targetInfoMatchParam}`
   );
 
   const targetInfoAttributes = targetInfoResponse.data ?? [];
@@ -293,7 +293,7 @@ export async function getNonPromotedOtelResources(datasourceUid: string, timeRan
   const targetInfoResponse = getBackendSrv().get<LabelResponse>(
     url,
     targetInfoParams,
-    `explore-metrics-all-otel-resources-on-target_info`
+    `metrics-drilldown-all-otel-resources-on-target_info`
   );
 
   // all labels in all metrics
@@ -310,7 +310,7 @@ export async function getNonPromotedOtelResources(datasourceUid: string, timeRan
   const metricResponse = await getBackendSrv().get<LabelResponse>(
     url,
     metricParams,
-    `explore-metrics-all-metric-labels-not-otel-resource-attributes`
+    `metrics-drilldown-all-metric-labels-not-otel-resource-attributes`
   );
   const promResponses = await Promise.all([targetInfoResponse, metricResponse]);
   // otel resource attributes

--- a/src/otel/util.ts
+++ b/src/otel/util.ts
@@ -548,7 +548,7 @@ function checkLabelPromotion(filters: AdHocVariableFilter[], nonPromotedOtelReso
  * Once we know this, we can add the selected filter to either the
  * VAR_OTEL_RESOURCES or VAR_FILTERS variable.
  *
- * When the correct variable is updated, the rest of the explore metrics behavior will remain the same.
+ * When the correct variable is updated, the rest of the Metrics Drilldown behavior will remain the same.
  *
  * @param newStateFilters
  * @param prevStateFilters


### PR DESCRIPTION
Deprecate "Explore Metrics" in favor of "Metrics Drilldown"

Fixes https://github.com/grafana/metrics-drilldown/issues/96