### PR TITLE
Hackathon: Opinionated handling of uptime/downtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@grafana/data": "^11.5.0",
         "@grafana/lezer-logql": "^0.2.7",
         "@grafana/prometheus": "^11.6.0-223871",
+        "@grafana/promql-builder": "^0.0.4",
         "@grafana/runtime": "^11.5.0",
         "@grafana/scenes": "^5.41.1",
         "@grafana/schema": "^11.5.0",
@@ -2542,6 +2543,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/@grafana/promql-builder": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@grafana/promql-builder/-/promql-builder-0.0.4.tgz",
+      "integrity": "sha512-Ay5miV6fCn+rHWfXRsyFKJJlf6OwfPiZCJpckEnJQuVFF5Hscx8Uo3ow7v4zWNCozK0CndcH/2xDywKDlZjN6w==",
+      "license": "Apache-2.0"
     },
     "node_modules/@grafana/runtime": {
       "version": "11.5.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@grafana/data": "^11.5.0",
     "@grafana/lezer-logql": "^0.2.7",
     "@grafana/prometheus": "^11.6.0-223871",
+    "@grafana/promql-builder": "^0.0.4",
     "@grafana/runtime": "^11.5.0",
     "@grafana/scenes": "^5.41.1",
     "@grafana/schema": "^11.5.0",

--- a/src/WingmanDataTrail/MetricVizPanel/MetricVizPanel.tsx
+++ b/src/WingmanDataTrail/MetricVizPanel/MetricVizPanel.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 
 import { trailDS } from 'shared';
 
-import { ConfigureAction } from './actions/ConfigureAction';
+import { ConfigureAction, type PrometheusFn } from './actions/ConfigureAction';
 import { SelectAction } from './actions/SelectAction';
 import { buildPrometheusQuery } from './buildPrometheusQuery';
 
@@ -26,7 +26,7 @@ export type GroupByLabel = {
 interface MetricVizPanelState extends SceneObjectState {
   metricName: string;
   color: string;
-  prometheusFunction: string;
+  prometheusFunction: PrometheusFn;
   title: string;
   hideLegend: boolean;
   highlight: boolean;

--- a/src/WingmanDataTrail/MetricVizPanel/actions/ApplyAction.tsx
+++ b/src/WingmanDataTrail/MetricVizPanel/actions/ApplyAction.tsx
@@ -3,24 +3,17 @@ import { SceneObjectBase, type SceneComponentProps, type SceneObjectState } from
 import { Button, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
+import { type PrometheusFn } from './ConfigureAction';
 import { EventApplyFunction } from './EventApplyFunction';
 
 interface ApplyActionState extends SceneObjectState {
   metricName: string;
-  prometheusFunction: string;
-  disabled: boolean;
+  prometheusFunction: PrometheusFn;
+  disabled?: boolean;
 }
 
 export class ApplyAction extends SceneObjectBase<ApplyActionState> {
-  constructor({
-    metricName,
-    prometheusFunction,
-    disabled,
-  }: {
-    metricName: ApplyActionState['metricName'];
-    prometheusFunction: ApplyActionState['prometheusFunction'];
-    disabled?: ApplyActionState['disabled'];
-  }) {
+  constructor({ metricName, prometheusFunction, disabled }: ApplyActionState) {
     super({
       metricName,
       prometheusFunction,

--- a/src/WingmanDataTrail/MetricVizPanel/actions/ConfigureAction.tsx
+++ b/src/WingmanDataTrail/MetricVizPanel/actions/ConfigureAction.tsx
@@ -17,7 +17,7 @@ export class ConfigureAction extends SceneObjectBase<ConfigureActionState> {
     { label: 'Maximum', value: 'max' },
     { label: 'Rate', value: 'rate' },
     { label: 'Instant rate', value: 'irate' },
-  ];
+  ] as const;
 
   constructor({ metricName }: { metricName: ConfigureActionState['metricName'] }) {
     super({
@@ -54,3 +54,5 @@ const getStyles = () => ({
     padding: 0;
   `,
 });
+
+export type PrometheusFn = (typeof ConfigureAction.PROMETHEUS_FN_OPTIONS)[number]['value'];

--- a/src/WingmanDataTrail/MetricVizPanel/buildPrometheusQuery.ts
+++ b/src/WingmanDataTrail/MetricVizPanel/buildPrometheusQuery.ts
@@ -1,24 +1,70 @@
+import * as promql from '@grafana/promql-builder';
+
+import { type PrometheusFn } from './actions/ConfigureAction';
 import { type GroupByLabel } from './MetricVizPanel';
 
-export function buildPrometheusQuery({
-  metricName,
-  matchers,
-  groupByLabel,
-  fn,
-}: {
+// Helper function to determine if a metric is an uptime metric
+function isUptimeMetric(metricName: string): boolean {
+  return metricName === 'up' || metricName.endsWith('_up');
+}
+
+interface BuildPrometheusQueryOptions {
   metricName: string;
-  matchers: string[];
+  fn: PrometheusFn;
   groupByLabel?: GroupByLabel;
-  fn: string;
-}) {
-  // well...
-  if (fn.includes('rate')) {
-    return `sum(${fn}(${metricName}{__ignore_usage__=\"\",${matchers.join(',')}}[$__rate_interval]))`;
+}
+
+export function buildPrometheusQuery({ metricName, fn, groupByLabel }: BuildPrometheusQueryOptions): string {
+  let expr: promql.AggregationExprBuilder;
+
+  // Create a vector with the metric name and __ignore_usage__ label
+  const vectorExpr = promql.vector(metricName);
+  vectorExpr.label('__ignore_usage__', '');
+
+  // Special handling for uptime metrics - use `min` to expose downtime in any series
+  if (isUptimeMetric(metricName)) {
+    expr = promql.min(vectorExpr);
+  }
+  // Handle rate functions
+  else if (fn.includes('rate')) {
+    // For rate functions, we need to add $__rate_interval range
+    vectorExpr.range('$__rate_interval');
+
+    // Apply the appropriate rate function
+    const rateResult = fn === 'irate' ? promql.irate(vectorExpr) : promql.rate(vectorExpr);
+
+    // Sum the rate result
+    expr = promql.sum(rateResult);
+  }
+  // Handle regular aggregation functions
+  else {
+    switch (fn) {
+      case 'sum':
+        expr = promql.sum(vectorExpr);
+        break;
+      case 'min':
+        expr = promql.min(vectorExpr);
+        break;
+      case 'max':
+        expr = promql.max(vectorExpr);
+        break;
+      case 'avg':
+        expr = promql.avg(vectorExpr);
+        break;
+      default:
+        // Fall back to string templates for unsupported functions
+        const template = !groupByLabel
+          ? `${fn}(${metricName}{__ignore_usage__=""})`
+          : `${fn}(${metricName}{__ignore_usage__=""}) by (${groupByLabel.name})`;
+        return template;
+    }
   }
 
-  if (!groupByLabel) {
-    return `${fn}(${metricName}{__ignore_usage__=\"\",${matchers.join(',')}})`;
+  // Add group by clause if needed
+  if (groupByLabel) {
+    return expr.by([groupByLabel.name]).toString();
   }
 
-  return `${fn}(${metricName}{__ignore_usage__=\"\",${matchers.join(',')}}) by (${groupByLabel.name})`;
+  // Return the final expression
+  return expr.toString();
 }

--- a/src/WingmanDataTrail/MetricVizPanel/buildPrometheusQuery.ts
+++ b/src/WingmanDataTrail/MetricVizPanel/buildPrometheusQuery.ts
@@ -22,6 +22,7 @@ export function buildPrometheusQuery({ metricName, fn, matchers, groupByLabel }:
   const vectorExpr = promql.vector(metricName);
   vectorExpr.label('__ignore_usage__', '');
 
+  // Add label matchers to the vector expression
   if (matchers) {
     matchers.forEach((matcher) => {
       const [key, value] = matcher.split('=');

--- a/src/WingmanDataTrail/MetricVizPanel/buildPrometheusQuery.ts
+++ b/src/WingmanDataTrail/MetricVizPanel/buildPrometheusQuery.ts
@@ -26,7 +26,8 @@ export function buildPrometheusQuery({ metricName, fn, matchers, groupByLabel }:
     matchers.forEach((matcher) => {
       const [key, value] = matcher.split('=');
       if (key && value) {
-        vectorExpr.label(key, value);
+        // Remove any single or double quotes from the value
+        vectorExpr.label(key, value.replace(/['"]/g, ''));
       }
     });
   }

--- a/src/WingmanDataTrail/MetricVizPanel/buildPrometheusQuery.ts
+++ b/src/WingmanDataTrail/MetricVizPanel/buildPrometheusQuery.ts
@@ -24,7 +24,10 @@ export function buildPrometheusQuery({ metricName, fn, matchers, groupByLabel }:
 
   if (matchers) {
     matchers.forEach((matcher) => {
-      vectorExpr.label(matcher, '');
+      const [key, value] = matcher.split('=');
+      if (key && value) {
+        vectorExpr.label(key, value);
+      }
     });
   }
 

--- a/src/WingmanDataTrail/MetricVizPanel/buildPrometheusQuery.ts
+++ b/src/WingmanDataTrail/MetricVizPanel/buildPrometheusQuery.ts
@@ -11,15 +11,22 @@ function isUptimeMetric(metricName: string): boolean {
 interface BuildPrometheusQueryOptions {
   metricName: string;
   fn: PrometheusFn;
+  matchers?: string[];
   groupByLabel?: GroupByLabel;
 }
 
-export function buildPrometheusQuery({ metricName, fn, groupByLabel }: BuildPrometheusQueryOptions): string {
+export function buildPrometheusQuery({ metricName, fn, matchers, groupByLabel }: BuildPrometheusQueryOptions): string {
   let expr: promql.AggregationExprBuilder;
 
   // Create a vector with the metric name and __ignore_usage__ label
   const vectorExpr = promql.vector(metricName);
   vectorExpr.label('__ignore_usage__', '');
+
+  if (matchers) {
+    matchers.forEach((matcher) => {
+      vectorExpr.label(matcher, '');
+    });
+  }
 
   // Special handling for uptime metrics - use `min` to expose downtime in any series
   if (isUptimeMetric(metricName)) {

--- a/src/WingmanDataTrail/MetricVizPanel/panels/statushistory.tsx
+++ b/src/WingmanDataTrail/MetricVizPanel/panels/statushistory.tsx
@@ -1,0 +1,43 @@
+import { PanelBuilders, type SceneQueryRunner } from '@grafana/scenes';
+import { MappingType, ThresholdsMode, VisibilityMode } from '@grafana/schema';
+
+interface PanelProps {
+  panelTitle: string;
+  queryRunner: SceneQueryRunner;
+}
+
+export function buildStatusHistoryPanel({ panelTitle, queryRunner }: PanelProps) {
+  queryRunner.setState({ maxDataPoints: 100 });
+
+  return (
+    PanelBuilders.statushistory()
+      .setTitle(panelTitle)
+      .setData(queryRunner)
+      .setColor({ mode: 'thresholds' }) // Set color mode to enable threshold coloring
+      .setMappings([
+        {
+          type: MappingType.ValueToText,
+          options: {
+            '0': {
+              color: 'red',
+              text: 'down',
+            },
+            '1': {
+              color: 'green',
+              text: 'up',
+            },
+          },
+        },
+      ])
+      .setThresholds({
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: 0, color: 'red' },
+          { value: 1, color: 'green' },
+        ],
+      })
+      // Hide the threshold annotations
+      .setOption('legend', { showLegend: false })
+      .setOption('showValue', VisibilityMode.Never)
+  );
+}

--- a/src/WingmanDataTrail/MetricVizPanel/panels/timeseries.tsx
+++ b/src/WingmanDataTrail/MetricVizPanel/panels/timeseries.tsx
@@ -1,0 +1,19 @@
+import { PanelBuilders, type SceneQueryRunner, type VizPanelState } from '@grafana/scenes';
+
+interface PanelProps {
+  panelTitle: string;
+  color: string;
+  queryRunner: SceneQueryRunner;
+  hideLegend: boolean;
+  headerActions?: VizPanelState['headerActions'];
+}
+
+export function buildTimeseriesPanel({ panelTitle, queryRunner, color, headerActions, hideLegend }: PanelProps) {
+  return PanelBuilders.timeseries()
+    .setTitle(panelTitle)
+    .setData(queryRunner)
+    .setColor({ mode: 'fixed', fixedColor: color })
+    .setCustomFieldConfig('fillOpacity', 9)
+    .setHeaderActions(headerActions)
+    .setOption('legend', { showLegend: !hideLegend });
+}

--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -110,14 +110,14 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
                 metricName,
                 color: getColorByIndex(colorIndex),
                 groupByLabel: undefined,
-                prometheusFunction: option.value as string,
+                prometheusFunction: option.value,
                 height: METRICS_VIZ_PANEL_HEIGHT_SMALL,
                 hideLegend: true,
                 highlight: colorIndex === 1,
                 headerActions: [
                   new ApplyAction({
                     metricName,
-                    prometheusFunction: option.value as string,
+                    prometheusFunction: option.value,
                     disabled: colorIndex === 1,
                   }),
                 ],


### PR DESCRIPTION
This PR adds opinionated visualization for uptime/downtime metrics. By using the [Status History](https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/status-history) panel, we can enjoy clearer visual feedback about uptime/downtime. For uptime metric, we also use the `min()` function to highlight downtime in any of the metric's series.

<img width="1081" alt="demo uptime with " src="https://github.com/user-attachments/assets/83147f83-09b9-4a97-ad72-03cb86053f68" />

This PR also experiments with using [`@grafana/promql-builder`](https://github.com/grafana/promql-builder) instead of string interpolation for PromQL query expression building.