### PR TITLE
chore: exclude non-default provisioned plugins from source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 .env*
 !.env.example
 
+# Local provisioned datasources
+provisioning/datasources/
+!provisioning/datasources/default.yaml
+
 # Logs
 logs
 !src/**/logs


### PR DESCRIPTION
## What is this change?

This PR is a quality-of-life update. It allows us to provision datasources via a `provisioning/datasources/local.yaml` file (note: it doesn't need to be called `local`) without fear of committing any `secureJsonData[basicAuthPassword]`s to this repo.