### PR TITLE
fix: display unit in metric panel y-axis

### DIFF
--- a/src/WingmanDataTrail/MetricVizPanel/MetricVizPanel.tsx
+++ b/src/WingmanDataTrail/MetricVizPanel/MetricVizPanel.tsx
@@ -11,6 +11,7 @@ import {
 import { useStyles2 } from '@grafana/ui';
 import React from 'react';
 
+import { getUnit } from 'autoQuery/units';
 import { trailDS } from 'shared';
 
 import { ConfigureAction, type PrometheusFn } from './actions/ConfigureAction';
@@ -91,6 +92,7 @@ export class MetricVizPanel extends SceneObjectBase<MetricVizPanelState> {
     headerActions: MetricVizPanelState['headerActions'];
   }) {
     const panelTitle = highlight ? `${title} (current)` : title;
+    const unit = getUnit(metricName);
 
     const isUptime = metricName === 'up' || metricName.endsWith('_up');
     if (isUptime) {
@@ -104,7 +106,9 @@ export class MetricVizPanel extends SceneObjectBase<MetricVizPanelState> {
           matchers,
           prometheusFunction,
         }),
-      }).build();
+      })
+        .setUnit(unit) // Set the appropriate unit for status history panel as well
+        .build();
     }
 
     // Default settings for non-uptime metrics - use timeseries
@@ -118,7 +122,9 @@ export class MetricVizPanel extends SceneObjectBase<MetricVizPanelState> {
         matchers,
         prometheusFunction,
       }),
