### PR TITLE
ci: persist bundle stats for 90 days

### DIFF
--- a/.github/workflows/bundle-stats-create.yml
+++ b/.github/workflows/bundle-stats-create.yml
@@ -1,6 +1,7 @@
 name: create bundle stats
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -34,4 +35,5 @@ jobs:
         with:
           name: main-branch-stats
           path: stats.json
+          retention-days: 90
           overwrite: true


### PR DESCRIPTION
## What is this change?

This PR is an attempt to avoid failures in [`bundle-stats-compare.yml` runs](https://github.com/grafana/metrics-drilldown/actions/workflows/bundle-stats-compare.yml runs) that seem to arise because the `main-branch-stats` artifact can't be found.