### PR TITLE
ci: update vault access pattern

### DIFF
--- a/.github/workflows/plugins-catalog.yml
+++ b/.github/workflows/plugins-catalog.yml
@@ -18,9 +18,6 @@ jobs:
     outputs:
       is_valid_tag: ${{ steps.check-tag.outputs.is_valid_tag }}
       tag_version: ${{ steps.check-tag.outputs.tag_version }}
-    permissions:
-      contents: 'read'
-      id-token: 'write'
     steps:
       - name: Check if running on a valid tag
         id: check-tag
@@ -42,6 +39,9 @@ jobs:
     if: needs.validate-ref.outputs.is_valid_tag == 'true'
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/plugins-catalog.yml
+++ b/.github/workflows/plugins-catalog.yml
@@ -11,10 +11,6 @@ on:
           - ops
           - prod
 
-permissions:
-  contents: 'read'
-  id-token: 'write'
-
 jobs:
   validate-ref:
     name: Validate Git Reference
@@ -22,6 +18,9 @@ jobs:
     outputs:
       is_valid_tag: ${{ steps.check-tag.outputs.is_valid_tag }}
       tag_version: ${{ steps.check-tag.outputs.tag_version }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - name: Check if running on a valid tag
         id: check-tag
@@ -52,6 +51,7 @@ jobs:
         with:
           common_secrets: |
             GCOM_PUBLISH_TOKEN=plugins/gcom-publish-token:${{ inputs.environment }}
+          repo_secrets: |
             GCS_PLUGIN_PUBLISHER_SERVICE_ACCOUNT_JSON=gcs_plugin_publisher_service_account_json:value
 
       - name: Login to GCS


### PR DESCRIPTION
## Relates issue

This PR supports #20.

## What does this do?

Fixes a mistake in `.github/workflows/plugins-catalog.yml`, and more closely follows the patterns from:
- https://github.com/grafana/explore-profiles/blob/main/.github/workflows/update-plugins-catalog.yml
- https://github.com/grafana/oncall/blob/main/.github/workflows/on-release-published.yml