### PR TITLE
Style: Make sidebar and header fixed

### DIFF
--- a/src/WingmanDataTrail/HeaderControls/HeaderControls.tsx
+++ b/src/WingmanDataTrail/HeaderControls/HeaderControls.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/css';
 import { type SelectableValue } from '@grafana/data';
 import {
   EmbeddedScene,
@@ -5,9 +6,12 @@ import {
   SceneFlexLayout,
   sceneGraph,
   SceneReactObject,
+  type SceneComponentProps,
   type SceneObjectState,
   type SceneVariableSet,
 } from '@grafana/scenes';
+import { useStyles2 } from '@grafana/ui';
+import React from 'react';
 
 import { VAR_WINGMAN_GROUP_BY, type LabelsVariable } from 'WingmanDataTrail/Labels/LabelsVariable';
 
@@ -28,11 +32,12 @@ export class HeaderControls extends EmbeddedScene {
       key: 'header-controls',
       body: new SceneFlexLayout({
         direction: 'row',
-        maxHeight: '32px',
         width: '100%',
         children: [
           new SceneFlexItem({
             body: new QuickSearch(),
+            minWidth: 700,
+            width: 1,
           }),
           new SceneFlexItem({
             key: 'group-by-label-selector-wingman',
@@ -65,4 +70,32 @@ export class HeaderControls extends EmbeddedScene {
       }),
     });
   }
+
+  public static Component = ({ model }: SceneComponentProps<HeaderControls>) => {
+    const styles = useStyles2(getStyles);
+    const { body } = model.useState();
+
+    return (
+      <div className={styles.headerWrapper}>
+        <body.Component model={body} />
+      </div>
+    );
+  };
+}
+
+function getStyles() {
+  return {
+    headerWrapper: css({
+      display: 'flex',
+      alignItems: 'center',
+      '& > div': {
+        display: 'flex',
+        alignItems: 'center',
+        '& > div': {
+          display: 'flex',
+          alignItems: 'center',
+        },
+      },
+    }),
+  };
 }

--- a/src/WingmanDataTrail/HeaderControls/HeaderControls.tsx
+++ b/src/WingmanDataTrail/HeaderControls/HeaderControls.tsx
@@ -29,6 +29,7 @@ export class HeaderControls extends EmbeddedScene {
       body: new SceneFlexLayout({
         direction: 'row',
         maxHeight: '32px',
+        width: '100%',
         children: [
           new SceneFlexItem({
             body: new QuickSearch(),

--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -104,7 +104,6 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     headerControls: css({
       gridArea: 'header',
-      background: theme.colors.background.primary,
       borderBottom: `1px solid ${theme.colors.border.weak}`,
       padding: theme.spacing(1, 0),
       zIndex: theme.zIndex.navbarFixed,

--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -70,7 +70,6 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
         className={styles.container}
         style={{
           height: `calc(100vh - ${chromeHeaderHeight}px)`,
-          marginTop: `${chromeHeaderHeight}px`,
         }}
       >
         <div className={styles.headerControls}>

--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import { type GrafanaTheme2 } from '@grafana/data';
+import { useChromeHeaderHeight } from '@grafana/runtime';
 import {
   sceneGraph,
   SceneObjectBase,
@@ -62,18 +63,24 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
   public static Component = ({ model }: SceneComponentProps<MetricsReducer>) => {
     const styles = useStyles2(getStyles);
     const { body, headerControls, sidebar } = model.useState();
+    const chromeHeaderHeight = useChromeHeaderHeight() ?? 0;
 
     return (
-      <div className={styles.container}>
+      <div
+        className={styles.container}
+        style={{
+          height: `calc(100vh - ${chromeHeaderHeight}px)`,
+          marginTop: `${chromeHeaderHeight}px`,
+        }}
+      >
         <div className={styles.headerControls}>
           <headerControls.Component model={headerControls} />
         </div>
-        <div className={styles.content}>
+        <div className={styles.sidebar}>
           <sidebar.Component model={sidebar} />
-
-          <div className={styles.mainContent}>
-            <body.Component model={body} />
-          </div>
+        </div>
+        <div className={styles.mainContent}>
+          <body.Component model={body} />
         </div>
       </div>
     );
@@ -81,25 +88,42 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
 }
 
 function getStyles(theme: GrafanaTheme2) {
+  const headerHeight = 55; // Height of our header controls
+
   return {
     container: css({
-      display: 'flex',
-      flexDirection: 'column',
-      height: '100%',
-      gap: theme.spacing(1),
-    }),
-    headerControls: css({}),
-    content: css({
-      display: 'flex',
-      flexGrow: 1,
-      gap: theme.spacing(2),
+      display: 'grid',
+      gridTemplateRows: `${headerHeight}px calc(100% - ${headerHeight}px)`,
+      gridTemplateColumns: '250px 1fr',
+      gridTemplateAreas: `
+        'header header'
+        'sidebar content'
+      `,
       height: '100%',
       overflow: 'hidden',
+      position: 'relative',
+    }),
+    headerControls: css({
+      gridArea: 'header',
+      background: theme.colors.background.primary,
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+      padding: theme.spacing(1, 0),
+      zIndex: theme.zIndex.navbarFixed,
+      position: 'sticky',
+      top: 0,
+    }),
+    sidebar: css({
+      gridArea: 'sidebar',
+      background: theme.colors.background.primary,
+      borderRight: `1px solid ${theme.colors.border.weak}`,
+      overflow: 'auto',
+      height: '100%',
     }),
     mainContent: css({
-      flexGrow: 1,
+      gridArea: 'content',
       overflow: 'auto',
       padding: theme.spacing(1),
+      height: '100%',
     }),
   };
 }

--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -182,7 +182,7 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     sidebar: css({
       gridArea: 'sidebar',
-      background: theme.colors.background.primary,
+      background: theme.colors.background.canvas,
       borderRight: `1px solid ${theme.colors.border.weak}`,
       overflow: 'auto',
       height: '100%',

--- a/src/WingmanDataTrail/SideBar/MetricsFilterSection.tsx
+++ b/src/WingmanDataTrail/SideBar/MetricsFilterSection.tsx
@@ -28,9 +28,12 @@ const CheckboxWithCount = ({
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }) => {
   const styles = useStyles2(getStyles);
+  // Create a combined label with the count
+  const combinedLabel = `${label} `;
+
   return (
     <div className={styles.checkboxWrapper}>
-      <Checkbox label={label} value={checked} onChange={onChange} />
+      <Checkbox label={combinedLabel} value={checked} onChange={onChange} />
       <span className={styles.count}>({count})</span>
     </div>
   );
@@ -226,7 +229,6 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     checkboxWrapper: css({
       display: 'flex',
-      justifyContent: 'space-between',
       alignItems: 'center',
       width: '100%',
       '& label': {
@@ -235,7 +237,8 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     count: css({
       color: theme.colors.text.secondary,
-      marginLeft: theme.spacing(1),
+      marginLeft: theme.spacing(0.5),
+      display: 'inline-block',
     }),
     field: css({
       marginBottom: '0 !important',
@@ -247,7 +250,6 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     checkboxItem: css({
       display: 'flex',
-      justifyContent: 'space-between',
       alignItems: 'center',
       width: '100%',
       padding: `${theme.spacing(0.5)} 0`,

--- a/src/WingmanDataTrail/SideBar/MetricsFilterSection.tsx
+++ b/src/WingmanDataTrail/SideBar/MetricsFilterSection.tsx
@@ -92,21 +92,23 @@ export function MetricsFilterSection({
   return (
     <FieldSet label={title} className={styles.fieldSetTitle}>
       <div className={styles.fieldSetContent}>
-        <Field>
-          <div className={styles.switchContainer}>
-            <span className={styles.switchLabel}>Hide empty</span>
-            <Switch value={hideEmpty} onChange={(e) => setHideEmpty(e.currentTarget.checked)} />
-          </div>
-        </Field>
-        <Field>
-          <Input
-            prefix={<Icon name="search" />}
-            placeholder="Search..."
-            value={inputValue}
-            onChange={(e) => setInputValue(e.currentTarget.value)}
-            onKeyDown={onKeyDown}
-          />
-        </Field>
+        <div className={styles.controlsRow}>
+          <Field className={styles.field}>
+            <div className={styles.switchContainer}>
+              <span className={styles.switchLabel}>Hide empty</span>
+              <Switch value={hideEmpty} onChange={(e) => setHideEmpty(e.currentTarget.checked)} />
+            </div>
+          </Field>
+          <Field className={styles.field}>
+            <Input
+              prefix={<Icon name="search" />}
+              placeholder="Search..."
+              value={inputValue}
+              onChange={(e) => setInputValue(e.currentTarget.value)}
+              onKeyDown={onKeyDown}
+            />
+          </Field>
+        </div>
         {loading && <Spinner inline />}
         {!loading && (
           <CheckBoxList
@@ -133,7 +135,7 @@ function CheckBoxList({
   return (
     <div className={styles.checkboxList}>
       {filteredList.map((item) => (
-        <Field key={item.value}>
+        <div key={item.value} className={styles.checkboxItem}>
           <CheckboxWithCount
             label={item.label}
             count={item.count}
@@ -146,7 +148,7 @@ function CheckBoxList({
               onSelectionChange(newValues);
             }}
           />
-        </Field>
+        </div>
       ))}
     </div>
   );
@@ -158,14 +160,27 @@ function getStyles(theme: GrafanaTheme2) {
       '& > legend': {
         fontSize: theme.typography.h5.fontSize + ' !important',
         fontWeight: theme.typography.h5.fontWeight + ' !important',
+        marginBottom: '0 !important',
+        paddingBottom: '0 !important',
       },
+      height: 'auto',
+      display: 'flex',
+      flexDirection: 'column',
+      '& > div': {
+        height: 'auto',
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: '250px',
+      },
+      padding: '0 !important',
+      margin: '0 !important',
     }),
     fieldSetContent: css({
       display: 'flex',
       flexDirection: 'column',
-      gap: theme.spacing(1.5),
-      height: '100%',
-      maxHeight: '400px',
+      gap: theme.spacing(0.5),
+      height: 'auto',
+      overflow: 'hidden',
       '& .css-1n4u71h-Label': {
         fontSize: '14px !important',
       },
@@ -177,13 +192,15 @@ function getStyles(theme: GrafanaTheme2) {
         marginBottom: 0,
       },
       '& > div:nth-child(2)': {
-        marginBottom: theme.spacing(1.5),
+        marginBottom: theme.spacing(0.5),
       },
     }),
     checkboxList: css({
-      overflowY: 'scroll',
-      flexGrow: 1,
+      overflowY: 'auto',
+      flexGrow: 0,
       paddingRight: theme.spacing(1),
+      maxHeight: '210px',
+      marginTop: theme.spacing(0.5),
       '& .css-1n4u71h-Label': {
         fontSize: '14px !important',
       },
@@ -212,10 +229,28 @@ function getStyles(theme: GrafanaTheme2) {
       justifyContent: 'space-between',
       alignItems: 'center',
       width: '100%',
+      '& label': {
+        fontSize: '14px !important',
+      },
     }),
     count: css({
       color: theme.colors.text.secondary,
       marginLeft: theme.spacing(1),
+    }),
+    field: css({
+      marginBottom: '0 !important',
+    }),
+    controlsRow: css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(0.5),
+    }),
+    checkboxItem: css({
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      width: '100%',
+      padding: `${theme.spacing(0.5)} 0`,
     }),
   };
 }

--- a/src/WingmanDataTrail/SideBar/SideBar.tsx
+++ b/src/WingmanDataTrail/SideBar/SideBar.tsx
@@ -101,27 +101,30 @@ export class SideBar extends SceneObjectBase<SideBarState> {
 
     return (
       <div className={styles.sidebar}>
-        <MetricsFilterSection
-          title="Metric groups"
-          items={prefixGroups}
-          hideEmpty={hideEmptyGroups}
-          searchValue={metricsGroupSearch}
-          selectedValues={selectedMetricGroups}
-          onSearchChange={(value) => model.setState({ metricsGroupSearch: value })}
-          onSelectionChange={(values) => model.setState({ selectedMetricGroups: values })}
-          loading={loading}
-        />
-
-        <MetricsFilterSection
-          title="Metric categories"
-          items={categories}
-          hideEmpty={hideEmptyTypes}
-          searchValue={metricsTypeSearch}
-          selectedValues={selectedMetricTypes}
-          onSearchChange={(value) => model.setState({ metricsTypeSearch: value })}
-          onSelectionChange={(values) => model.setState({ selectedMetricTypes: values })}
-          loading={loading}
-        />
+        <div className={styles.sectionContainer}>
+          <MetricsFilterSection
+            title="Metric groups"
+            items={prefixGroups}
+            hideEmpty={hideEmptyGroups}
+            searchValue={metricsGroupSearch}
+            selectedValues={selectedMetricGroups}
+            onSearchChange={(value) => model.setState({ metricsGroupSearch: value })}
+            onSelectionChange={(values) => model.setState({ selectedMetricGroups: values })}
+            loading={loading}
+          />
+        </div>
+        <div className={styles.sectionContainer}>
+          <MetricsFilterSection
+            title="Metric categories"
+            items={categories}
+            hideEmpty={hideEmptyTypes}
+            searchValue={metricsTypeSearch}
+            selectedValues={selectedMetricTypes}
+            onSearchChange={(value) => model.setState({ metricsTypeSearch: value })}
+            onSelectionChange={(values) => model.setState({ selectedMetricTypes: values })}
+            loading={loading}
+          />
+        </div>
       </div>
     );
   };
@@ -132,12 +135,20 @@ function getStyles(theme: GrafanaTheme2) {
     sidebar: css({
       display: 'flex',
       flexDirection: 'column',
+      justifyContent: 'flex-start',
       gap: theme.spacing(2),
       padding: theme.spacing(1),
       width: '100%',
       height: '100%',
       overflow: 'auto',
       background: theme.colors.background.canvas,
+    }),
+    sectionContainer: css({
+      flex: '0 0 auto',
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+      marginBottom: 0,
     }),
   };
 }

--- a/src/WingmanDataTrail/SideBar/SideBar.tsx
+++ b/src/WingmanDataTrail/SideBar/SideBar.tsx
@@ -134,11 +134,10 @@ function getStyles(theme: GrafanaTheme2) {
       flexDirection: 'column',
       gap: theme.spacing(2),
       padding: theme.spacing(1),
-      width: '250px',
+      width: '100%',
       height: '100%',
-      overflow: 'hidden',
-      borderRadius: theme.shape.radius.default,
-      borderRight: `1px solid ${theme.colors.border.weak}`,
+      overflow: 'auto',
+      background: theme.colors.background.primary,
     }),
   };
 }

--- a/src/WingmanDataTrail/SideBar/SideBar.tsx
+++ b/src/WingmanDataTrail/SideBar/SideBar.tsx
@@ -137,7 +137,7 @@ function getStyles(theme: GrafanaTheme2) {
       width: '100%',
       height: '100%',
       overflow: 'auto',
-      background: theme.colors.background.primary,
+      background: theme.colors.background.canvas,
     }),
   };
 }


### PR DESCRIPTION
- [x] independently scroll through metrics while sidebar and header are fixed
- [x] render counts next to label names (rather than right justified)

**before changes**

https://github.com/user-attachments/assets/fe3ca485-a0ec-4014-afaa-a835234f340a


**after changes**

https://github.com/user-attachments/assets/a05ae7f6-14bd-4225-a5a2-b18ed25960bc

**bug**: when scrolling the Data source header and teh Search metrics header have different sticky-ness so it looks weird

https://github.com/user-attachments/assets/753e855f-b9cd-4cff-89f3-931da80c42e8

