### PR TITLE
docs: add new tag to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0-2
+
+See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-2>
+
 ## 1.0.0-1
 
 See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-1>


### PR DESCRIPTION
This PR adds a link to the release notes for the forthcoming `1.0.0-2` tag to the changelog.