### PR TITLE
fix: plugin signing

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -49,7 +49,6 @@ runs:
       shell: bash
       env:
         GRAFANA_ACCESS_POLICY_TOKEN: ${{ inputs.policy_token }}
-      if: ${{ inputs.policy_token != '' }}
 
     - name: Get plugin metadata
       id: metadata

--- a/.github/workflows/plugin-artifact.yml
+++ b/.github/workflows/plugin-artifact.yml
@@ -1,6 +1,7 @@
 name: build & upload plugin artifact to GCS
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -53,7 +54,7 @@ jobs:
         id: build
         uses: ./.github/actions/build
         with:
-          policy_token: ${{ steps.get-secrets.outputs.GRAFANA_ACCESS_POLICY_TOKEN }}
+          policy_token: ${{ env.GRAFANA_ACCESS_POLICY_TOKEN }}
 
   upload-to-gcs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Related issue

This PR supports #20.

## What does this do?

This fixes an issue that was preventing plugin signing. See https://github.com/grafana/shared-workflows/tree/main/actions/get-vault-secrets#get-vault-secrets for more information about the secrets patterns associated with `get-vault-secrets`.