### PR TITLE
fix: add missing module dependency

### DIFF
--- a/src/stubs/moment-timezone.ts
+++ b/src/stubs/moment-timezone.ts
@@ -1,1 +1,0 @@
-export const tz = {};

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -23,7 +23,6 @@ const config = async (env): Promise<Configuration> => {
         /@grafana\/plugin-ui/,
         path.resolve(__dirname, 'src/stubs/grafana-plugin-ui.ts')
       ),
-      new NormalModuleReplacementPlugin(/moment-timezone/, path.resolve(__dirname, 'src/stubs/moment-timezone.ts')),
     ],
   });
 };


### PR DESCRIPTION
## Related issue

Fixes #206 

## What does this do?

Re-adds a transitive dependency `moment-timezone`, which was stubbed out in #161.