### PR TITLE
perf: preload app and reduce bundle size

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -55,6 +55,7 @@
     "grafanaDependency": ">=11.3.0",
     "plugins": []
   },
+  "preload": true,
   "extensions": {
     "addedLinks": [],
     "extensionPoints": [

--- a/src/stubs/moment-timezone.ts
+++ b/src/stubs/moment-timezone.ts
@@ -1,0 +1,1 @@
+export const tz = {};

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -23,6 +23,7 @@ const config = async (env): Promise<Configuration> => {
         /@grafana\/plugin-ui/,
         path.resolve(__dirname, 'src/stubs/grafana-plugin-ui.ts')
       ),
+      new NormalModuleReplacementPlugin(/moment-timezone/, path.resolve(__dirname, 'src/stubs/moment-timezone.ts')),
     ],
   });
 };


### PR DESCRIPTION
## What does this PR do?

This PR does a couple of things:

### Webpack changes

We're now stubbing another transitive dependency (from `@grafana/prometheus`) that was adding unnecessary heft to our bundle. Check out the results of `npm run analyze` before and after this change:

#### Before

<img width="1366" alt="node modules before" src="https://github.com/user-attachments/assets/8e353905-788b-4c97-85d9-3a528fa3b962" />

#### After

<img width="1366" alt="node modules after moment-timezone stub" src="https://github.com/user-attachments/assets/f79722d8-0558-45b0-8c25-25fb81999e32" />

### Plugin config changes

This PR adds [`preload` config](https://grafana.com/developers/plugin-tools/reference/plugin-json) to load the app before users navigate to it. This is something that other Drilldown apps do, and we should feel free to also, since we've taken steps to keep the bundle size under control and use code splitting (in https://github.com/grafana/metrics-drilldown/pull/56, https://github.com/grafana/metrics-drilldown/pull/64, and this PR).

Note that `preload` is not the same as "preinstall." Preinstall is taken care of by https://github.com/grafana/grafana/pull/100094. Preload relates only to when the JS, CSS etc. resources from this app are loaded by Grafana.

## How to test

The normal `npm run server` and `npm run dev`. Navigate the app, change time ranges, etc., checking for anything broken. In my local testing, everything continues to work as expected.