### PR TITLE
Chore: Set Grafana version 11.6.0-82198 as oldest supported version

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -4,7 +4,7 @@ The Grafana Metrics Drilldown app provides a queryless experience for browsing P
 
 ## Requirements
 
-Requires Grafana 11.6.0-82198 or newer.
+Requires Grafana 11.6.0 or newer.
 
 ## Getting Started
 

--- a/src/README.md
+++ b/src/README.md
@@ -4,7 +4,7 @@ The Grafana Metrics Drilldown app provides a queryless experience for browsing P
 
 ## Requirements
 
-Requires Grafana 11.3.0 or newer.
+Requires Grafana 11.6.0-82198 or newer.
 
 ## Getting Started
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -52,7 +52,7 @@
     }
   ],
   "dependencies": {
-    "grafanaDependency": ">=11.3.0",
+    "grafanaDependency": ">=11.6.0-82198",
     "plugins": []
   },
   "preload": true,


### PR DESCRIPTION
Make our CI workflow only test against 11.6.0-82198 and newer

- [x] Update src/plugin.json’s minimum Grafana version dependency to 11.6.0-82198
- [x] Update the minimum version in the Requirements section of src/README.md to 11.6.0-82198