### PR TITLE
ci: fix workflow dispatch

### DIFF
--- a/.github/workflows/bundle-stats-create.yml
+++ b/.github/workflows/bundle-stats-create.yml
@@ -30,7 +30,6 @@ jobs:
         run: npm run build -- --profile --json stats.json
 
       - name: Upload stats.json artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: main-branch-stats


### PR DESCRIPTION
## Why?

A troublesome conditional is preventing the `build-stats` job from uploading bundle size artifacts when `.github/workflows/bundle-stats-create.yml` is run via workflow dispatch.