### PR TITLE
RelatedLogs: Display count of found logs in the Related Logs tab

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,10 @@ services:
     container_name: 'grafana'
     environment:
       GF_SERVER_ROOT_URL: 'http://localhost:${GRAFANA_PORT:-3000}'
+      GF_FEATURE_TOGGLES_ENABLE: 'exploreMetricsRelatedLogs'
+    extra_hosts:
+      # This allows us to connect to other services running on the host machine.
+      - 'host.docker.internal:host-gateway'
 
   prometheus:
     container_name: 'prometheus'

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -46,7 +46,7 @@ function getStyles(theme: GrafanaTheme2) {
     appContainer: css({
       display: 'flex',
       flexDirection: 'column',
-      minHeight: '100vh', // Ensure full page height
+      height: '100%',
       backgroundColor: theme.colors.background.primary,
     }),
   };

--- a/src/Integrations/logs/base.ts
+++ b/src/Integrations/logs/base.ts
@@ -20,7 +20,7 @@ export interface MetricsLogsConnector {
   /**
    * Whether the conditions are met for related logs to be shown by the connector
    */
-  conditionsMetForRelatedLogs: boolean;
+  checkConditionsMetForRelatedLogs: () => boolean;
 
   /**
    * Retrieves the Loki data sources associated with the specified metric.

--- a/src/Integrations/logs/base.ts
+++ b/src/Integrations/logs/base.ts
@@ -18,6 +18,11 @@ export interface MetricsLogsConnector {
   name: string;
 
   /**
+   * Whether the conditions are met for related logs to be shown by the connector
+   */
+  conditionsMetForRelatedLogs: boolean;
+
+  /**
    * Retrieves the Loki data sources associated with the specified metric.
    */
   getDataSources(selectedMetric: string): Promise<FoundLokiDataSource[]>;

--- a/src/Integrations/logs/labelsCrossReference.ts
+++ b/src/Integrations/logs/labelsCrossReference.ts
@@ -82,7 +82,7 @@ export const createLabelsCrossReferenceConnector = (scene: SceneObject) => {
 
   return createMetricsLogsConnector({
     name: 'labelsCrossReference',
-    conditionsMetForRelatedLogs,
+    checkConditionsMetForRelatedLogs: () => conditionsMetForRelatedLogs,
     async getDataSources(): Promise<FoundLokiDataSource[]> {
       const trail = getTrailFor(scene);
       const filtersVariable = sceneGraph.lookupVariable(VAR_FILTERS, trail);

--- a/src/Integrations/logs/labelsCrossReference.ts
+++ b/src/Integrations/logs/labelsCrossReference.ts
@@ -3,7 +3,7 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { sceneGraph, type SceneObject } from '@grafana/scenes';
 
 import { createMetricsLogsConnector, type FoundLokiDataSource } from './base';
-import { findHealthyLokiDataSources } from '../../RelatedLogs/RelatedLogsManager';
+import { findHealthyLokiDataSources } from '../../RelatedLogs/RelatedLogsOrchestrator';
 import { VAR_FILTERS } from '../../shared';
 import { getTrailFor } from '../../utils';
 import { isAdHocFiltersVariable } from '../../utils/utils.variables';

--- a/src/Integrations/logs/labelsCrossReference.ts
+++ b/src/Integrations/logs/labelsCrossReference.ts
@@ -1,9 +1,9 @@
 import { type AdHocVariableFilter, type TimeRange } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
-import { sceneGraph } from '@grafana/scenes';
+import { sceneGraph, type SceneObject } from '@grafana/scenes';
 
 import { createMetricsLogsConnector, type FoundLokiDataSource } from './base';
-import { findHealthyLokiDataSources, type RelatedLogsScene } from '../../RelatedLogs/RelatedLogsScene';
+import { findHealthyLokiDataSources } from '../../RelatedLogs/RelatedLogsScene';
 import { VAR_FILTERS } from '../../shared';
 import { getTrailFor } from '../../utils';
 import { isAdHocFiltersVariable } from '../../utils/utils.variables';
@@ -76,7 +76,7 @@ async function hasMatchingLabels(datasourceUid: string, filters: AdHocVariableFi
   return results.every(Boolean);
 }
 
-export const createLabelsCrossReferenceConnector = (scene: RelatedLogsScene) => {
+export const createLabelsCrossReferenceConnector = (scene: SceneObject) => {
   return createMetricsLogsConnector({
     name: 'labelsCrossReference',
     async getDataSources(): Promise<FoundLokiDataSource[]> {

--- a/src/Integrations/logs/labelsCrossReference.ts
+++ b/src/Integrations/logs/labelsCrossReference.ts
@@ -77,16 +77,22 @@ async function hasMatchingLabels(datasourceUid: string, filters: AdHocVariableFi
 }
 
 export const createLabelsCrossReferenceConnector = (scene: SceneObject) => {
+  // In this connector, conditions have been met for related logs when label filters have been applied
+  let conditionsMetForRelatedLogs = false;
+
   return createMetricsLogsConnector({
     name: 'labelsCrossReference',
+    conditionsMetForRelatedLogs,
     async getDataSources(): Promise<FoundLokiDataSource[]> {
       const trail = getTrailFor(scene);
       const filtersVariable = sceneGraph.lookupVariable(VAR_FILTERS, trail);
 
       if (!isAdHocFiltersVariable(filtersVariable) || !filtersVariable.state.filters.length) {
+        conditionsMetForRelatedLogs = false;
         return [];
       }
 
+      conditionsMetForRelatedLogs = true;
       const filters = filtersVariable.state.filters.map(({ key, operator, value }) => ({ key, operator, value }));
 
       // Get current time range if available

--- a/src/Integrations/logs/labelsCrossReference.ts
+++ b/src/Integrations/logs/labelsCrossReference.ts
@@ -3,7 +3,7 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { sceneGraph, type SceneObject } from '@grafana/scenes';
 
 import { createMetricsLogsConnector, type FoundLokiDataSource } from './base';
-import { findHealthyLokiDataSources } from '../../RelatedLogs/RelatedLogsScene';
+import { findHealthyLokiDataSources } from '../../RelatedLogs/RelatedLogsManager';
 import { VAR_FILTERS } from '../../shared';
 import { getTrailFor } from '../../utils';
 import { isAdHocFiltersVariable } from '../../utils/utils.variables';

--- a/src/Integrations/logs/lokiRecordingRules.ts
+++ b/src/Integrations/logs/lokiRecordingRules.ts
@@ -5,7 +5,7 @@ import { type SyntaxNode } from '@lezer/common';
 import { lastValueFrom } from 'rxjs';
 
 import { createMetricsLogsConnector, type FoundLokiDataSource } from './base';
-import { findHealthyLokiDataSources } from '../../RelatedLogs/RelatedLogsManager';
+import { findHealthyLokiDataSources } from '../../RelatedLogs/RelatedLogsOrchestrator';
 
 export interface RecordingRuleGroup {
   name: string;

--- a/src/Integrations/logs/lokiRecordingRules.ts
+++ b/src/Integrations/logs/lokiRecordingRules.ts
@@ -183,7 +183,7 @@ const createLokiRecordingRulesConnector = () => {
 
   return createMetricsLogsConnector({
     name: 'lokiRecordingRules',
-    conditionsMetForRelatedLogs,
+    checkConditionsMetForRelatedLogs: () => conditionsMetForRelatedLogs,
     async getDataSources(selectedMetric: string): Promise<FoundLokiDataSource[]> {
       lokiRecordingRules = await fetchAndExtractLokiRecordingRules();
       const lokiDataSources = getDataSourcesWithRecordingRulesContainingMetric(selectedMetric, lokiRecordingRules);

--- a/src/Integrations/logs/lokiRecordingRules.ts
+++ b/src/Integrations/logs/lokiRecordingRules.ts
@@ -176,15 +176,21 @@ export async function fetchAndExtractLokiRecordingRules() {
 const createLokiRecordingRulesConnector = () => {
   let lokiRecordingRules: ExtractedRecordingRules = {};
 
+  // In this connector, conditions have been met for related logs
+  // when we find at least one data source with recording rules
+  // containing the selected metric
+  let conditionsMetForRelatedLogs = false;
+
   return createMetricsLogsConnector({
     name: 'lokiRecordingRules',
+    conditionsMetForRelatedLogs,
     async getDataSources(selectedMetric: string): Promise<FoundLokiDataSource[]> {
       lokiRecordingRules = await fetchAndExtractLokiRecordingRules();
       const lokiDataSources = getDataSourcesWithRecordingRulesContainingMetric(selectedMetric, lokiRecordingRules);
+      conditionsMetForRelatedLogs = Boolean(lokiDataSources.length);
 
       return lokiDataSources;
     },
-
     getLokiQueryExpr(selectedMetric: string, datasourceUid: string): string {
       return getLokiQueryForRelatedMetric(selectedMetric, datasourceUid, lokiRecordingRules);
     },

--- a/src/Integrations/logs/lokiRecordingRules.ts
+++ b/src/Integrations/logs/lokiRecordingRules.ts
@@ -5,7 +5,7 @@ import { type SyntaxNode } from '@lezer/common';
 import { lastValueFrom } from 'rxjs';
 
 import { createMetricsLogsConnector, type FoundLokiDataSource } from './base';
-import { findHealthyLokiDataSources } from '../../RelatedLogs/RelatedLogsScene';
+import { findHealthyLokiDataSources } from '../../RelatedLogs/RelatedLogsManager';
 
 export interface RecordingRuleGroup {
   name: string;

--- a/src/MetricGraphScene.tsx
+++ b/src/MetricGraphScene.tsx
@@ -58,6 +58,7 @@ function getStyles(theme: GrafanaTheme2, chromeHeaderHeight: number) {
       display: 'flex',
       flexDirection: 'column',
       position: 'relative',
+      flexGrow: 1,
     }),
     sticky: css({
       display: 'flex',

--- a/src/MetricScene.tsx
+++ b/src/MetricScene.tsx
@@ -30,7 +30,7 @@ import {
   METRIC_AUTOVIZPANEL_KEY,
   MetricGraphScene,
 } from './MetricGraphScene';
-import { RelatedLogsManager } from './RelatedLogs/RelatedLogsManager';
+import { RelatedLogsOrchestrator } from './RelatedLogs/RelatedLogsOrchestrator';
 import { buildRelatedLogsScene } from './RelatedLogs/RelatedLogsScene';
 import {
   getVariablesWithMetricConstant,
@@ -68,14 +68,14 @@ export const actionViews = {
 export type ActionViewType = (typeof actionViews)[keyof typeof actionViews];
 
 export class MetricScene extends SceneObjectBase<MetricSceneState> {
+  public readonly relatedLogsOrchestrator = new RelatedLogsOrchestrator(this);
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['actionView'] });
-  public relatedLogsManager = new RelatedLogsManager(this);
   protected _variableDependency = new VariableDependencyConfig(this, {
     variableNames: [VAR_FILTERS],
     onReferencedVariableValueChanged: () => {
       // When filters change, we need to re-check for related logs
       if (relatedLogsFeatureEnabled) {
-        this.relatedLogsManager.handleFiltersChange();
+        this.relatedLogsOrchestrator.handleFiltersChange();
       }
     },
   });
@@ -99,8 +99,8 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
     }
 
     if (relatedLogsFeatureEnabled) {
-      this.relatedLogsManager.initializeLokiDatasources();
-      this.relatedLogsManager.addRelatedLogsCountChangeHandler((count) => {
+      this.relatedLogsOrchestrator.initializeLokiDatasources();
+      this.relatedLogsOrchestrator.addRelatedLogsCountChangeHandler((count) => {
         this.setState({ relatedLogsCount: count });
       });
     }
@@ -166,7 +166,7 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
   public createRelatedLogsScene(): SceneObject<SceneObjectState> {
     // Create the scene with the current datasources and the manager
     return buildRelatedLogsScene({
-      manager: this.relatedLogsManager,
+      orchestrator: this.relatedLogsOrchestrator,
     });
   }
 }

--- a/src/MetricScene.tsx
+++ b/src/MetricScene.tsx
@@ -171,15 +171,13 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
    * Creates a Related Logs scene with the current state
    */
   public createRelatedLogsScene(): SceneObject<SceneObjectState> {
-    const { lokiDataSources, relatedLogsCount } = this.state;
+    const { lokiDataSources } = this.state;
     const relatedLogsManager = this._relatedLogsManager;
 
-    // Create the scene with the current datasources and loading state
+    // Create the scene with the current datasources
     const scene = buildRelatedLogsScene({
       lokiDataSources: lokiDataSources || [],
-      // If we have a logs count but no scene is showing logs,
-      // set isLoading to true to trigger a refresh
-      isLoading: relatedLogsCount && relatedLogsCount > 0 ? true : false,
+      // No need for isLoading flag - we'll use proper scene mechanisms instead
     });
 
     // Initialize datasources if needed
@@ -188,7 +186,6 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
     }
 
     // Add an activation handler to refresh logs data when the scene is activated
-    // This is the proper @grafana/scenes way to handle initialization after the scene is created
     scene.addActivationHandler(() => {
       if (relatedLogsManager) {
         relatedLogsManager.refreshLogsData();

--- a/src/MetricScene.tsx
+++ b/src/MetricScene.tsx
@@ -140,14 +140,9 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
     if (actionViewDef && actionViewDef.value !== this.state.actionView) {
       // reduce max height for main panel to reduce height flicker
       body.state.topView.state.children[0].setState({ maxHeight: MAIN_PANEL_MIN_HEIGHT });
-
-      // Get the scene from the action view definition
-      const scene = actionViewDef.getScene(this);
-
-      // Update the state
-      body.setState({ selectedTab: scene });
+      body.setState({ selectedTab: actionViewDef.getScene(this) });
       this.setState({ actionView: actionViewDef.value });
-    } else if (this.state.actionView !== undefined) {
+    } else {
       // restore max height
       body.state.topView.state.children[0].setState({ maxHeight: MAIN_PANEL_MAX_HEIGHT });
       body.setState({ selectedTab: undefined });
@@ -160,11 +155,7 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
     return <body.Component model={body} />;
   };
 
-  /**
-   * Creates a Related Logs scene with the current state
-   */
   public createRelatedLogsScene(): SceneObject<SceneObjectState> {
-    // Create the scene with the current datasources and the manager
     return buildRelatedLogsScene({
       orchestrator: this.relatedLogsOrchestrator,
     });

--- a/src/MetricScene.tsx
+++ b/src/MetricScene.tsx
@@ -171,14 +171,11 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
    * Creates a Related Logs scene with the current state
    */
   public createRelatedLogsScene(): SceneObject<SceneObjectState> {
-    const { lokiDataSources } = this.state;
+    const lokiDataSources = this.state.lokiDataSources ?? [];
     const relatedLogsManager = this._relatedLogsManager;
 
     // Create the scene with the current datasources
-    const scene = buildRelatedLogsScene({
-      lokiDataSources: lokiDataSources || [],
-      // No need for isLoading flag - we'll use proper scene mechanisms instead
-    });
+    const scene = buildRelatedLogsScene({ lokiDataSources });
 
     // Initialize datasources if needed
     if (lokiDataSources === undefined && relatedLogsManager) {

--- a/src/MetricScene.tsx
+++ b/src/MetricScene.tsx
@@ -99,7 +99,7 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
     }
 
     if (relatedLogsFeatureEnabled) {
-      this.relatedLogsOrchestrator.initializeLokiDatasources();
+      this.relatedLogsOrchestrator.findAndCheckAllDatasources();
       this.relatedLogsOrchestrator.addRelatedLogsCountChangeHandler((count) => {
         this.setState({ relatedLogsCount: count });
       });

--- a/src/MetricScene.tsx
+++ b/src/MetricScene.tsx
@@ -23,7 +23,7 @@ import { AutoVizPanel } from './autoQuery/components/AutoVizPanel';
 import { getAutoQueriesForMetric } from './autoQuery/getAutoQueriesForMetric';
 import { type AutoQueryDef, type AutoQueryInfo } from './autoQuery/types';
 import { buildLabelBreakdownActionScene } from './Breakdown/LabelBreakdownScene';
-import { reportExploreMetrics } from './interactions';
+import { reportExploreMetrics, type Interactions } from './interactions';
 import {
   MAIN_PANEL_MAX_HEIGHT,
   MAIN_PANEL_MIN_HEIGHT,
@@ -301,7 +301,13 @@ export class MetricActionBar extends SceneObjectBase<MetricActionBarState> {
                 counter={counter}
                 active={actionView === tab.value}
                 onChangeTab={() => {
-                  reportExploreMetrics('metric_action_view_changed', { view: tab.value });
+                  const actionViewChangedPayload: Interactions['metric_action_view_changed'] = { view: tab.value };
+
+                  if (relatedLogsFeatureEnabled) {
+                    actionViewChangedPayload.related_logs_count = counter;
+                  }
+
+                  reportExploreMetrics('metric_action_view_changed', actionViewChangedPayload);
                   metricScene.setActionView(tab.value);
                 }}
               />

--- a/src/MetricScene.tsx
+++ b/src/MetricScene.tsx
@@ -119,10 +119,6 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
     }
   }
 
-  public updateRelatedLogsCount(count: number) {
-    this.setState({ relatedLogsCount: count });
-  }
-
   getUrlState() {
     return { actionView: this.state.actionView };
   }

--- a/src/MetricScene.tsx
+++ b/src/MetricScene.tsx
@@ -172,24 +172,18 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
    */
   public createRelatedLogsScene(): SceneObject<SceneObjectState> {
     const lokiDataSources = this.state.lokiDataSources ?? [];
-    const relatedLogsManager = this._relatedLogsManager;
 
-    // Create the scene with the current datasources
-    const scene = buildRelatedLogsScene({ lokiDataSources });
-
-    // Initialize datasources if needed
-    if (lokiDataSources === undefined && relatedLogsManager) {
-      relatedLogsManager.initializeLokiDatasources();
+    // Ensure we have a manager
+    if (!this._relatedLogsManager) {
+      // Create a new manager if one doesn't exist
+      this._relatedLogsManager = new RelatedLogsManager(this);
     }
 
-    // Add an activation handler to refresh logs data when the scene is activated
-    scene.addActivationHandler(() => {
-      if (relatedLogsManager) {
-        relatedLogsManager.refreshLogsData();
-      }
+    // Create the scene with the current datasources and the manager
+    return buildRelatedLogsScene({
+      lokiDataSources,
+      manager: this._relatedLogsManager,
     });
-
-    return scene;
   }
 }
 

--- a/src/MetricScene.tsx
+++ b/src/MetricScene.tsx
@@ -282,7 +282,10 @@ export class MetricActionBar extends SceneObjectBase<MetricActionBarState> {
                 onChangeTab={() => {
                   const actionViewChangedPayload: Interactions['metric_action_view_changed'] = { view: tab.value };
 
-                  if (relatedLogsFeatureEnabled) {
+                  if (
+                    relatedLogsFeatureEnabled &&
+                    metricScene.relatedLogsOrchestrator.checkConditionsMetForRelatedLogs()
+                  ) {
                     actionViewChangedPayload.related_logs_count = counter;
                   }
 

--- a/src/MetricScene.tsx
+++ b/src/MetricScene.tsx
@@ -62,7 +62,7 @@ export const actionViews = {
   overview: 'overview',
   breakdown: 'breakdown',
   related: 'related',
-  relatedLogs: 'related_logs',
+  relatedLogs: 'logs',
 } as const;
 
 export type ActionViewType = (typeof actionViews)[keyof typeof actionViews];

--- a/src/RelatedLogs/NoRelatedLogsFoundScene.tsx
+++ b/src/RelatedLogs/NoRelatedLogsFoundScene.tsx
@@ -27,8 +27,7 @@ export class NoRelatedLogsScene extends SceneObjectBase<SceneObjectState> {
           </ul>
         </Text>
         <Text variant="bodySmall" color="secondary">
-          Note: Related logs is an experimental feature that attempts to find logs with labels matching your current
-          metric selection.
+          Note: Related logs is an experimental feature.
         </Text>
       </Stack>
     );

--- a/src/RelatedLogs/NoRelatedLogsFoundScene.tsx
+++ b/src/RelatedLogs/NoRelatedLogsFoundScene.tsx
@@ -14,16 +14,16 @@ export class NoRelatedLogsScene extends SceneObjectBase<SceneObjectState> {
           We couldn&apos;t find any logs related to the current metric with your selected filters.
         </Alert>
         <Text>
-          To find related logs, you can try:
+          To find related logs, try the following:
           <ul className={styles.list}>
-            <li>Adjusting your label filters to include labels that exist in both the current metric and your logs</li>
+            <li>Adjust your label filters to include labels that exist in both the current metric and your logs</li>
             <li>
-              Selecting a metric created by a{' '}
+              Select a metric created by a{' '}
               <TextLink external href="https://grafana.com/docs/loki/latest/alert/#recording-rules">
                 Loki Recording Rule
               </TextLink>
             </li>
-            <li>Broadening the time range to include more data</li>
+            <li>Broaden the time range to include more data</li>
           </ul>
         </Text>
         <Text variant="bodySmall" color="secondary">

--- a/src/RelatedLogs/NoRelatedLogsFoundScene.tsx
+++ b/src/RelatedLogs/NoRelatedLogsFoundScene.tsx
@@ -11,19 +11,19 @@ export class NoRelatedLogsScene extends SceneObjectBase<SceneObjectState> {
     return (
       <Stack direction="column" gap={2}>
         <Alert title="No related logs found" severity="info">
-          We couldn't find any logs related to the current metric with your selected filters.
+          We couldn&apos;t find any logs related to the current metric with your selected filters.
         </Alert>
         <Text>
           To find related logs, you can try:
           <ul className={styles.list}>
-            <li>Selecting labels that are shared by the current metric and your logs</li>
+            <li>Adjusting your label filters to include labels that exist in both the current metric and your logs</li>
             <li>
               Selecting a metric created by a{' '}
               <TextLink external href="https://grafana.com/docs/loki/latest/alert/#recording-rules">
                 Loki Recording Rule
               </TextLink>
             </li>
-            <li>Adjusting the time range to include more data</li>
+            <li>Broadening the time range to include more data</li>
           </ul>
         </Text>
         <Text variant="bodySmall" color="secondary">

--- a/src/RelatedLogs/NoRelatedLogsFoundScene.tsx
+++ b/src/RelatedLogs/NoRelatedLogsFoundScene.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { SceneObjectBase, type SceneObjectState } from '@grafana/scenes';
-import { Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
+import { Alert, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 export class NoRelatedLogsScene extends SceneObjectBase<SceneObjectState> {
@@ -9,19 +9,26 @@ export class NoRelatedLogsScene extends SceneObjectBase<SceneObjectState> {
     const styles = useStyles2(getStyles);
 
     return (
-      <Stack direction="column" gap={1}>
-        <Text color="warning">Related logs is an experimental feature.</Text>
+      <Stack direction="column" gap={2}>
+        <Alert title="No related logs found" severity="info">
+          We couldn't find any logs related to the current metric with your selected filters.
+        </Alert>
         <Text>
-          No related logs found. To see related logs, you can either:
+          To find related logs, you can try:
           <ul className={styles.list}>
-            <li>adjust the label filter to find logs with the same labels as the currently-selected metric</li>
+            <li>Selecting labels that are shared by the current metric and your logs</li>
             <li>
-              select a metric created by a{' '}
+              Selecting a metric created by a{' '}
               <TextLink external href="https://grafana.com/docs/loki/latest/alert/#recording-rules">
                 Loki Recording Rule
               </TextLink>
             </li>
+            <li>Adjusting the time range to include more data</li>
           </ul>
+        </Text>
+        <Text variant="bodySmall" color="secondary">
+          Note: Related logs is an experimental feature that attempts to find logs with labels matching your current
+          metric selection.
         </Text>
       </Stack>
     );
@@ -32,6 +39,7 @@ function getStyles(theme: GrafanaTheme2) {
   return {
     list: css({
       paddingLeft: theme.spacing(2),
+      marginTop: theme.spacing(1),
     }),
   };
 }

--- a/src/RelatedLogs/RelatedLogsManager.ts
+++ b/src/RelatedLogs/RelatedLogsManager.ts
@@ -60,11 +60,17 @@ export class RelatedLogsManager {
     // Reset logs count immediately to avoid showing stale counts
     this._metricScene.updateRelatedLogsCount(0);
 
-    // Show loading state in the RelatedLogsScene if it's active
+    // Get the active RelatedLogsScene
     const relatedLogsScene = this.getActiveRelatedLogsScene();
+
+    // Instead of directly setting isLoading or calling a private method,
+    // we'll update the scene's state in a way that triggers the loading UI
+    // This is more idiomatic for @grafana/scenes
     if (relatedLogsScene) {
+      // Set lokiDataSources to an empty array to trigger the loading UI
+      // The RelatedLogsScene will handle this appropriately in its state subscription
       relatedLogsScene.setState({
-        isLoading: true,
+        lokiDataSources: [],
       });
     }
 
@@ -154,13 +160,6 @@ export class RelatedLogsManager {
     // Get the active RelatedLogsScene once to avoid repeated lookups
     const relatedLogsScene = this.getActiveRelatedLogsScene();
 
-    // If the RelatedLogsScene is active, ensure it shows a loading state
-    if (relatedLogsScene) {
-      relatedLogsScene.setState({
-        isLoading: true,
-      });
-    }
-
     // Check each datasource for logs
     datasources.forEach((datasource) => {
       const queryRunner = new SceneQueryRunner({
@@ -221,8 +220,6 @@ export class RelatedLogsManager {
             if (relatedLogsScene) {
               relatedLogsScene.setState({
                 lokiDataSources: datasourcesWithLogs.length > 0 ? datasourcesWithLogs : [],
-                // Only set isLoading to false if we found logs, otherwise let the scene handle it
-                isLoading: false,
               });
             }
           }
@@ -262,7 +259,6 @@ export class RelatedLogsManager {
       if (relatedLogsScene) {
         relatedLogsScene.setState({
           lokiDataSources: lokiDataSources,
-          isLoading: false,
         });
       }
     }

--- a/src/RelatedLogs/RelatedLogsManager.ts
+++ b/src/RelatedLogs/RelatedLogsManager.ts
@@ -63,7 +63,7 @@ export class RelatedLogsManager {
     }
 
     // Reset logs count immediately to avoid showing stale counts
-    this._metricScene.updateRelatedLogsCount(0);
+    this._metricScene.setState({ relatedLogsCount: 0 });
 
     // Update the scene to indicate new data is being loaded
     // This approach sets lokiDataSources to an empty array which will
@@ -202,12 +202,10 @@ export class RelatedLogsManager {
     datasourcesWithLogs: Array<DataSourceInstanceSettings<DataSourceJsonData>>,
     totalLogsCount: number
   ): void {
-    // Update logs count
-    this._metricScene.updateRelatedLogsCount(totalLogsCount);
-
-    // Update MetricScene with datasources that have logs
+    // Update MetricScene with logs count & datasources that have logs
     this._metricScene.setState({
       lokiDataSources: datasourcesWithLogs,
+      relatedLogsCount: totalLogsCount,
     });
 
     // Update the RelatedLogsScene if active

--- a/src/RelatedLogs/RelatedLogsManager.ts
+++ b/src/RelatedLogs/RelatedLogsManager.ts
@@ -1,0 +1,270 @@
+import { type DataSourceInstanceSettings, type DataSourceJsonData } from '@grafana/data';
+import { SceneQueryRunner } from '@grafana/scenes';
+
+import { type MetricsLogsConnector } from '../Integrations/logs/base';
+import { createLabelsCrossReferenceConnector } from '../Integrations/logs/labelsCrossReference';
+import { lokiRecordingRulesConnector } from '../Integrations/logs/lokiRecordingRules';
+import { type MetricScene } from '../MetricScene';
+import { findHealthyLokiDataSources, type RelatedLogsScene } from './RelatedLogsScene';
+
+/**
+ * Manager class that handles the orchestration of related logs functionality.
+ * This centralizes logs-related logic that was previously spread across multiple components.
+ */
+export class RelatedLogsManager {
+  private _metricScene: MetricScene;
+  private _logsConnectors: MetricsLogsConnector[];
+  private _activeQueryRunners: SceneQueryRunner[] = [];
+
+  constructor(metricScene: MetricScene) {
+    this._metricScene = metricScene;
+    this._logsConnectors = [lokiRecordingRulesConnector, createLabelsCrossReferenceConnector(metricScene)];
+  }
+
+  /**
+   * Initialize Loki datasources by fetching healthy ones and updating the MetricScene state.
+   * If the Related Logs tab is active, it also updates the RelatedLogsScene.
+   */
+  public async initializeLokiDatasources(): Promise<void> {
+    const lokiDataSources = await findHealthyLokiDataSources();
+
+    // Update MetricScene state
+    this._metricScene.setState({
+      lokiDataSources,
+      relatedLogsCount: 0,
+    });
+
+    // If the Related logs tab is active, update it directly
+    const relatedLogsScene = this.getActiveRelatedLogsScene();
+    if (relatedLogsScene) {
+      relatedLogsScene.setState({
+        lokiDataSources: lokiDataSources,
+      });
+    }
+
+    // Then check which ones have logs
+    if (lokiDataSources.length > 0) {
+      this.checkLogsInDataSources(lokiDataSources);
+    }
+  }
+
+  /**
+   * Called when filters change to re-check for logs in datasources.
+   */
+  public handleFiltersChange(): void {
+    const { lokiDataSources } = this._metricScene.state;
+    if (!lokiDataSources) {
+      return;
+    }
+
+    // Reset logs count immediately to avoid showing stale counts
+    this._metricScene.updateRelatedLogsCount(0);
+
+    // Show loading state in the RelatedLogsScene if it's active
+    const relatedLogsScene = this.getActiveRelatedLogsScene();
+    if (relatedLogsScene) {
+      relatedLogsScene.setState({
+        isLoading: true,
+      });
+    }
+
+    // Always use all available datasources when filters change
+    // This ensures we check all possible datasources for logs after filter changes
+    this.findAndCheckAllDatasources();
+  }
+
+  /**
+   * Find all available datasources and check them for logs.
+   * This is used when filters change to ensure we're checking all possible datasources.
+   */
+  private async findAndCheckAllDatasources(): Promise<void> {
+    // Get all available Loki datasources
+    const allLokiDatasources = await findHealthyLokiDataSources();
+
+    // Check all datasources for logs
+    if (allLokiDatasources.length > 0) {
+      this.checkLogsInDataSources(allLokiDatasources);
+    } else {
+      // No datasources available
+      this._metricScene.updateRelatedLogsCount(0);
+      this._metricScene.setState({
+        lokiDataSources: [],
+      });
+
+      // Update the RelatedLogsScene if active
+      const relatedLogsScene = this.getActiveRelatedLogsScene();
+      if (relatedLogsScene) {
+        relatedLogsScene.setState({
+          lokiDataSources: [],
+        });
+      }
+    }
+  }
+
+  /**
+   * Release resources used by this manager.
+   */
+  public dispose(): void {
+    this.cleanupQueryRunners();
+  }
+
+  /**
+   * Get the active RelatedLogsScene if Related Logs tab is selected.
+   */
+  private getActiveRelatedLogsScene(): RelatedLogsScene | undefined {
+    const { actionView, body } = this._metricScene.state;
+    if (actionView === 'related_logs' && body.state.selectedTab) {
+      return body.state.selectedTab as RelatedLogsScene;
+    }
+    return undefined;
+  }
+
+  /**
+   * Check each datasource for logs and update the MetricScene and RelatedLogsScene accordingly.
+   */
+  private checkLogsInDataSources(datasources: Array<DataSourceInstanceSettings<DataSourceJsonData>>): void {
+    // Clean up existing query runners
+    this.cleanupQueryRunners();
+
+    // Get metric name
+    const { metric } = this._metricScene.state;
+
+    // Check each datasource for logs
+    const datasourcesWithLogs: Array<DataSourceInstanceSettings<DataSourceJsonData>> = [];
+    let totalLogsCount = 0;
+    let totalChecked = 0;
+
+    // If no datasources to check, update immediately
+    if (datasources.length === 0) {
+      this._metricScene.updateRelatedLogsCount(0);
+      this._metricScene.setState({
+        lokiDataSources: [],
+      });
+
+      // Update the RelatedLogsScene if active
+      const relatedLogsScene = this.getActiveRelatedLogsScene();
+      if (relatedLogsScene) {
+        relatedLogsScene.setState({
+          lokiDataSources: [],
+        });
+      }
+      return;
+    }
+
+    // Get the active RelatedLogsScene once to avoid repeated lookups
+    const relatedLogsScene = this.getActiveRelatedLogsScene();
+
+    // If the RelatedLogsScene is active, ensure it shows a loading state
+    if (relatedLogsScene) {
+      relatedLogsScene.setState({
+        isLoading: true,
+      });
+    }
+
+    // Check each datasource for logs
+    datasources.forEach((datasource) => {
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: datasource.uid },
+        queries: [],
+        key: `logs_check_${datasource.uid}`,
+      });
+
+      // Track this query runner for later cleanup
+      this._activeQueryRunners.push(queryRunner);
+
+      // Build queries for this datasource
+      const lokiQueries = this._logsConnectors.reduce<Record<string, string>>((acc, connector, idx) => {
+        const lokiExpr = connector.getLokiQueryExpr(metric, datasource.uid);
+        if (lokiExpr) {
+          acc[connector.name ?? `connector-${idx}`] = lokiExpr;
+        }
+        return acc;
+      }, {});
+
+      // Set queries
+      queryRunner.setState({
+        queries: Object.keys(lokiQueries).map((connectorName) => ({
+          refId: `RelatedLogs-${connectorName}`,
+          expr: lokiQueries[connectorName],
+          maxLines: 100,
+        })),
+      });
+
+      // Subscribe to results
+      queryRunner.subscribeToState((state) => {
+        if (state.data?.state === 'Done') {
+          totalChecked++;
+
+          // Check if we found logs in this datasource
+          if (state.data?.series) {
+            const rowCount = state.data.series.reduce((sum: number, frame) => sum + frame.length, 0);
+            if (rowCount > 0) {
+              // This datasource has logs
+              datasourcesWithLogs.push(datasource);
+              totalLogsCount += rowCount;
+              // Don't update the count here, wait until all datasources are checked
+            }
+          }
+
+          // When all datasources have been checked
+          if (totalChecked === datasources.length) {
+            // Update the logs count once all datasources have been checked
+            this._metricScene.updateRelatedLogsCount(totalLogsCount);
+
+            // Store the datasources with logs in the MetricScene state
+            // This ensures that when the RelatedLogsScene is created, it gets the correct datasources
+            this._metricScene.setState({
+              lokiDataSources: datasourcesWithLogs.length > 0 ? datasourcesWithLogs : [],
+            });
+
+            // Update the RelatedLogsScene if active
+            if (relatedLogsScene) {
+              relatedLogsScene.setState({
+                lokiDataSources: datasourcesWithLogs.length > 0 ? datasourcesWithLogs : [],
+                // Only set isLoading to false if we found logs, otherwise let the scene handle it
+                isLoading: false,
+              });
+            }
+          }
+        }
+      });
+
+      // Activate query
+      queryRunner.activate();
+    });
+  }
+
+  /**
+   * Clean up all active query runners.
+   */
+  private cleanupQueryRunners(): void {
+    this._activeQueryRunners.forEach((runner) => {
+      runner.setState({ queries: [] });
+    });
+    this._activeQueryRunners = [];
+  }
+
+  /**
+   * Called when the Related Logs tab is activated to ensure it has the latest data.
+   * This is particularly important when the tab is activated after filters have changed.
+   */
+  public refreshLogsData(): void {
+    const { lokiDataSources, relatedLogsCount } = this._metricScene.state;
+
+    // If we have a logs count but no datasources with logs in the scene,
+    // we need to re-check for logs
+    if (relatedLogsCount && relatedLogsCount > 0 && (!lokiDataSources || lokiDataSources.length === 0)) {
+      // Initialize datasources if needed
+      this.initializeLokiDatasources();
+    } else if (lokiDataSources && lokiDataSources.length > 0) {
+      // We have datasources with logs, update the RelatedLogsScene
+      const relatedLogsScene = this.getActiveRelatedLogsScene();
+      if (relatedLogsScene) {
+        relatedLogsScene.setState({
+          lokiDataSources: lokiDataSources,
+          isLoading: false,
+        });
+      }
+    }
+  }
+}

--- a/src/RelatedLogs/RelatedLogsOrchestrator.ts
+++ b/src/RelatedLogs/RelatedLogsOrchestrator.ts
@@ -6,6 +6,7 @@ import { type MetricsLogsConnector } from '../Integrations/logs/base';
 import { createLabelsCrossReferenceConnector } from '../Integrations/logs/labelsCrossReference';
 import { lokiRecordingRulesConnector } from '../Integrations/logs/lokiRecordingRules';
 import { type MetricScene } from '../MetricScene';
+import pluginJson from '../plugin.json';
 
 type DataSource = DataSourceInstanceSettings<DataSourceJsonData>;
 
@@ -123,6 +124,7 @@ export class RelatedLogsOrchestrator {
       refId: `RelatedLogs-${connectorName}`,
       expr: queriesByConnector[connectorName],
       maxLines,
+      supportingQueryType: pluginJson.id,
     }));
 
     return queries;

--- a/src/RelatedLogs/RelatedLogsOrchestrator.ts
+++ b/src/RelatedLogs/RelatedLogsOrchestrator.ts
@@ -82,7 +82,10 @@ export class RelatedLogsOrchestrator {
       return;
     }
 
+    // When filters change, we need to reset our state to trigger updates in listeners
+    // Setting to empty array (vs undefined) signals we're actively checking
     this.lokiDataSources = [];
+    this.relatedLogsCount = 0;
 
     // Check all available datasources for logs after filter changes
     this.findAndCheckAllDatasources();
@@ -183,6 +186,17 @@ export class RelatedLogsOrchestrator {
       // Activate query
       queryRunner.activate();
     });
+  }
+
+  /**
+   * Ensures Loki datasources are initialized and appropriate UI state is set.
+   * This handles the complete initialization flow with proper loading states.
+   */
+  public ensureLokiDatasources(): void {
+    if (this.lokiDataSources === undefined) {
+      // No datasources yet, need to initialize
+      this.initializeLokiDatasources();
+    }
   }
 }
 

--- a/src/RelatedLogs/RelatedLogsOrchestrator.ts
+++ b/src/RelatedLogs/RelatedLogsOrchestrator.ts
@@ -13,7 +13,7 @@ type DataSource = DataSourceInstanceSettings<DataSourceJsonData>;
  * Manager class that handles the orchestration of related logs functionality.
  * This centralizes logs-related logic that was previously spread across multiple components.
  */
-export class RelatedLogsManager {
+export class RelatedLogsOrchestrator {
   private readonly _logsConnectors: MetricsLogsConnector[];
   private readonly _metricScene: MetricScene;
   private readonly _changeHandlers = {

--- a/src/RelatedLogs/RelatedLogsOrchestrator.ts
+++ b/src/RelatedLogs/RelatedLogsOrchestrator.ts
@@ -214,7 +214,7 @@ export class RelatedLogsOrchestrator {
    * Returns true if any of the connectors have conditions met for related logs to be shown.
    */
   public checkConditionsMetForRelatedLogs(): boolean {
-    return this._logsConnectors.some((connector) => connector.conditionsMetForRelatedLogs);
+    return this._logsConnectors.some((connector) => connector.checkConditionsMetForRelatedLogs());
   }
 }
 

--- a/src/RelatedLogs/RelatedLogsOrchestrator.ts
+++ b/src/RelatedLogs/RelatedLogsOrchestrator.ts
@@ -209,6 +209,13 @@ export class RelatedLogsOrchestrator {
       this.initializeLokiDatasources();
     }
   }
+
+  /**
+   * Returns true if any of the connectors have conditions met for related logs to be shown.
+   */
+  public checkConditionsMetForRelatedLogs(): boolean {
+    return this._logsConnectors.some((connector) => connector.conditionsMetForRelatedLogs);
+  }
 }
 
 export async function findHealthyLokiDataSources() {

--- a/src/RelatedLogs/RelatedLogsOrchestrator.ts
+++ b/src/RelatedLogs/RelatedLogsOrchestrator.ts
@@ -41,7 +41,7 @@ export class RelatedLogsOrchestrator {
     const currentDataSourcesSignature = this._internalState.lokiDataSources.map((ds) => ds.uid).join(',');
     const newDataSourcesSignature = dataSources.map((ds) => ds.uid).join(',');
 
-    if (currentDataSourcesSignature === newDataSourcesSignature) {
+    if (currentDataSourcesSignature && currentDataSourcesSignature === newDataSourcesSignature) {
       return;
     }
 

--- a/src/RelatedLogs/RelatedLogsOrchestrator.ts
+++ b/src/RelatedLogs/RelatedLogsOrchestrator.ts
@@ -69,19 +69,6 @@ export class RelatedLogsOrchestrator {
   }
 
   /**
-   * Initialize Loki datasources by fetching healthy ones and updating the MetricScene state.
-   * If the Related Logs tab is active, it also updates the RelatedLogsScene.
-   */
-  public async initializeLokiDatasources(): Promise<void> {
-    this.lokiDataSources = await findHealthyLokiDataSources();
-
-    // Then check which ones have logs
-    if (this.lokiDataSources.length) {
-      this.checkLogsInDataSources(this.lokiDataSources);
-    }
-  }
-
-  /**
    * Called when filters change to re-check for logs in datasources.
    */
   public handleFiltersChange(): void {
@@ -102,7 +89,7 @@ export class RelatedLogsOrchestrator {
    * Find all available datasources and check them for logs.
    * This is used when filters change to ensure we're checking all possible datasources.
    */
-  private async findAndCheckAllDatasources(): Promise<void> {
+  public async findAndCheckAllDatasources(): Promise<void> {
     // Get all available Loki datasources
     const allLokiDatasources = await findHealthyLokiDataSources();
 
@@ -142,7 +129,7 @@ export class RelatedLogsOrchestrator {
   }
 
   /**
-   * Check each datasource for logs and update the MetricScene and RelatedLogsScene accordingly.
+   * Check each datasource for logs, then update the datasources and relatedLogsCount accordingly.
    */
   private checkLogsInDataSources(datasources: DataSource[]): void {
     // Check each datasource for logs
@@ -197,17 +184,6 @@ export class RelatedLogsOrchestrator {
       // Activate query
       queryRunner.activate();
     });
-  }
-
-  /**
-   * Ensures Loki datasources are initialized and appropriate UI state is set.
-   * This handles the complete initialization flow with proper loading states.
-   */
-  public ensureLokiDatasources(): void {
-    if (this.lokiDataSources === undefined) {
-      // No datasources yet, need to initialize
-      this.initializeLokiDatasources();
-    }
   }
 
   /**

--- a/src/RelatedLogs/RelatedLogsOrchestrator.ts
+++ b/src/RelatedLogs/RelatedLogsOrchestrator.ts
@@ -38,11 +38,22 @@ export class RelatedLogsOrchestrator {
   }
 
   set lokiDataSources(dataSources: DataSource[]) {
+    const currentDataSourcesSignature = this._internalState.lokiDataSources.map((ds) => ds.uid).join(',');
+    const newDataSourcesSignature = dataSources.map((ds) => ds.uid).join(',');
+
+    if (currentDataSourcesSignature === newDataSourcesSignature) {
+      return;
+    }
+
     this._internalState.lokiDataSources = dataSources;
     this._changeHandlers.lokiDataSources.forEach((handler) => handler(this._internalState.lokiDataSources));
   }
 
   set relatedLogsCount(count: number) {
+    if (this._internalState.relatedLogsCount === count) {
+      return;
+    }
+
     this._internalState.relatedLogsCount = count;
     this._changeHandlers.relatedLogsCount.forEach((handler) => handler(this._internalState.relatedLogsCount));
   }

--- a/src/RelatedLogs/RelatedLogsOrchestrator.ts
+++ b/src/RelatedLogs/RelatedLogsOrchestrator.ts
@@ -50,10 +50,6 @@ export class RelatedLogsOrchestrator {
   }
 
   set relatedLogsCount(count: number) {
-    if (this._internalState.relatedLogsCount === count) {
-      return;
-    }
-
     this._internalState.relatedLogsCount = count;
     this._changeHandlers.relatedLogsCount.forEach((handler) => handler(this._internalState.relatedLogsCount));
   }

--- a/src/RelatedLogs/RelatedLogsScene.tsx
+++ b/src/RelatedLogs/RelatedLogsScene.tsx
@@ -195,12 +195,7 @@ export class RelatedLogsScene extends SceneObjectBase<RelatedLogsSceneState> {
       return;
     }
 
-    const lokiQueries = this.state.orchestrator.getLokiQueries(selectedDatasourceUid);
-    const queries = Object.keys(lokiQueries).map((connectorName) => ({
-      refId: `RelatedLogs-${connectorName}`,
-      expr: lokiQueries[connectorName],
-      maxLines: 100,
-    }));
+    const queries = this.state.orchestrator.getLokiQueries(selectedDatasourceUid);
 
     // If no queries were generated, show the NoRelatedLogsScene
     if (queries.length === 0) {

--- a/src/RelatedLogs/RelatedLogsScene.tsx
+++ b/src/RelatedLogs/RelatedLogsScene.tsx
@@ -140,9 +140,6 @@ export class RelatedLogsScene extends SceneObjectBase<RelatedLogsSceneState> {
           ? state.data.series.reduce((sum: number, frame) => sum + frame.length, 0)
           : 0;
 
-        // Update logs count
-        this.state.orchestrator.relatedLogsCount = totalRows;
-
         // Show NoRelatedLogsScene if no logs found
         if (totalRows === 0 || !state.data.series?.length) {
           this.showNoLogsScene();

--- a/src/RelatedLogs/RelatedLogsScene.tsx
+++ b/src/RelatedLogs/RelatedLogsScene.tsx
@@ -79,7 +79,36 @@ export class RelatedLogsScene extends SceneObjectBase<RelatedLogsSceneState> {
       }
     });
 
-    this.setupLogsPanel();
+    // If we don't have datasources yet, wait for them
+    if (!this.state.lokiDataSources?.length) {
+      // Show loading state
+      const logsPanelContainer = sceneGraph.findByKeyAndType(this, LOGS_PANEL_CONTAINER_KEY, SceneFlexItem);
+      logsPanelContainer.setState({
+        body: new SceneFlexLayout({
+          direction: 'column',
+          children: [
+            new SceneFlexItem({
+              body: PanelBuilders.text()
+                .setTitle('Loading related logs...')
+                .setOption('content', 'Checking for related logs...')
+                .build(),
+            }),
+          ],
+        }),
+      });
+
+      // Subscribe to state changes to detect when datasources are loaded
+      const subscription = this.subscribeToState((state) => {
+        if (state.lokiDataSources?.length) {
+          // Datasources are now available, set up the logs panel
+          subscription.unsubscribe();
+          this.setupLogsPanel();
+        }
+      });
+    } else {
+      // Datasources are already available, set up the logs panel
+      this.setupLogsPanel();
+    }
   }
 
   private setupLogsPanel(): void {

--- a/src/RelatedLogs/RelatedLogsScene.tsx
+++ b/src/RelatedLogs/RelatedLogsScene.tsx
@@ -3,8 +3,8 @@ import { config } from '@grafana/runtime';
 import {
   CustomVariable,
   PanelBuilders,
-  SceneFlexItem,
-  SceneFlexLayout,
+  SceneCSSGridItem,
+  SceneCSSGridLayout,
   sceneGraph,
   SceneObjectBase,
   SceneQueryRunner,
@@ -31,7 +31,7 @@ interface RelatedLogsSceneProps {
 
 export interface RelatedLogsSceneState extends SceneObjectState, RelatedLogsSceneProps {
   controls: SceneObject[];
-  body: SceneFlexLayout;
+  body: SceneCSSGridLayout;
 }
 
 const LOGS_PANEL_CONTAINER_KEY = 'related_logs/logs_panel_container';
@@ -43,11 +43,11 @@ export class RelatedLogsScene extends SceneObjectBase<RelatedLogsSceneState> {
   constructor(props: RelatedLogsSceneProps) {
     super({
       controls: [],
-      body: new SceneFlexLayout({
-        direction: 'column',
-        height: '400px',
+      body: new SceneCSSGridLayout({
+        templateColumns: '1fr',
+        autoRows: 'minmax(300px, 1fr)',
         children: [
-          new SceneFlexItem({
+          new SceneCSSGridItem({
             key: LOGS_PANEL_CONTAINER_KEY,
             body: undefined,
           }),
@@ -88,27 +88,20 @@ export class RelatedLogsScene extends SceneObjectBase<RelatedLogsSceneState> {
   }
 
   private showLoadingState() {
-    const logsPanelContainer = sceneGraph.findByKeyAndType(this, LOGS_PANEL_CONTAINER_KEY, SceneFlexItem);
+    const logsPanelContainer = sceneGraph.findByKeyAndType(this, LOGS_PANEL_CONTAINER_KEY, SceneCSSGridItem);
     logsPanelContainer.setState({
-      body: new SceneFlexLayout({
-        direction: 'column',
-        children: [
-          new SceneFlexItem({
-            body: PanelBuilders.text()
-              .setTitle('Searching for related logs...')
-              .setOption(
-                'content',
-                "We're searching for logs related to your current metric and filters. This may take a moment..."
-              )
-              .build(),
-          }),
-        ],
-      }),
+      body: PanelBuilders.text()
+        .setTitle('Searching for related logs...')
+        .setOption(
+          'content',
+          "We're searching for logs related to your current metric and filters. This may take a moment..."
+        )
+        .build(),
     });
   }
 
   private showNoLogsScene() {
-    const logsPanelContainer = sceneGraph.findByKeyAndType(this, LOGS_PANEL_CONTAINER_KEY, SceneFlexItem);
+    const logsPanelContainer = sceneGraph.findByKeyAndType(this, LOGS_PANEL_CONTAINER_KEY, SceneCSSGridItem);
     logsPanelContainer.setState({
       body: new NoRelatedLogsScene({}),
     });
@@ -148,7 +141,7 @@ export class RelatedLogsScene extends SceneObjectBase<RelatedLogsSceneState> {
     });
 
     // Set up UI for logs panel
-    const logsPanelContainer = sceneGraph.findByKeyAndType(this, LOGS_PANEL_CONTAINER_KEY, SceneFlexItem);
+    const logsPanelContainer = sceneGraph.findByKeyAndType(this, LOGS_PANEL_CONTAINER_KEY, SceneCSSGridItem);
     logsPanelContainer.setState({
       body: PanelBuilders.logs().setTitle('Logs').setData(this._queryRunner).build(),
     });
@@ -221,29 +214,27 @@ export class RelatedLogsScene extends SceneObjectBase<RelatedLogsSceneState> {
     const { controls, body } = model.useState();
 
     return (
-      <div>
-        <Stack gap={1} direction={'column'} grow={1}>
-          <Stack gap={1} direction={'row'} grow={1} justifyContent={'space-between'} alignItems={'start'}>
-            <Stack gap={1}>
-              {controls?.map((control) => (
-                <control.Component key={control.state.key} model={control} />
-              ))}
-            </Stack>
-
-            <LinkButton
-              href={`${config.appSubUrl}/a/grafana-lokiexplore-app`} // We prefix with the appSubUrl for environments that don't host grafana at the root.
-              target="_blank"
-              tooltip="Navigate to the Explore Logs app"
-              variant="secondary"
-              size="sm"
-              onClick={() => reportExploreMetrics('related_logs_action_clicked', { action: 'open_explore_logs' })}
-            >
-              Open Explore Logs
-            </LinkButton>
+      <Stack gap={1} direction={'column'} grow={1}>
+        <Stack gap={1} direction={'row'} justifyContent={'space-between'} alignItems={'start'}>
+          <Stack gap={1}>
+            {controls?.map((control) => (
+              <control.Component key={control.state.key} model={control} />
+            ))}
           </Stack>
-          <body.Component model={body} />
+
+          <LinkButton
+            href={`${config.appSubUrl}/a/grafana-lokiexplore-app`} // We prefix with the appSubUrl for environments that don't host grafana at the root.
+            target="_blank"
+            tooltip="Navigate to the Explore Logs app"
+            variant="secondary"
+            size="sm"
+            onClick={() => reportExploreMetrics('related_logs_action_clicked', { action: 'open_explore_logs' })}
+          >
+            Open Explore Logs
+          </LinkButton>
         </Stack>
-      </div>
+        <body.Component model={body} />
+      </Stack>
     );
   };
 }

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -3,7 +3,7 @@ import { reportInteraction } from '@grafana/runtime';
 
 import { type BreakdownLayoutType } from './Breakdown/types';
 import { type TrailStepType } from './DataTrailsHistory';
-import { type ActionViewType } from './shared';
+import { type ActionViewType } from './MetricScene';
 
 // prettier-ignore
 type Interactions = {

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -6,7 +6,7 @@ import { type TrailStepType } from './DataTrailsHistory';
 import { type ActionViewType } from './MetricScene';
 
 // prettier-ignore
-type Interactions = {
+export type Interactions = {
   // User selected a label to view its breakdown.
   label_selected: {
     label: string;
@@ -72,7 +72,12 @@ type Interactions = {
     numberOfSteps: number;
   };
   // User clicks on tab to change the action view
-  metric_action_view_changed: { view: ActionViewType };
+  metric_action_view_changed: { 
+    view: ActionViewType 
+
+    // The number of related logs
+    related_logs_count?: number
+  };
   // User clicks on one of the action buttons associated with a selected metric
   selected_metric_action_clicked: {
     action: (

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,15 +1,6 @@
 import { BusEventBase, BusEventWithPayload } from '@grafana/data';
-import { ConstantVariable, type SceneObject } from '@grafana/scenes';
+import { ConstantVariable } from '@grafana/scenes';
 import { VariableHide } from '@grafana/schema';
-
-export type ActionViewType = 'overview' | 'breakdown' | 'related_logs' | 'related';
-
-export interface ActionViewDefinition {
-  displayName: string;
-  value: ActionViewType;
-  description?: string;
-  getScene: () => SceneObject;
-}
 
 export const TRAILS_ROUTE = '/explore/metrics/trail';
 export const HOME_ROUTE = '/explore/metrics';


### PR DESCRIPTION
## Related issue

This PR closes #119.

## What does this do?

This PR extracts logic from the Related Logs scene to display a count of related logs in the Metric scene's action view tabs. Most of the orchestration of related logs is now handled in a new utility class (`src/RelatedLogs/RelatedLogsOrchestrator.ts`).

![demo related logs count from breakdown](https://github.com/user-attachments/assets/d210471b-b50b-411e-bb26-eceadd99c683)

Other changes include:
- When the related logs feature is enabled, we now track the number of related logs that exist when a user clicks on an Action View tab. The related logs count is only reported when conditions have been met to show related logs (e.g. when at least one label filter has been applied, or the selected metric is the product of a Loki recording rule). 
- The `NoRelatedLogsScene` has a new look and updated messaging, which aims to improve clarity.
- The logs DS picker now filters out data sources with no log lines.
- The Grafana server created by `npm run server` wasn't previously able to connect to TSDBs created outside of our `docker-compose.yaml`. This PR updates the config to allow adding data sources with other TSDBs running on your `localhost`. It also now has the `exploreMetricsRelatedLogs` feature toggle enabled.

## Demo

https://github.com/user-attachments/assets/30ebe02d-e04e-4bba-b703-96adbd2d3827

## How to test

(Adapted from https://github.com/grafana/grafana/pull/98775)

I recommend using https://github.com/NWRichmond/demo-prometheus-loki-shared-labels to test this PR. If you'd like to test with other Prometheus & Loki resources, awesome!

1. Check out https://github.com/NWRichmond/demo-prometheus-loki-shared-labels and follow the Getting Started to spin up Prometheus and Loki resources on ports `9098` and `3108`, respectively
2. Create new Prometheus and Loki data sources that point to these services. The easiest way to do that is to create a `provisioning/datasources/labels-cross-reference.yaml` file containing:

```yaml
apiVersion: 1

datasources:
  - name: prometheus-labels-x-ref
    uid: prometheus-labels-x-ref
    type: prometheus
    access: proxy
    url: http://host.docker.internal:9098
    basicAuth: false
    withCredentials: false
    jsonData:
      manageAlerts: true
      prometheusType: Prometheus
      prometheusVersion: '3.2.1'
      cacheLevel: 'Low'
  - name: loki-labels-x-ref
    uid: loki-labels-x-ref
    type: loki
    access: proxy
    url: http://host.docker.internal:3108
    jsonData:
      manageAlerts: true
```

4. In Metrics Drilldown, select the new Prometheus data source (`prometheus-labels-x-ref`)
5. Select a metric and apply some labels to the filter. Some labels are shared (such as `region=us-west-2,environment=dev`) while others are not (`instance=demo-app:80`). We expect logs to only appear when the filters contain shared labels.
