### PR TITLE
feat: default to onboard filters sidebar

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -44,11 +44,19 @@
   "includes": [
     {
       "type": "page",
-      "name": "Grafana Metrics Drilldown",
-      "path": "/a/%PLUGIN_ID%/",
+      "name": "Metric Select",
+      "path": "/a/%PLUGIN_ID%/onboard-filters-sidebar",
       "action": "datasources:explore",
       "addToNav": true,
       "defaultNav": true
+    },
+    {
+      "type": "page",
+      "name": "Home",
+      "path": "/a/%PLUGIN_ID%/",
+      "action": "datasources:explore",
+      "addToNav": true,
+      "defaultNav": false
     }
   ],
   "dependencies": {


### PR DESCRIPTION
### ✨ Description

This PR aims to make one of the three UX experiments from #131 the default experience. This version of the app will be used in a staging environment for the purposes of collecting feedback.

### 📖 Summary of the changes

The plugin config has been updated to make the `/onboard-filters-sidebar` route the default experience when clicking **Drilldown** > **Metrics**.

As an escape hatch, we offer users the ability to go to the **Home** page, where they can get to the original `/trails` experience if desired.

### Demo

https://github.com/user-attachments/assets/5b331490-b564-47c3-864f-ee56ef3e90e2
