### PR TITLE
feat(investigations): add `fieldConfig` to investigations context

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -281,3 +281,22 @@ export async function callSuggestionsApi(
     })
   );
 }
+
+interface SceneType<T> extends Function {
+  new (...args: never[]): T;
+}
+
+export function findObjectOfType<T extends SceneObject>(
+  scene: SceneObject,
+  check: (obj: SceneObject) => boolean,
+  returnType: SceneType<T>
+) {
+  const obj = sceneGraph.findObject(scene, check);
+  if (obj instanceof returnType) {
+    return obj;
+  } else if (obj !== null) {
+    console.warn(`invalid return type: ${returnType.toString()}`);
+  }
+
+  return null;
+}


### PR DESCRIPTION
Corresponding PR for https://github.com/grafana/investigations-app/pull/229 to pass fieldConfig to the investigations app in order to keep same colors, etc of panels.