### PR TITLE
test(E2E): Single E2E compose for Grafana, Prometheus and Playwright

### DIFF
--- a/e2e/docker/docker-compose.playwright.e2e.yaml
+++ b/e2e/docker/docker-compose.playwright.e2e.yaml
@@ -1,5 +1,21 @@
-name: 'metrics-drilldown-e2e'
+# include:
+#   - ./docker-compose.e2e.yaml
+name: 'metrics-drilldown-playwright-e2e'
 services:
+  playwright:
+    network_mode: host
+    container_name: playwright
+    build:
+      dockerfile: ./docker/Dockerfile.plugin
+      context: ..
+    volumes:
+      - ../../e2e:/app/e2e
+      - ../../src:/app/src
+    depends_on:
+      - grafana
+    healthcheck:
+      test: ./wait-for-grafana.sh http://localhost:${GRAFANA_PORT:-3001}/ 200 60 3
+
   grafana:
     extends:
       file: ../../.config/docker-compose-base.yaml

--- a/e2e/docker/wait-for-grafana.sh
+++ b/e2e/docker/wait-for-grafana.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+url="$1"
+expected_response_code="$2"
+timeout="$3"
+interval="$4"
+
+echo "Checking URL: $url"
+echo "Expected response code: $expected_response_code"
+echo "Timeout: $timeout seconds"
+echo "Interval: $interval seconds"
+
+end_time=$((SECONDS + timeout))
+
+while [ $SECONDS -lt $end_time ]; do
+  response=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+
+  if [ "$response" -eq "$expected_response_code" ]; then
+    echo "Server is up and responding with status code $expected_response_code"
+    exit 0
+  fi
+
+  echo "Waiting for server to respond with status code $expected_response_code. Current status: $response"
+  sleep "$interval"
+done
+
+echo "Timeout reached. Server did not respond with status code $expected_response_code within $timeout seconds"
+exit 1

--- a/package.json
+++ b/package.json
@@ -24,10 +24,7 @@
     "e2e:local": "playwright test -c ./e2e/config/playwright.config.local.ts",
     "e2e:local:watch": "npm run e2e:local -- --ui",
     "e2e:local:codegen": "playwright codegen",
-    "e2e:ci:prepare": "docker build --progress=auto -t metrics-drilldown-plugin-e2e:latest -f e2e/docker/Dockerfile.plugin .",
-    "e2e:ci:server:up": "docker compose -f e2e/docker/docker-compose.e2e.yaml up --build -d",
-    "e2e:ci:server:down": "docker compose down",
-    "e2e:ci": " docker run --network host -v $(pwd)/e2e:/app/e2e -v $(pwd)/src:/app/src metrics-drilldown-plugin-e2e:latest"
+    "e2e:ci": "docker compose -f e2e/docker/docker-compose.playwright.e2e.yaml up --attach playwright"
   },
   "author": "Grafana",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR relates to https://github.com/grafana/metrics-drilldown/pull/171

and aims at providing a single docker compose file, to support https://github.com/grafana/plugin-ci-workflows/pull/57