### PR TITLE
chore: rerelease `1.0.0-3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "1.0.0-2",
+  "version": "1.0.0-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-metricsdrilldown-app",
-      "version": "1.0.0-2",
+      "version": "1.0.0-3",
       "license": "Apache-2.0",
       "dependencies": {
         "@bsull/augurs": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "1.0.0-2",
+  "version": "1.0.0-3",
   "scripts": {
     "prebuild": "./scripts/update-commit-sha.sh",
     "build": "webpack -c ./webpack.config.ts --env production",


### PR DESCRIPTION
## What does this PR do?

Runs `npm version prerelease` to:
- Update the project's version to `1.0.0-3` in `package.json` & `package-lock.json`
- Create a new `v1.0.0-3` tag which will be the basis of a new release