### PR TITLE
fix: display unit in metric panel y-axis

### DIFF
--- a/src/WingmanDataTrail/MetricVizPanel/MetricVizPanel.tsx
+++ b/src/WingmanDataTrail/MetricVizPanel/MetricVizPanel.tsx
@@ -11,6 +11,7 @@ import {
 import { useStyles2 } from '@grafana/ui';
 import React from 'react';
 
+import { getUnit } from 'autoQuery/units';
 import { trailDS } from 'shared';
 
 import { ConfigureAction, type PrometheusFn } from './actions/ConfigureAction';
@@ -91,6 +92,7 @@ export class MetricVizPanel extends SceneObjectBase<MetricVizPanelState> {
     headerActions: MetricVizPanelState['headerActions'];
   }) {
     const panelTitle = highlight ? `${title} (current)` : title;
+    const unit = getUnit(metricName);
 
     const isUptime = metricName === 'up' || metricName.endsWith('_up');
     if (isUptime) {
@@ -104,7 +106,9 @@ export class MetricVizPanel extends SceneObjectBase<MetricVizPanelState> {
           matchers,
           prometheusFunction,
         }),
-      }).build();
+      })
+        .setUnit(unit) // Set the appropriate unit for status history panel as well
+        .build();
     }
 
     // Default settings for non-uptime metrics - use timeseries
@@ -118,7 +122,9 @@ export class MetricVizPanel extends SceneObjectBase<MetricVizPanelState> {
         matchers,
         prometheusFunction,
       }),
