### PR TITLE
ci: unset vault instance

### DIFF
--- a/.github/workflows/plugins-catalog.yml
+++ b/.github/workflows/plugins-catalog.yml
@@ -50,7 +50,6 @@ jobs:
         id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
-          vault_instance: ops
           common_secrets: |
             GCOM_PUBLISH_TOKEN=plugins/gcom-publish-token:${{ inputs.environment }}
             GCS_PLUGIN_PUBLISHER_SERVICE_ACCOUNT_JSON=gcs_plugin_publisher_service_account_json:value


### PR DESCRIPTION
## Related issue

This PR supports #20.

## What does this do?

Yet another attempt to get this workflow running. More closely following https://github.com/grafana/oncall/blob/3bd20edb661d4ea047bd937ed75638f097d4a651/.github/workflows/on-release-published.yml this time.