### PR TITLE
docs: prepare app for prod plugins catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,85 @@
-# Metrics Drilldown
+# Grafana Metrics Drilldown
 
-[Metrics Drilldown](https://grafana.com/docs/grafana/latest/explore/simplified-exploration/metrics) is not yet an externalized app. The code is part of `grafana/grafana` (in [`public/app/features/trails`](https://github.com/grafana/grafana/tree/main/public/app/features/trails)). This repository is a placeholder for future development. For more details, see: [DesignDoc: Externalizing Metrics Drilldown](https://docs.google.com/document/d/1M0i2XJ-lseb8gtCqk02vxxNUsWk5P7dbUP8449qJ9Rw/edit?usp=sharing).
+[Grafana Metrics Drilldown](https://grafana.com/docs/grafana/latest/explore/simplified-exploration/metrics) provides a query-less experience for browsing Prometheus-compatible metrics. Quickly find related metrics without writing PromQL queries.
 
-## What are Grafana app plugins?
+## Installing in your own Grafana instance
 
-App plugins can let you create a custom out-of-the-box monitoring experience by custom pages, nested datasources and panel plugins.
+Grafana Metrics Drilldown will be preinstalled by default in all Grafana instances in the near future.
 
-## What is @grafana/scenes?
+In the meantime, you can install the plugin from the `main` branch using [`grafana-cli`](https://grafana.com/docs/grafana/latest/cli/#plugins-commands):
 
-[@grafana/scenes](https://github.com/grafana/scenes) is a framework to enable versatile app plugins implementation. It provides an easy way to build apps that resemble Grafana's dashboarding experience, including template variables support, versatile layouts, panels rendering and more.
+```bash
+grafana cli plugins install grafana-metricsdrilldown-app
+```
 
-To learn more about @grafana/scenes usage please refer to the [documentation](https://grafana.com/developers/scenes)
+## Development
 
-## What does this template contain?
+### Frontend
 
-1. An example of a simple scene. See [Home scene](./src/pages/Home/Home.tsx)
-1. An example of a scene with tabs. See [Scene with tabs](./src/pages/WithTabs/WithTabs.tsx)
-1. An example of a scene with drill down. See [Scene with drill down](./src/pages/WithDrilldown/WithDrilldown.tsx)
+#### Prerequisites
+
+- Node.js 22+
+- Docker Desktop
+
+#### Install dependencies
+
+```bash
+npm install
+```
+
+#### Run in watch mode
+
+Begin by starting the Grafana server in a separate terminal:
+
+```bash
+npm run server
+```
+
+Then, run the plugin in watch mode:
+
+```bash
+npm run dev
+```
+
+#### Running tests
+
+##### Unit tests
+
+```bash
+# Runs the tests and watches for changes
+npm run test
+
+# Exits after running all the tests
+npm run test:ci
+```
+
+##### End-to-end tests
+
+First, ensure that the Grafana server is running:
+
+```bash
+npm run server
+```
+
+Then, run the E2E tests:
+
+```bash
+npm run e2e
+```
+
+#### Run the linter
+
+To see lint errors, run:
+
+```bash
+npm run lint
+```
+
+To fix lint errors automatically, run:
+
+```bash
+npm run lint:fix
+```
 
 ### Configuration
 
@@ -26,98 +89,3 @@ If you'd like to customize the exposed port of the Grafana instance that is used
 # .env
 GRAFANA_PORT=3001
 ```
-
-### Frontend
-
-1. Install dependencies
-
-   ```bash
-   npm install
-   ```
-
-2. Build plugin in development mode and run in watch mode
-
-   ```bash
-   npm run dev
-   ```
-
-3. Build plugin in production mode
-
-   ```bash
-   npm run build
-   ```
-
-4. Run the tests (using Jest)
-
-   ```bash
-   # Runs the tests and watches for changes, requires git init first
-   npm run test
-
-   # Exits after running all the tests
-   npm run test:ci
-   ```
-
-5. Spin up a Grafana instance and run the plugin inside it (using Docker)
-
-   ```bash
-   npm run server
-   ```
-
-6. Run the E2E tests (using Cypress)
-
-   ```bash
-   # Spins up a Grafana instance first that we tests against
-   npm run server
-
-   # Starts the tests
-   npm run e2e
-   ```
-
-7. Run the linter
-
-   ```bash
-   npm run lint
-
-   # or
-
-   npm run lint:fix
-   ```
-
-# Distributing your plugin
-
-When distributing a Grafana plugin either within the community or privately the plugin must be signed so the Grafana application can verify its authenticity. This can be done with the `@grafana/sign-plugin` package.
-
-_Note: It's not necessary to sign a plugin during development. The docker development environment that is scaffolded with `@grafana/create-plugin` caters for running the plugin without a signature._
-
-## Initial steps
-
-Before signing a plugin please read the Grafana [plugin publishing and signing criteria](https://grafana.com/legal/plugins/#plugin-publishing-and-signing-criteria) documentation carefully.
-
-`@grafana/create-plugin` has added the necessary commands and workflows to make signing and distributing a plugin via the grafana plugins catalog as straightforward as possible.
-
-Before signing a plugin for the first time please consult the Grafana [plugin signature levels](https://grafana.com/legal/plugins/#what-are-the-different-classifications-of-plugins) documentation to understand the differences between the types of signature level.
-
-1. Create a [Grafana Cloud account](https://grafana.com/signup).
-2. Make sure that the first part of the plugin ID matches the slug of your Grafana Cloud account.
-   - _You can find the plugin ID in the `plugin.json` file inside your plugin directory. For example, if your account slug is `acmecorp`, you need to prefix the plugin ID with `acmecorp-`._
-3. Create a Grafana Cloud API key with the `PluginPublisher` role.
-4. Keep a record of this API key as it will be required for signing a plugin
-
-## Signing a plugin
-
-### Using Github actions release workflow
-
-If the plugin is using the github actions supplied with `@grafana/create-plugin` signing a plugin is included out of the box. The [release workflow](./.github/workflows/release.yml) can prepare everything to make submitting your plugin to Grafana as easy as possible. Before being able to sign the plugin however a secret needs adding to the Github repository.
-
-1. Please navigate to "settings > secrets > actions" within your repo to create secrets.
-2. Click "New repository secret"
-3. Name the secret "GRAFANA_API_KEY"
-4. Paste your Grafana Cloud API key in the Secret field
-5. Click "Add secret"
-
-#### Push a version tag
-
-To trigger the workflow we need to push a version tag to github. This can be achieved with the following steps:
-
-1. Run `npm version <major|minor|patch>`
-2. Run `git push origin main --follow-tags`

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
-# Metrics-Drilldown
+# Grafana Metrics Drilldown
 
-Metrics Drilldown provides a query-less experience for browsing Prometheus-compatible metrics. Quickly find related metrics without writing PromQL queries.
+Grafana Metrics Drilldown provides a query-less experience for browsing Prometheus-compatible metrics. Quickly find related metrics without writing PromQL queries.
 
 ## Requirements
 
@@ -8,13 +8,13 @@ Requires Grafana 11.3.0 or newer.
 
 ## Getting Started
 
-See the [docs](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/metrics/#standalone-experience) for more info using Metrics Drilldown.
+See the [docs](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/metrics/#standalone-experience) for more info using Grafana Metrics Drilldown.
 
 ## Documentation
 
-- [DOCS](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/metrics/)
+- [DOCS](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/metrics)
 - [CHANGELOG](https://github.com/grafana/metrics-drilldown/releases)
-- [GITHUB](https://github.com/grafana/metrics-drilldown/)
+- [GITHUB](https://github.com/grafana/metrics-drilldown)
 
 ## Contributing
 
@@ -26,5 +26,4 @@ If your issue is a bug, please open one [here](https://github.com/grafana/metric
 
 ### Changes
 
-We do not have a formal proposal process for changes or feature requests. If you have a change you would like to see in
-Metrics Drilldown, please [file an issue](https://github.com/grafana/metrics-drilldown/issues/new) with the necessary details.
+We do not have a formal proposal process for changes or feature requests. If you have a change you would like to see in Grafana Metrics Drilldown, please [file an issue](https://github.com/grafana/metrics-drilldown/issues/new) with the necessary details.

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -55,7 +55,6 @@
     "grafanaDependency": ">=11.3.0",
     "plugins": []
   },
-  "preload": true,
   "extensions": {
     "addedLinks": [],
     "extensionPoints": [

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
-  "name": "Metrics Drilldown",
+  "name": "Grafana Metrics Drilldown",
   "id": "grafana-metricsdrilldown-app",
   "autoEnabled": true,
   "info": {
-    "keywords": ["app", "mimir", "prometheus", "metrics", "drilldown"],
+    "keywords": ["drilldown", "metrics", "app", "prometheus", "mimir"],
     "description": "Queryless metrics explorer for Prometheus data sources",
     "author": {
       "name": "Grafana"
@@ -44,7 +44,7 @@
   "includes": [
     {
       "type": "page",
-      "name": "Metrics App",
+      "name": "Grafana Metrics Drilldown",
       "path": "/a/%PLUGIN_ID%/",
       "action": "datasources:explore",
       "addToNav": true,
@@ -55,6 +55,7 @@
     "grafanaDependency": ">=11.3.0",
     "plugins": []
   },
+  "preload": true,
   "extensions": {
     "addedLinks": [],
     "extensionPoints": [


### PR DESCRIPTION
## What does this do?

- Updates the repo-level README and the README published to the plugins catalog, to improve clarity, accuracy, and naming correctness.
- Updates the `plugin.json` config for naming correctness and rearranges keywords for plugin catalog search.

## Notes for reviewers

Please check out:
- the README that'll be visible in the Grafana plugins catalog: https://github.com/grafana/metrics-drilldown/blob/chore/prepare-app-for-prod-plugins-catalog/src/README.md
- the repo-level README: https://github.com/grafana/metrics-drilldown/tree/chore/prepare-app-for-prod-plugins-catalog?tab=readme-ov-file#grafana-metrics-drilldown