### PR TITLE
Bohandley/fix timerange bug

### DIFF
--- a/src/WingmanDataTrail/GroupBy/MetricsWithLabelValue/MetricsWithLabelValueDataSource.ts
+++ b/src/WingmanDataTrail/GroupBy/MetricsWithLabelValue/MetricsWithLabelValueDataSource.ts
@@ -52,7 +52,14 @@ export class MetricsWithLabelValueDataSource extends RuntimeDataSource {
       return [];
     }
 
-    const metricsList = await ds.languageProvider.fetchSeriesValuesWithMatch('__name__', matcher);
+    const timeRange = sceneGraph.getTimeRange(sceneObject).state.value;
+    let metricsList: string[] = [];
+    if (ds.languageProvider.fetchLabelValues.length === 2) {
+      // @ts-ignore: Ignoring type error due to breaking change in fetchLabelValues signature
+      metricsList = await ds.languageProvider.fetchSeriesValuesWithMatch(timeRange, '__name__', matcher);
+    } else {
+      metricsList = await ds.languageProvider.fetchSeriesValuesWithMatch('__name__', matcher);
+    }
 
     return metricsList.map((metricName) => ({ value: metricName, text: metricName }));
   }

--- a/src/WingmanDataTrail/Labels/LabelsDataSource.ts
+++ b/src/WingmanDataTrail/Labels/LabelsDataSource.ts
@@ -123,14 +123,19 @@ export class LabelsDataSource extends RuntimeDataSource {
     }
 
     const filterExpression = sceneGraph.interpolate(sceneObject, VAR_FILTERS_EXPR, {});
-
-    const response = await ds.languageProvider.fetchLabelValues(
-      labelName,
-      // `{__name__=~".+",$${VAR_FILTERS}}` // FIXME: the filters var is not interpolated, why?!
-      `{__name__=~".+",${filterExpression}}`
-    );
-
-    return response;
+    const timeRange = sceneGraph.getTimeRange(sceneObject).state.value;
+    // new signature for fetchLabelValues includes time range
+    // handle old signature for backwards compatibility
+    if (ds.languageProvider.fetchLabelValues.length === 2) {
+      return await ds.languageProvider.fetchLabelValues(
+        timeRange,
+        labelName,
+        // `{__name__=~".+",$${VAR_FILTERS}}` // FIXME: the filters var is not interpolated, why?!
+        `{__name__=~".+",${filterExpression}}`
+      );
+    } else {
+      return await ds.languageProvider.fetchLabelValues(labelName, `{__name__=~".+",${filterExpression}}`);
+    }
   }
 
   static async fetchLabelCardinality(labelName: string, limit: number, sceneObject: SceneObject): Promise<number> {


### PR DESCRIPTION
**What was the bug?**

The signature for Prometheus data source resource calls had a breaking change. Now `timeRange` is required for each call. 

**What are we doing?**

Check the signature for the function parameters and pass in time range or do not.