### PR TITLE
fix: use `main` again now that it's been fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   CI:
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ee1344ca8211bc595561a92d88a023c31240487d
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
     with:
       upload-playwright-artifacts: true # IMPORTANT: we must ensure there are no unmasked secrets in the E2E tests


### PR DESCRIPTION
This PR allows us to use `main` again now that https://github.com/grafana/plugin-ci-workflows/pull/41 has been merged.