### PR TITLE
chore: set version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.0-1
+
+See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-1>
+
+## 1.0.0-0
+
+See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-0>
+
 ## 0.1.0 (Unreleased)
 
 Initial release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "1.0.0-0",
+  "version": "1.0.0-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-metricsdrilldown-app",
-      "version": "1.0.0-0",
+      "version": "1.0.0-1",
       "license": "Apache-2.0",
       "dependencies": {
         "@bsull/augurs": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "1.0.0-0",
+  "version": "1.0.0-1",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",
     "dev": "webpack -w -c ./webpack.config.ts --env development",


### PR DESCRIPTION
This PR updates the package version to reflect the most recent tag (`v1.0.0-1`).

It also updates the Changelog to point to the release notes for each tag.