### PR TITLE
ci: add option to skip dev image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      skip-grafana-dev-image:
+        required: false
+        type: boolean
+        default: false
   pull_request:
     branches:
       - main
@@ -15,3 +20,4 @@ jobs:
     uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
     with:
       upload-playwright-artifacts: true # IMPORTANT: we must ensure there are no unmasked secrets in the E2E tests
+      run-playwright-with-skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image || false }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,10 @@ on:
           - dev
           - ops
           - prod
+      skip-grafana-dev-image:
+        required: false
+        type: boolean
+        default: false
   push:
     tags:
       - 'v*' # Run workflow on version tags, e.g. v1.0.0.
@@ -48,3 +52,4 @@ jobs:
       environment: ${{ inputs.environment || 'prod' }}
       upload-playwright-artifacts: true # IMPORTANT: we must ensure there are no unmasked secrets in the E2E tests
       attestation: true # this guarantees that the plugin was built from the source code provided in the release
+      run-playwright-with-skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image || false }}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const GIT_COMMIT = 'dev';
+export const GIT_COMMIT = '4683aee56da080c8dd83912f8e99874ed1788b7c';


### PR DESCRIPTION
### ✨ Description

This PR intends to overcome some flakiness with the current `grafana-dev@12` image.

### 📖 Summary of the changes

For a couple of workflows (that build GCS artifacts and publish to the Grafana plugins catalog), add a Workflow Dispatch [option](https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows) to skip running e2e tests with the dev image.

### 🧪 How to test?

We'll need to merge this to test.
