### PR TITLE
Bug fix: Fix explore link in panel using metricScene

### DIFF
--- a/src/Menu/PanelMenu.tsx
+++ b/src/Menu/PanelMenu.tsx
@@ -2,7 +2,6 @@ import { type DataFrame, type PanelMenuItem } from '@grafana/data';
 import { getPluginLinkExtensions } from '@grafana/runtime';
 import {
   getExploreURL,
-  SceneCSSGridItem,
   sceneGraph,
   SceneObjectBase,
   VizPanel,
@@ -13,11 +12,8 @@ import {
 } from '@grafana/scenes';
 import React from 'react';
 
-import { MetricScene } from 'MetricScene';
-
 import { AddToExplorationButton, extensionPointId } from '../MetricSelect/AddToExplorationsButton';
 import { getQueryRunnerFor } from '../utils/utils.queries';
-import { MetricSelectScene } from 'MetricSelect/MetricSelectScene';
 
 const ADD_TO_INVESTIGATION_MENU_TEXT = 'Add to investigation';
 const ADD_TO_INVESTIGATION_MENU_DIVIDER_TEXT = 'investigations_divider'; // Text won't be visible

--- a/src/Menu/PanelMenu.tsx
+++ b/src/Menu/PanelMenu.tsx
@@ -12,10 +12,10 @@ import {
 } from '@grafana/scenes';
 import React from 'react';
 
-import { AddToExplorationButton, extensionPointId } from '../MetricSelect/AddToExplorationsButton';
-import { getTrailFor } from '../utils';
-import { getQueryRunnerFor } from '../utils/utils.queries';
 import { MetricScene } from 'MetricScene';
+
+import { AddToExplorationButton, extensionPointId } from '../MetricSelect/AddToExplorationsButton';
+import { getQueryRunnerFor } from '../utils/utils.queries';
 
 const ADD_TO_INVESTIGATION_MENU_TEXT = 'Add to investigation';
 const ADD_TO_INVESTIGATION_MENU_DIVIDER_TEXT = 'investigations_divider'; // Text won't be visible
@@ -51,6 +51,7 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
           delete query.legendFormat;
         });
         // use the metric scene to get the explore url with interpolated variables
+        // need to get not just the metric scene but something deeper so that we can access this in the trail
         const metricScene = sceneGraph.getAncestor(this, MetricScene);
         exploreUrl = getExploreURL(panelData, metricScene, panelData.timeRange);
       } catch (e) {}

--- a/src/Menu/PanelMenu.tsx
+++ b/src/Menu/PanelMenu.tsx
@@ -2,6 +2,7 @@ import { type DataFrame, type PanelMenuItem } from '@grafana/data';
 import { getPluginLinkExtensions } from '@grafana/runtime';
 import {
   getExploreURL,
+  SceneCSSGridItem,
   sceneGraph,
   SceneObjectBase,
   VizPanel,
@@ -16,6 +17,7 @@ import { MetricScene } from 'MetricScene';
 
 import { AddToExplorationButton, extensionPointId } from '../MetricSelect/AddToExplorationsButton';
 import { getQueryRunnerFor } from '../utils/utils.queries';
+import { MetricSelectScene } from 'MetricSelect/MetricSelectScene';
 
 const ADD_TO_INVESTIGATION_MENU_TEXT = 'Add to investigation';
 const ADD_TO_INVESTIGATION_MENU_DIVIDER_TEXT = 'investigations_divider'; // Text won't be visible
@@ -50,10 +52,11 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
           // removing legendFormat to get verbose legend in Explore
           delete query.legendFormat;
         });
-        // use the metric scene to get the explore url with interpolated variables
-        // need to get not just the metric scene but something deeper so that we can access this in the trail
-        const metricScene = sceneGraph.getAncestor(this, MetricScene);
-        exploreUrl = getExploreURL(panelData, metricScene, panelData.timeRange);
+        // 'this' scene object contain the variable for the metric name which is correctly interpolated into the explore url
+        // when used in the metric select scene case,
+        // this will get the explore url with interpolated variables and include the labels __ignore_usage__, this is a known issue
+        // in the metric scene we do not get use the __ignore_usage__ labels in the explore url
+        exploreUrl = getExploreURL(panelData, this, panelData.timeRange);
       } catch (e) {}
 
       // Navigation options (all panels)

--- a/src/Menu/PanelMenu.tsx
+++ b/src/Menu/PanelMenu.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 import { AddToExplorationButton, extensionPointId } from '../MetricSelect/AddToExplorationsButton';
 import { getTrailFor } from '../utils';
 import { getQueryRunnerFor } from '../utils/utils.queries';
+import { MetricScene } from 'MetricScene';
 
 const ADD_TO_INVESTIGATION_MENU_TEXT = 'Add to investigation';
 const ADD_TO_INVESTIGATION_MENU_DIVIDER_TEXT = 'investigations_divider'; // Text won't be visible
@@ -49,8 +50,9 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
           // removing legendFormat to get verbose legend in Explore
           delete query.legendFormat;
         });
-        const trail = getTrailFor(this);
-        exploreUrl = getExploreURL(panelData, trail, panelData.timeRange);
+        // use the metric scene to get the explore url with interpolated variables
+        const metricScene = sceneGraph.getAncestor(this, MetricScene);
+        exploreUrl = getExploreURL(panelData, metricScene, panelData.timeRange);
       } catch (e) {}
 
       // Navigation options (all panels)


### PR DESCRIPTION
Fixes https://github.com/grafana/metrics-drilldown/issues/170

The open in explore link that is in the panel (not the open in explore icon) was not interpolating the metric in the expression passed to the explore query editor. This fixes that.

How to Test:

1. Select a metric in GMD.
2. See the metric panel.
3. Find the hamburger dots in the large metric panel.
4. Click explore link from the dots.
5. See that the query open in explore query editor has the metric correctly interpolated.

![Screenshot 2025-03-13 at 11 02 01 AM](https://github.com/user-attachments/assets/b41783d3-7f4d-4d77-9ceb-23eddd8abb0b)
![Screenshot 2025-03-13 at 11 02 38 AM](https://github.com/user-attachments/assets/130ab375-67e8-4dca-9161-bf55932409e9)
