### PR TITLE
ci: update plugins catalog

### DIFF
--- a/.github/workflows/plugins-catalog.yml
+++ b/.github/workflows/plugins-catalog.yml
@@ -1,0 +1,68 @@
+name: Update the Grafana plugins catalog
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        required: true
+        type: choice
+        options:
+          - dev
+          - ops
+          - prod
+
+jobs:
+  validate-ref:
+    name: Validate Git Reference
+    runs-on: ubuntu-latest
+    outputs:
+      is_valid_tag: ${{ steps.check-tag.outputs.is_valid_tag }}
+      tag_version: ${{ steps.check-tag.outputs.tag_version }}
+    steps:
+      - name: Check if running on a valid tag
+        id: check-tag
+        run: |
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            echo "is_valid_tag=true" >> $GITHUB_OUTPUT
+            TAG=${GITHUB_REF#refs/tags/v}
+            echo "tag_version=$TAG" >> $GITHUB_OUTPUT
+            echo "Running on valid tag: v$TAG"
+          else
+            echo "is_valid_tag=false" >> $GITHUB_OUTPUT
+            echo "This workflow can only run on tags starting with 'v'"
+            echo "Current ref: $GITHUB_REF"
+          fi
+
+  update-catalog:
+    name: Update ${{ inputs.environment }} Plugins Catalog
+    needs: validate-ref
+    if: needs.validate-ref.outputs.is_valid_tag == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      # Required for updating the catalog to retrieve the name of the repository
+      - uses: actions/checkout@v4
+
+      - name: Get secrets from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          vault_instance: ops
+          common_secrets: |
+            GCOM_PUBLISH_TOKEN=plugins/gcom-publish-token:${{ inputs.environment }}
+            GCS_PLUGIN_PUBLISHER_SERVICE_ACCOUNT_JSON=github_actions:gcs-plugin-publisher
+
+      - name: Login to GCS
+        id: gcloud
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: ${{ env.GCS_PLUGIN_PUBLISHER_SERVICE_ACCOUNT_JSON }}
+
+      - name: Update catalog
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@main
+        with:
+          zips: '["https://storage.googleapis.com/integration-artifacts/grafana-metricsdrilldown-app/grafana-metricsdrilldown-app-${{ inputs.version }}.zip"]'
+          environment: ${{ inputs.environment }}
+          scopes: universal
+          gcom-publish-token: ${{ env.GCOM_PUBLISH_TOKEN }}
+          gcloud-auth-token: ${{ steps.gcloud.outputs.auth_token }}

--- a/.github/workflows/plugins-catalog.yml
+++ b/.github/workflows/plugins-catalog.yml
@@ -40,7 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
-      # Required for updating the catalog to retrieve the name of the repository
       - uses: actions/checkout@v4
 
       - name: Get secrets from Vault


### PR DESCRIPTION
## Related issue

This PR supports #20.

## What is this change?

This is a temporary workaround until we can merge #122. It allows us to publish the app to the Grafana plugins catalog. This new workflow is heavily inspired by https://github.com/grafana/explore-profiles/blob/main/.github/workflows/update-plugins-catalog.yml.