-    }).build();
+    })
+      .setUnit(unit) // Set the appropriate unit
+      .build();
   }
 
   private static buildQueryRunner({

--- a/src/autoQuery/units.test.ts
+++ b/src/autoQuery/units.test.ts
@@ -10,11 +10,6 @@ describe('getUnitFromMetric', () => {
     expect(getUnitFromMetric('go_gc_duration_seconds')).toBe('seconds');
   });
 
-  it('should return the second to last part of the metric if it is a valid unit', () => {
-    expect(getUnitFromMetric('go_gc_heap_allocs_by_size_bytes_count')).toBe('bytes');
-    expect(getUnitFromMetric('go_cpu_classes_gc_mark_assist_cpu_seconds_total')).toBe('seconds');
-  });
-
   it('should return null if no valid unit is found', () => {
     expect(getUnitFromMetric('ALERTS')).toBe(null);
     expect(getUnitFromMetric('utf8 metric with.dot')).toBe(null);

--- a/src/autoQuery/units.test.ts
+++ b/src/autoQuery/units.test.ts
@@ -4,6 +4,7 @@ import {
   getPerSecondRateUnit,
   getUnit,
   getUnitFromMetric,
+  RATE_BYTES_PER_SECOND,
   UNIT_BYTES,
   UNIT_SECONDS,
 } from './units';
@@ -14,8 +15,8 @@ describe('getUnitFromMetric', () => {
   });
 
   it('should return the last part of the metric if it is a valid unit', () => {
-    expect(getUnitFromMetric('go_gc_gomemlimit_bytes')).toBe('bytes');
-    expect(getUnitFromMetric('go_gc_duration_seconds')).toBe('seconds');
+    expect(getUnitFromMetric('go_gc_gomemlimit_bytes')).toBe(UNIT_BYTES);
+    expect(getUnitFromMetric('go_gc_duration_seconds')).toBe(UNIT_SECONDS);
   });
 
   it('should return null if no valid unit is found', () => {
@@ -24,7 +25,7 @@ describe('getUnitFromMetric', () => {
   });
 
   it('should handle metrics with extra underscores', () => {
-    expect(getUnitFromMetric('go_gc__duration__seconds')).toBe('seconds');
+    expect(getUnitFromMetric('go_gc__duration__seconds')).toBe(UNIT_SECONDS);
   });
 
   it('should return null if the metric ends with an invalid unit', () => {
@@ -32,7 +33,7 @@ describe('getUnitFromMetric', () => {
   });
 
   it('should return the last unit if the metric contains only valid units', () => {
-    expect(getUnitFromMetric('bytes_seconds')).toBe('seconds');
+    expect(getUnitFromMetric('bytes_seconds')).toBe(UNIT_SECONDS);
   });
 });
 
@@ -63,7 +64,7 @@ describe('getUnit', () => {
 
 describe('getPerSecondRateUnit', () => {
   it('should return the mapped rate unit for a valid metric part', () => {
-    expect(getPerSecondRateUnit('bytes')).toBe('Bps');
+    expect(getPerSecondRateUnit('bytes')).toBe(RATE_BYTES_PER_SECOND);
     expect(getPerSecondRateUnit('seconds')).toBe('short');
   });
 

--- a/src/autoQuery/units.test.ts
+++ b/src/autoQuery/units.test.ts
@@ -55,6 +55,11 @@ describe('getUnit', () => {
     expect(getUnit('invalidPart')).toBe(DEFAULT_UNIT);
   });
 
+  it('should handle case sensitivity correctly', () => {
+    expect(getUnit('BYTES')).toBe(UNIT_BYTES);
+    expect(getUnit('SECONDS')).toBe('s');
+  });
+
   it('should not throw errors for unusual input', () => {
     expect(() => getUnit('123')).not.toThrow();
     expect(() => getUnit('some_random_string')).not.toThrow();
@@ -78,6 +83,10 @@ describe('getPerSecondRateUnit', () => {
 
   it('should return the default rate unit if the metric part is not in RATE_UNIT_MAP', () => {
     expect(getPerSecondRateUnit('invalidPart')).toBe(DEFAULT_RATE_UNIT);
+  });
+
+  it('should handle case sensitivity correctly', () => {
+    expect(getPerSecondRateUnit('BYTES')).toBe(RATE_BYTES_PER_SECOND);
   });
 
   it('should not throw errors for unusual input', () => {

--- a/src/autoQuery/units.test.ts
+++ b/src/autoQuery/units.test.ts
@@ -1,4 +1,12 @@
-import { DEFAULT_RATE_UNIT, DEFAULT_UNIT, getPerSecondRateUnit, getUnit, getUnitFromMetric } from './units';
+import {
+  DEFAULT_RATE_UNIT,
+  DEFAULT_UNIT,
+  getPerSecondRateUnit,
+  getUnit,
+  getUnitFromMetric,
+  UNIT_BYTES,
+  UNIT_SECONDS,
+} from './units';
 
 describe('getUnitFromMetric', () => {
   it('should return null for an empty string input', () => {
@@ -46,11 +54,6 @@ describe('getUnit', () => {
     expect(getUnit('invalidPart')).toBe(DEFAULT_UNIT);
   });
 
-  it('should handle case sensitivity correctly', () => {
-    expect(getUnit('BYTES')).toBe(DEFAULT_UNIT);
-    expect(getUnit('Seconds')).toBe(DEFAULT_UNIT);
-  });
-
   it('should not throw errors for unusual input', () => {
     expect(() => getUnit('123')).not.toThrow();
     expect(() => getUnit('some_random_string')).not.toThrow();
@@ -74,11 +77,6 @@ describe('getPerSecondRateUnit', () => {
 
   it('should return the default rate unit if the metric part is not in RATE_UNIT_MAP', () => {
     expect(getPerSecondRateUnit('invalidPart')).toBe(DEFAULT_RATE_UNIT);
-  });
-
-  it('should handle case sensitivity correctly', () => {
-    expect(getPerSecondRateUnit('BYTES')).toBe(DEFAULT_RATE_UNIT);
-    expect(getPerSecondRateUnit('Seconds')).toBe(DEFAULT_RATE_UNIT);
   });
 
   it('should not throw errors for unusual input', () => {

--- a/src/autoQuery/units.ts
+++ b/src/autoQuery/units.ts
@@ -1,13 +1,27 @@
 export const DEFAULT_UNIT = 'short';
 export const DEFAULT_RATE_UNIT = 'cps'; // Count per second
 
-const UNIT_MAP: Record<string, string> = { bytes: 'bytes', seconds: 's' };
+// Enhanced unit mappings with more common unit types
+const UNIT_MAP: Record<string, string> = {
+  bytes: 'bytes',
+  seconds: 's',
+  milliseconds: 'ms',
+  bits: 'bits',
+  percent: 'percent',
+  count: 'short',
+};
+
 const UNIT_LIST = Object.keys(UNIT_MAP);
+
+// Enhanced rate unit mappings
 const RATE_UNIT_MAP: Record<string, string> = {
   bytes: 'Bps', // bytes per second
+  bits: 'bps', // bits per second
   // seconds per second is unitless
   // this may indicate a count of some resource that is active
   seconds: 'short',
+  count: 'cps', // counts per second
+  percent: 'percent', // percent stays percent even as a rate
 };
 
 // Get unit from metric name (e.g. "go_gc_duration_seconds" -> "seconds")
@@ -16,20 +30,74 @@ export function getUnitFromMetric(metric: string) {
     return null;
   }
 
-  const metricParts = metric.toLowerCase().split('_').slice(-2); // Get last two parts
-  for (let i = metricParts.length - 1; i >= 0; i--) {
-    if (UNIT_LIST.includes(metricParts[i])) {
-      return metricParts[i];
+  const metricLower = metric.toLowerCase();
+
+  // First check for special patterns like CPU metrics
+  if (metricLower.includes('cpu_seconds') || metricLower.includes('cpu_seconds_total')) {
+    return 'seconds';
+  }
+
+  // Check for duration or latency metrics
+  if (metricLower.includes('duration') || metricLower.includes('latency')) {
+    return 'seconds';
+  }
+
+  // Then try the suffix-based approach
+  const metricParts = metricLower.split('_');
+
+  // Check the last two parts first (common pattern)
+  for (let i = metricParts.length - 1; i >= Math.max(0, metricParts.length - 2); i--) {
+    const part = metricParts[i];
+    if (UNIT_LIST.includes(part)) {
+      return part;
     }
   }
+
+  // Check for common units anywhere in the metric name
+  for (const unit of UNIT_LIST) {
+    if (metricLower.includes(unit)) {
+      return unit;
+    }
+  }
+
+  // Check for common patterns
+  if (metricLower.endsWith('_ms') || metricLower.includes('_ms_')) {
+    return 'milliseconds';
+  } else if (metricLower.endsWith('_count') || metricLower.includes('_count_')) {
+    return 'count';
+  } else if (metricLower.includes('percentage') || metricLower.includes('ratio')) {
+    return 'percent';
+  }
+
   return null;
 }
 
 // Get Grafana unit for a panel (e.g. "go_gc_duration_seconds" -> "s")
-export function getUnit(metricPart: string | undefined) {
+export function getUnit(metricName: string | undefined) {
+  if (!metricName) {
+    return DEFAULT_UNIT;
+  }
+
+  const metricPart = getUnitFromMetric(metricName);
   return (metricPart && UNIT_MAP[metricPart]) || DEFAULT_UNIT;
 }
 
-export function getPerSecondRateUnit(metricPart: string | undefined) {
+export function getPerSecondRateUnit(metricName: string | undefined) {
+  if (!metricName) {
+    return DEFAULT_RATE_UNIT;
+  }
+
+  const metricPart = getUnitFromMetric(metricName);
+
+  // Special case for rate metrics
+  const metricLower = metricName.toLowerCase();
+  if ((metricLower.includes('rate') || metricLower.includes('per_second')) && metricPart === 'bytes') {
+    return 'Bps';
+  } else if ((metricLower.includes('rate') || metricLower.includes('per_second')) && metricPart === 'bits') {
+    return 'bps';
+  } else if (metricLower.includes('rate') || metricLower.includes('per_second')) {
+    return 'ops'; // Operations per second as a general fallback for rates
+  }
+
   return (metricPart && RATE_UNIT_MAP[metricPart]) || DEFAULT_RATE_UNIT;
 }

--- a/src/autoQuery/units.ts
+++ b/src/autoQuery/units.ts
@@ -78,7 +78,7 @@ export function getUnit(metricName: string | undefined) {
   }
 
   const metricPart = getUnitFromMetric(metricName);
-  return (metricPart && UNIT_MAP[metricPart]) || DEFAULT_UNIT;
+  return (metricPart && UNIT_MAP[metricPart.toLowerCase()]) || DEFAULT_UNIT;
 }
 
 export function getPerSecondRateUnit(metricName: string | undefined) {

--- a/src/autoQuery/units.ts
+++ b/src/autoQuery/units.ts
@@ -48,11 +48,6 @@ export function getUnitFromMetric(metric: string) {
     return UNIT_SECONDS;
   }
 
-  // Check for duration or latency metrics
-  if (metricLower.includes('duration') || metricLower.includes('latency')) {
-    return UNIT_SECONDS;
-  }
-
   // Then try the suffix-based approach
   const metricParts = metricLower.split('_');
 
@@ -64,19 +59,12 @@ export function getUnitFromMetric(metric: string) {
     }
   }
 
-  // Check for common units anywhere in the metric name
-  for (const unit of UNIT_LIST) {
-    if (metricLower.includes(unit)) {
-      return unit;
-    }
-  }
-
   // Check for common patterns
   if (metricLower.endsWith('_ms') || metricLower.includes('_ms_')) {
     return UNIT_MILLISECONDS;
   } else if (metricLower.endsWith('_count') || metricLower.includes('_count_')) {
     return UNIT_COUNT;
-  } else if (metricLower.includes('percentage') || metricLower.includes('ratio')) {
+  } else if (metricLower.endsWith('_percentage') || metricLower.endsWith('_ratio')) {
     return UNIT_PERCENT;
   }
 

--- a/src/autoQuery/units.ts
+++ b/src/autoQuery/units.ts
@@ -1,25 +1,38 @@
 export const DEFAULT_UNIT = 'short';
 export const DEFAULT_RATE_UNIT = 'cps'; // Count per second
 
+// Unit constants
+export const UNIT_BYTES = 'bytes';
+export const UNIT_SECONDS = 'seconds';
+export const UNIT_MILLISECONDS = 'milliseconds';
+export const UNIT_BITS = 'bits';
+export const UNIT_PERCENT = 'percent';
+export const UNIT_COUNT = 'count';
+
+// Rate unit constants
+export const RATE_BYTES_PER_SECOND = 'Bps';
+export const RATE_BITS_PER_SECOND = 'bps';
+export const RATE_OPS_PER_SECOND = 'ops';
+
 const UNIT_MAP: Record<string, string> = {
-  bytes: 'bytes',
-  seconds: 's',
-  milliseconds: 'ms',
-  bits: 'bits',
-  percent: 'percent',
-  count: 'short',
+  [UNIT_BYTES]: UNIT_BYTES,
+  [UNIT_SECONDS]: 's',
+  [UNIT_MILLISECONDS]: 'ms',
+  [UNIT_BITS]: UNIT_BITS,
+  [UNIT_PERCENT]: UNIT_PERCENT,
+  [UNIT_COUNT]: DEFAULT_UNIT,
 };
 
 const UNIT_LIST = Object.keys(UNIT_MAP);
 
 const RATE_UNIT_MAP: Record<string, string> = {
-  bytes: 'Bps',
-  bits: 'bps',
+  [UNIT_BYTES]: RATE_BYTES_PER_SECOND,
+  [UNIT_BITS]: RATE_BITS_PER_SECOND,
   // seconds per second is unitless
   // this may indicate a count of some resource that is active
-  seconds: 'short',
-  count: 'cps',
-  percent: 'percent',
+  [UNIT_SECONDS]: DEFAULT_UNIT,
+  [UNIT_COUNT]: DEFAULT_RATE_UNIT,
+  [UNIT_PERCENT]: UNIT_PERCENT,
 };
 
 // Get unit from metric name (e.g. "go_gc_duration_seconds" -> "seconds")
@@ -32,12 +45,12 @@ export function getUnitFromMetric(metric: string) {
 
   // First check for special patterns like CPU metrics
   if (metricLower.includes('cpu_seconds') || metricLower.includes('cpu_seconds_total')) {
-    return 'seconds';
+    return UNIT_SECONDS;
   }
 
   // Check for duration or latency metrics
   if (metricLower.includes('duration') || metricLower.includes('latency')) {
-    return 'seconds';
+    return UNIT_SECONDS;
   }
 
   // Then try the suffix-based approach
@@ -60,11 +73,11 @@ export function getUnitFromMetric(metric: string) {
 
   // Check for common patterns
   if (metricLower.endsWith('_ms') || metricLower.includes('_ms_')) {
-    return 'milliseconds';
+    return UNIT_MILLISECONDS;
   } else if (metricLower.endsWith('_count') || metricLower.includes('_count_')) {
-    return 'count';
+    return UNIT_COUNT;
   } else if (metricLower.includes('percentage') || metricLower.includes('ratio')) {
-    return 'percent';
+    return UNIT_PERCENT;
   }
 
   return null;
@@ -89,12 +102,12 @@ export function getPerSecondRateUnit(metricName: string | undefined) {
 
   // Special case for rate metrics
   const metricLower = metricName.toLowerCase();
-  if ((metricLower.includes('rate') || metricLower.includes('per_second')) && metricPart === 'bytes') {
-    return 'Bps';
-  } else if ((metricLower.includes('rate') || metricLower.includes('per_second')) && metricPart === 'bits') {
-    return 'bps';
+  if ((metricLower.includes('rate') || metricLower.includes('per_second')) && metricPart === UNIT_BYTES) {
+    return RATE_BYTES_PER_SECOND;
+  } else if ((metricLower.includes('rate') || metricLower.includes('per_second')) && metricPart === UNIT_BITS) {
+    return RATE_BITS_PER_SECOND;
   } else if (metricLower.includes('rate') || metricLower.includes('per_second')) {
-    return 'ops'; // Operations per second as a general fallback for rates
+    return RATE_OPS_PER_SECOND; // Operations per second as a general fallback for rates
   }
 
   return (metricPart && RATE_UNIT_MAP[metricPart]) || DEFAULT_RATE_UNIT;

--- a/src/autoQuery/units.ts
+++ b/src/autoQuery/units.ts
@@ -4,32 +4,25 @@ export const DEFAULT_RATE_UNIT = 'cps'; // Count per second
 // Unit constants
 export const UNIT_BYTES = 'bytes';
 export const UNIT_SECONDS = 'seconds';
-export const UNIT_MILLISECONDS = 'milliseconds';
-export const UNIT_BITS = 'bits';
 export const UNIT_PERCENT = 'percent';
 export const UNIT_COUNT = 'count';
 
 // Rate unit constants
 export const RATE_BYTES_PER_SECOND = 'Bps';
 export const RATE_BITS_PER_SECOND = 'bps';
-export const RATE_OPS_PER_SECOND = 'ops';
 
 const UNIT_MAP: Record<string, string> = {
   [UNIT_BYTES]: UNIT_BYTES,
   [UNIT_SECONDS]: 's',
-  [UNIT_MILLISECONDS]: 'ms',
-  [UNIT_BITS]: UNIT_BITS,
   [UNIT_PERCENT]: UNIT_PERCENT,
   [UNIT_COUNT]: DEFAULT_UNIT,
 };
 
-const UNIT_LIST = Object.keys(UNIT_MAP);
+const UNIT_LIST = Object.keys(UNIT_MAP); // used to check if a metric name contains any of the supported units
 
 const RATE_UNIT_MAP: Record<string, string> = {
   [UNIT_BYTES]: RATE_BYTES_PER_SECOND,
-  [UNIT_BITS]: RATE_BITS_PER_SECOND,
   // seconds per second is unitless
-  // this may indicate a count of some resource that is active
   [UNIT_SECONDS]: DEFAULT_UNIT,
   [UNIT_COUNT]: DEFAULT_RATE_UNIT,
   [UNIT_PERCENT]: UNIT_PERCENT,
@@ -41,31 +34,13 @@ export function getUnitFromMetric(metric: string) {
     return null;
   }
 
-  const metricLower = metric.toLowerCase();
-
-  // First check for special patterns like CPU metrics
-  if (metricLower.includes('cpu_seconds') || metricLower.includes('cpu_seconds_total')) {
-    return UNIT_SECONDS;
-  }
-
-  // Then try the suffix-based approach
-  const metricParts = metricLower.split('_');
-
-  // Check the last two parts first (common pattern)
+  // Get last two parts of the metric name and check if they are valid units
+  const metricParts = metric.toLowerCase().split('_').slice(-2);
   for (let i = metricParts.length - 1; i >= Math.max(0, metricParts.length - 2); i--) {
     const part = metricParts[i];
     if (UNIT_LIST.includes(part)) {
       return part;
     }
-  }
-
-  // Check for common patterns
-  if (metricLower.endsWith('_ms') || metricLower.includes('_ms_')) {
-    return UNIT_MILLISECONDS;
-  } else if (metricLower.endsWith('_count') || metricLower.includes('_count_')) {
-    return UNIT_COUNT;
-  } else if (metricLower.endsWith('_percentage') || metricLower.endsWith('_ratio')) {
-    return UNIT_PERCENT;
   }
 
   return null;
@@ -87,16 +62,6 @@ export function getPerSecondRateUnit(metricName: string | undefined) {
   }
 
   const metricPart = getUnitFromMetric(metricName);
-
-  // Special case for rate metrics
-  const metricLower = metricName.toLowerCase();
-  if ((metricLower.includes('rate') || metricLower.includes('per_second')) && metricPart === UNIT_BYTES) {
-    return RATE_BYTES_PER_SECOND;
-  } else if ((metricLower.includes('rate') || metricLower.includes('per_second')) && metricPart === UNIT_BITS) {
-    return RATE_BITS_PER_SECOND;
-  } else if (metricLower.includes('rate') || metricLower.includes('per_second')) {
-    return RATE_OPS_PER_SECOND; // Operations per second as a general fallback for rates
-  }
 
   return (metricPart && RATE_UNIT_MAP[metricPart]) || DEFAULT_RATE_UNIT;
 }

--- a/src/autoQuery/units.ts
+++ b/src/autoQuery/units.ts
@@ -1,7 +1,6 @@
 export const DEFAULT_UNIT = 'short';
 export const DEFAULT_RATE_UNIT = 'cps'; // Count per second
 
-// Enhanced unit mappings with more common unit types
 const UNIT_MAP: Record<string, string> = {
   bytes: 'bytes',
   seconds: 's',
@@ -13,15 +12,14 @@ const UNIT_MAP: Record<string, string> = {
 
 const UNIT_LIST = Object.keys(UNIT_MAP);
 
-// Enhanced rate unit mappings
 const RATE_UNIT_MAP: Record<string, string> = {
-  bytes: 'Bps', // bytes per second
-  bits: 'bps', // bits per second
+  bytes: 'Bps',
+  bits: 'bps',
   // seconds per second is unitless
   // this may indicate a count of some resource that is active
   seconds: 'short',
-  count: 'cps', // counts per second
-  percent: 'percent', // percent stays percent even as a rate
+  count: 'cps',
+  percent: 'percent',
 };
 
 // Get unit from metric name (e.g. "go_gc_duration_seconds" -> "seconds")


### PR DESCRIPTION
## description
fixes https://github.com/grafana/metrics-drilldown/issues/192
(and actually passes the unit tests this time - run `npm run test:ci` to check!)

the y-axis of the panels now displays units like 's' for seconds-based metrics, 'bytes' for byte-based metrics, etc. Grafana automatically formats these units appropriately (e.g., converting bytes to KB, MB, GB as needed).

changes in `MetricVizPanel.tsx`:
- [x] call `getUnit` and `setUnit` 

changes in `units.ts`:
- [x] use constants instead of strings for units
- [x] add percent unit type to `UNIT_MAP` and `RATE_UNIT_MAP`
- [x] refactor `getUnitFromMetric` to only check the last and second to last part of the metric name for a valid unit (suffix matching method)
- [x] update `getUnit` and `getPerSecondRateUnit` to work with the metric name directly instead of requiring a pre-processed part

### demo
#### before changes

https://github.com/user-attachments/assets/0f54d6d4-d8e1-4bbc-827a-099ed8ce1224


#### after changes

https://github.com/user-attachments/assets/b999b7f3-3786-4398-bb0c-0d5b0c997b6c
