### PR TITLE
chore: prerelease 1.0.0 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0-4
+
+See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-4>
+
 ## 1.0.0-3
 
 See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-3>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "1.0.0-3",
+  "version": "1.0.0-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-metricsdrilldown-app",
-      "version": "1.0.0-3",
+      "version": "1.0.0-4",
       "license": "Apache-2.0",
       "dependencies": {
         "@bsull/augurs": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "1.0.0-3",
+  "version": "1.0.0-4",
   "scripts": {
     "prebuild": "./scripts/update-commit-sha.sh",
     "build": "webpack -c ./webpack.config.ts --env production",


### PR DESCRIPTION
## What does this PR do?

Runs `npm version prerelease` to:
- Update the project's version to `1.0.0-4` in `package.json` & `package-lock.json`
- Adds the release notes for the forthcoming `v1.0.0-4` tag to the changelog