### PR TITLE
chore: upgrade grafana to 11.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,15 @@ Begin by starting the Grafana server in a separate terminal:
 npm run server
 ```
 
+This will start the Grafana server on port 3000. If you'd like to use a different port, follow the instructions in the [Configuration](#configuration) section below.
+
 Then, run the plugin in watch mode:
 
 ```bash
 npm run dev
 ```
+
+You can now visit `http://localhost:3000/a/grafana-metricsdrilldown-app` to use the local version of the Grafana Metrics Drilldown app.
 
 #### Running tests
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,13 +7,12 @@ services:
     container_name: 'grafana'
     environment:
       GF_SERVER_ROOT_URL: 'http://localhost:${GRAFANA_PORT:-3000}'
-      GF_FEATURE_TOGGLES_ENABLE: 'exploreMetricsRelatedLogs'
+      GF_FEATURE_TOGGLES_ENABLE: exploreMetricsUseExternalAppPlugin,exploreMetricsRelatedLogs
     extra_hosts:
       # This allows us to connect to other services running on the host machine.
       - 'host.docker.internal:host-gateway'
 
   prometheus:
-    container_name: 'prometheus'
     image: prom/prometheus:v3.2.1
     ports:
       - '9099:9090'


### PR DESCRIPTION
## What does this PR do?

A few of things:
1. Upgrade to Grafana 11.6 (released yesterday) and enable the `exploreMetricsUseExternalAppPlugin` feature toggle. This allows Grafana Metrics Drilldown app to move from **More apps** to **Drilldown** > **Metrics** where it belongs.
2. Removes the `container_name` for our Prometheus container. This avoids container name collisions with other services you might be running locally.
3. Updates the local dev docs to more pointedly describe how to see the local app.

## How to test

After checking out the `chore/upgrade-grafana` branch and running `npm run server` to rebuild our containers, observe that **More apps** no longer contains our app, and **Drilldown** > **Metrics** routes to `/a/grafana-metricsdrilldown-app`, like so:

<img width="819" alt="demo gmd in sidebar" src="https://github.com/user-attachments/assets/475ab37f-ab72-44c6-8dfb-a7b1e897517f" />