-    }).build();
+    })
+      .setUnit(unit) // Set the appropriate unit
+      .build();
   }
 
   private static buildQueryRunner({

--- a/src/autoQuery/units.ts
+++ b/src/autoQuery/units.ts
@@ -1,13 +1,27 @@
 export const DEFAULT_UNIT = 'short';
 export const DEFAULT_RATE_UNIT = 'cps'; // Count per second
 
-const UNIT_MAP: Record<string, string> = { bytes: 'bytes', seconds: 's' };
+// Enhanced unit mappings with more common unit types
+const UNIT_MAP: Record<string, string> = {
+  bytes: 'bytes',
+  seconds: 's',
+  milliseconds: 'ms',
+  bits: 'bits',
+  percent: 'percent',
+  count: 'short',
+};
+
 const UNIT_LIST = Object.keys(UNIT_MAP);
+
+// Enhanced rate unit mappings
 const RATE_UNIT_MAP: Record<string, string> = {
   bytes: 'Bps', // bytes per second
+  bits: 'bps', // bits per second
   // seconds per second is unitless
   // this may indicate a count of some resource that is active
   seconds: 'short',
+  count: 'cps', // counts per second
+  percent: 'percent', // percent stays percent even as a rate
 };
 
 // Get unit from metric name (e.g. "go_gc_duration_seconds" -> "seconds")
@@ -16,20 +30,74 @@ export function getUnitFromMetric(metric: string) {
     return null;
   }
 
-  const metricParts = metric.toLowerCase().split('_').slice(-2); // Get last two parts
-  for (let i = metricParts.length - 1; i >= 0; i--) {
-    if (UNIT_LIST.includes(metricParts[i])) {
-      return metricParts[i];
+  const metricLower = metric.toLowerCase();
+
+  // First check for special patterns like CPU metrics
+  if (metricLower.includes('cpu_seconds') || metricLower.includes('cpu_seconds_total')) {
+    return 'seconds';
+  }
+
+  // Check for duration or latency metrics
+  if (metricLower.includes('duration') || metricLower.includes('latency')) {
+    return 'seconds';
+  }
+
+  // Then try the suffix-based approach
+  const metricParts = metricLower.split('_');
+
+  // Check the last two parts first (common pattern)
+  for (let i = metricParts.length - 1; i >= Math.max(0, metricParts.length - 2); i--) {
+    const part = metricParts[i];
+    if (UNIT_LIST.includes(part)) {
+      return part;
     }
   }
+
+  // Check for common units anywhere in the metric name
+  for (const unit of UNIT_LIST) {
+    if (metricLower.includes(unit)) {
+      return unit;
+    }
+  }
+
+  // Check for common patterns
+  if (metricLower.endsWith('_ms') || metricLower.includes('_ms_')) {
+    return 'milliseconds';
+  } else if (metricLower.endsWith('_count') || metricLower.includes('_count_')) {
+    return 'count';
+  } else if (metricLower.includes('percentage') || metricLower.includes('ratio')) {
+    return 'percent';
+  }
+
   return null;
 }
 
 // Get Grafana unit for a panel (e.g. "go_gc_duration_seconds" -> "s")
-export function getUnit(metricPart: string | undefined) {
+export function getUnit(metricName: string | undefined) {
+  if (!metricName) {
+    return DEFAULT_UNIT;
+  }
+
+  const metricPart = getUnitFromMetric(metricName);
   return (metricPart && UNIT_MAP[metricPart]) || DEFAULT_UNIT;
 }
 
-export function getPerSecondRateUnit(metricPart: string | undefined) {
+export function getPerSecondRateUnit(metricName: string | undefined) {
+  if (!metricName) {
+    return DEFAULT_RATE_UNIT;
+  }
+
+  const metricPart = getUnitFromMetric(metricName);
+
+  // Special case for rate metrics
+  const metricLower = metricName.toLowerCase();
+  if ((metricLower.includes('rate') || metricLower.includes('per_second')) && metricPart === 'bytes') {
+    return 'Bps';
+  } else if ((metricLower.includes('rate') || metricLower.includes('per_second')) && metricPart === 'bits') {
+    return 'bps';
+  } else if (metricLower.includes('rate') || metricLower.includes('per_second')) {
+    return 'ops'; // Operations per second as a general fallback for rates
+  }
+
   return (metricPart && RATE_UNIT_MAP[metricPart]) || DEFAULT_RATE_UNIT;
 }

--- a/src/autoQuery/units.ts
+++ b/src/autoQuery/units.ts
@@ -1,25 +1,38 @@
 export const DEFAULT_UNIT = 'short';
 export const DEFAULT_RATE_UNIT = 'cps'; // Count per second
 
+// Unit constants
+export const UNIT_BYTES = 'bytes';
+export const UNIT_SECONDS = 'seconds';
+export const UNIT_MILLISECONDS = 'milliseconds';
+export const UNIT_BITS = 'bits';
+export const UNIT_PERCENT = 'percent';
+export const UNIT_COUNT = 'count';
+
+// Rate unit constants
+export const RATE_BYTES_PER_SECOND = 'Bps';
+export const RATE_BITS_PER_SECOND = 'bps';
+export const RATE_OPS_PER_SECOND = 'ops';
+
 const UNIT_MAP: Record<string, string> = {
-  bytes: 'bytes',
-  seconds: 's',
-  milliseconds: 'ms',
-  bits: 'bits',
-  percent: 'percent',
-  count: 'short',
+  [UNIT_BYTES]: UNIT_BYTES,
+  [UNIT_SECONDS]: 's',
+  [UNIT_MILLISECONDS]: 'ms',
+  [UNIT_BITS]: UNIT_BITS,
+  [UNIT_PERCENT]: UNIT_PERCENT,
+  [UNIT_COUNT]: DEFAULT_UNIT,
 };
 
 const UNIT_LIST = Object.keys(UNIT_MAP);
 
 const RATE_UNIT_MAP: Record<string, string> = {
-  bytes: 'Bps',
-  bits: 'bps',
+  [UNIT_BYTES]: RATE_BYTES_PER_SECOND,
+  [UNIT_BITS]: RATE_BITS_PER_SECOND,
   // seconds per second is unitless
   // this may indicate a count of some resource that is active
-  seconds: 'short',
-  count: 'cps',
-  percent: 'percent',
+  [UNIT_SECONDS]: DEFAULT_UNIT,
+  [UNIT_COUNT]: DEFAULT_RATE_UNIT,
+  [UNIT_PERCENT]: UNIT_PERCENT,
 };
 
 // Get unit from metric name (e.g. "go_gc_duration_seconds" -> "seconds")
@@ -32,12 +45,12 @@ export function getUnitFromMetric(metric: string) {
 
   // First check for special patterns like CPU metrics
   if (metricLower.includes('cpu_seconds') || metricLower.includes('cpu_seconds_total')) {
-    return 'seconds';
+    return UNIT_SECONDS;
   }
 
   // Check for duration or latency metrics
   if (metricLower.includes('duration') || metricLower.includes('latency')) {
-    return 'seconds';
+    return UNIT_SECONDS;
   }
 
   // Then try the suffix-based approach
@@ -60,11 +73,11 @@ export function getUnitFromMetric(metric: string) {
 
   // Check for common patterns
   if (metricLower.endsWith('_ms') || metricLower.includes('_ms_')) {
-    return 'milliseconds';
+    return UNIT_MILLISECONDS;
   } else if (metricLower.endsWith('_count') || metricLower.includes('_count_')) {
-    return 'count';
+    return UNIT_COUNT;
   } else if (metricLower.includes('percentage') || metricLower.includes('ratio')) {
-    return 'percent';
+    return UNIT_PERCENT;
   }
 
   return null;
@@ -89,12 +102,12 @@ export function getPerSecondRateUnit(metricName: string | undefined) {
 
   // Special case for rate metrics
   const metricLower = metricName.toLowerCase();
-  if ((metricLower.includes('rate') || metricLower.includes('per_second')) && metricPart === 'bytes') {
-    return 'Bps';
-  } else if ((metricLower.includes('rate') || metricLower.includes('per_second')) && metricPart === 'bits') {
-    return 'bps';
+  if ((metricLower.includes('rate') || metricLower.includes('per_second')) && metricPart === UNIT_BYTES) {
+    return RATE_BYTES_PER_SECOND;
+  } else if ((metricLower.includes('rate') || metricLower.includes('per_second')) && metricPart === UNIT_BITS) {
+    return RATE_BITS_PER_SECOND;
   } else if (metricLower.includes('rate') || metricLower.includes('per_second')) {
-    return 'ops'; // Operations per second as a general fallback for rates
+    return RATE_OPS_PER_SECOND; // Operations per second as a general fallback for rates
   }
 
   return (metricPart && RATE_UNIT_MAP[metricPart]) || DEFAULT_RATE_UNIT;

--- a/src/autoQuery/units.ts
+++ b/src/autoQuery/units.ts
@@ -1,7 +1,6 @@
 export const DEFAULT_UNIT = 'short';
 export const DEFAULT_RATE_UNIT = 'cps'; // Count per second
 
-// Enhanced unit mappings with more common unit types
 const UNIT_MAP: Record<string, string> = {
   bytes: 'bytes',
   seconds: 's',
@@ -13,15 +12,14 @@ const UNIT_MAP: Record<string, string> = {
 
 const UNIT_LIST = Object.keys(UNIT_MAP);
 
-// Enhanced rate unit mappings
 const RATE_UNIT_MAP: Record<string, string> = {
-  bytes: 'Bps', // bytes per second
-  bits: 'bps', // bits per second
+  bytes: 'Bps',
+  bits: 'bps',
   // seconds per second is unitless
   // this may indicate a count of some resource that is active
   seconds: 'short',
-  count: 'cps', // counts per second
-  percent: 'percent', // percent stays percent even as a rate
+  count: 'cps',
+  percent: 'percent',
 };
 
 // Get unit from metric name (e.g. "go_gc_duration_seconds" -> "seconds")


### PR DESCRIPTION
## description
fixes https://github.com/grafana/metrics-drilldown/issues/192

the y-axis of the panels now displays units like 's' for seconds-based metrics such as CPU metrics, 'bytes' for byte-based metrics, etc. Grafana automatically formats these units appropriately (e.g., converting bytes to KB, MB, GB as needed).

changes in `units.ts`
- [x] add more unit types to `UNIT_MAP` (milliseconds, bits, percent, count)
- [x] expand `RATE_UNIT_MAP` to handle more rate metrics
- [x] refactor `getUnitFromMetric` to be more robust using several detection strategies
- [x] update `getUnit` and `getPerSecondRateUnit` to work with the metric name directly instead of requiring a pre-processed part

### demo
#### before changes

https://github.com/user-attachments/assets/9f9acb01-6802-470f-8e60-a9c5fc7bc3b7


#### after changes

https://github.com/user-attachments/assets/6ab62a09-bec0-4277-80af-2c31d1b32c17

