### PR TITLE
feat: Instrument the plugin with Faro

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@bsull/augurs": "^0.9.0",
         "@emotion/css": "11.10.6",
         "@grafana/data": "^11.6.0",
+        "@grafana/faro-web-sdk": "^1.14.1",
         "@grafana/lezer-logql": "^0.2.7",
         "@grafana/prometheus": "^11.6.0-223871",
         "@grafana/promql-builder": "^0.0.4",
@@ -1331,9 +1332,9 @@
       }
     },
     "node_modules/@grafana/faro-core": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.13.3.tgz",
-      "integrity": "sha512-EC94lAKV5mG01WImV08uFjds8mqZjQCEqE2kLS90i5Ke32RaXD5iaNZjNNdz4/2lTHwbtXDixLIllXuB+lXiuA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.14.1.tgz",
+      "integrity": "sha512-wPQEJ3Ow4s5m+scrHUHAbwCTMoXlXgwdjtO5PCKCimaI5q4nzFHp5D2FpFGDul2WfRVzwWvkhX6A7CGTui/myw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -1344,12 +1345,12 @@
       }
     },
     "node_modules/@grafana/faro-web-sdk": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.13.3.tgz",
-      "integrity": "sha512-iK4Snwcxo+5Mw1TF8zgBARyDCHiIzlHbIKGr8S3M3Stm5mqjhmZTaLOAMiDs2A+qe0mhG3wC0rTCrD5iwAOa1A==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.14.1.tgz",
+      "integrity": "sha512-Ii1xdpYysBfHO7XbK05uCXGwskDzLH7CYSdXU2gC8loRDR5PiqPzEczzVFeNhzGRcQzcecYWMxOzeucXdhNilw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/faro-core": "^1.13.3",
+        "@grafana/faro-core": "^1.14.1",
         "ua-parser-js": "^1.0.32",
         "web-vitals": "^4.0.1"
       },
@@ -3787,9 +3788,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.1.tgz",
-      "integrity": "sha512-I4PHczeujhQAQv6ZBzqHYEUiggZL4IdSMixtVD3EYqbdrjujE7kRfI5QohjlPoJm8BvenoW5YaTMWRrbpot6tg==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -3814,15 +3815,15 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.1.tgz",
-      "integrity": "sha512-EX67y+ukNNfFrOLyjYGw8AMy0JPIlEX1dW60SGUNZWW2hSQyyolX7EqFuHP5LtXLjJHNfzx5SMBVQ3owaQCNDw==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.2.tgz",
+      "integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.1",
+        "@opentelemetry/api-logs": "0.57.2",
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
-        "@opentelemetry/sdk-logs": "0.57.1",
+        "@opentelemetry/sdk-logs": "0.57.2",
         "@opentelemetry/sdk-metrics": "1.30.1",
         "@opentelemetry/sdk-trace-base": "1.30.1",
         "protobufjs": "^7.3.0"
@@ -3851,12 +3852,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.1.tgz",
-      "integrity": "sha512-jGdObb/BGWu6Peo3cL3skx/Rl1Ak/wDDO3vpPrrThGbqE7isvkCsX6uE+OAt8Ayjm9YC8UGkohWbLR09JmM0FA==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
+      "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.1",
+        "@opentelemetry/api-logs": "0.57.2",
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1"
       },
@@ -12088,9 +12089,9 @@
       "dev": true
     },
     "node_modules/long": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.0.tgz",
-      "integrity": "sha512-5vvY5yF1zF/kXk+L94FRiTDa1Znom46UjPCH6/XbSvS8zBKMFBHTJk8KDMqJ+2J6QezQFi7k1k8v21ClJYHPaw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
+      "integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==",
       "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@bsull/augurs": "^0.9.0",
     "@emotion/css": "11.10.6",
     "@grafana/data": "^11.6.0",
+    "@grafana/faro-web-sdk": "^1.14.1",
     "@grafana/lezer-logql": "^0.2.7",
     "@grafana/prometheus": "^11.6.0-223871",
     "@grafana/promql-builder": "^0.0.4",

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -5,10 +5,13 @@ import { useStyles2 } from '@grafana/ui';
 import React, { createContext, useState } from 'react';
 
 import { type DataTrail } from 'DataTrail';
+import { initFaro } from 'tracking/faro/faro';
 import { getUrlForTrail, newMetricsTrail } from 'utils';
 
 import { AppRoutes } from './Routes';
 import { PluginPropsContext } from '../utils/utils.plugin';
+
+initFaro();
 
 interface MetricsAppContext {
   trail: DataTrail;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 import pluginJson from './plugin.json';
 
+export const PLUGIN_ID = pluginJson.id;
 export const PLUGIN_BASE_URL = `/a/${pluginJson.id}`;
 
 // we have to duplicate this definition from 'WingmanOnboarding/VariantVariable' here

--- a/src/tracking/__tests__/getEnvironment.spec.ts
+++ b/src/tracking/__tests__/getEnvironment.spec.ts
@@ -1,0 +1,27 @@
+import { getEnvironment } from '../getEnvironment';
+
+describe('getEnvironment()', () => {
+  test.each([
+    // edge cases
+    [undefined, null],
+    ['unknownhost', null],
+    // local
+    ['localhost', 'local'],
+    // dev
+    ['grafana-dev.net', 'dev'],
+    ['test.grafana-dev.net', 'dev'],
+    // ops
+    ['foobar.grafana-ops.net', 'ops'],
+    ['grafana-ops.net', 'ops'],
+    // prod
+    ['foobar.grafana.net', 'prod'],
+    ['grafana.net', 'prod'],
+  ])('when the host is "%s" → %s', (host, expectedEnvironment) => {
+    Object.defineProperty(window, 'location', {
+      value: { host },
+      writable: true,
+    });
+
+    expect(getEnvironment()).toBe(expectedEnvironment);
+  });
+});

--- a/src/tracking/faro/__tests__/faro.spec.ts
+++ b/src/tracking/faro/__tests__/faro.spec.ts
@@ -125,7 +125,6 @@ describe('initFaro()', () => {
         release: 'v1-test',
         version: GIT_COMMIT,
         environment: 'prod',
-        namespace: 'v11.6.0 (Enterprise)',
       });
 
       expect(user).toStrictEqual({ email: 'sixty.four@grafana.com' });

--- a/src/tracking/faro/__tests__/faro.spec.ts
+++ b/src/tracking/faro/__tests__/faro.spec.ts
@@ -1,0 +1,154 @@
+import { getWebInstrumentations, initializeFaro } from '@grafana/faro-web-sdk';
+
+import { PLUGIN_ID } from '../../../constants';
+import { GIT_COMMIT } from '../../../version';
+import { initFaro, setFaro } from '../faro';
+
+// Faro dependencies
+jest.mock('@grafana/faro-web-sdk');
+
+// Grafana dependency
+jest.mock('@grafana/runtime', () => ({
+  config: {
+    apps: {
+      [PLUGIN_ID]: {
+        version: 'v1-test',
+      },
+    },
+    bootData: {
+      user: {
+        email: 'sixty.four@grafana.com',
+      },
+    },
+    buildInfo: {
+      version: '11.6.0',
+      edition: 'Enterprise',
+    },
+  },
+}));
+
+function setup(location: Partial<Location>) {
+  (initializeFaro as jest.Mock).mockReturnValue({});
+  (getWebInstrumentations as jest.Mock).mockReturnValue([{}]);
+
+  Object.defineProperty(window, 'location', {
+    value: location,
+    writable: true,
+  });
+
+  return {
+    initializeFaro: initializeFaro as jest.Mock,
+  };
+}
+
+describe('initFaro()', () => {
+  afterEach(() => {
+    setFaro(null);
+
+    jest.clearAllMocks();
+  });
+
+  describe('when running in environment where the host not defined', () => {
+    test('does not initialize Faro', () => {
+      const { initializeFaro } = setup({ host: undefined });
+
+      initFaro();
+
+      expect(initializeFaro).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when running in an unknown environment', () => {
+    test('does not initialize Faro', () => {
+      const { initializeFaro } = setup({ host: 'unknownhost' });
+
+      initFaro();
+
+      expect(initializeFaro).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when running in an known environment', () => {
+    test.each([
+      // dev
+      [
+        'grafana-dev.net',
+        'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/8c57b32175ba39d35dfaccee7cd793c7',
+        'grafana-metricsdrilldown-app-dev',
+      ],
+      [
+        'test.grafana-dev.net',
+        'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/8c57b32175ba39d35dfaccee7cd793c7',
+        'grafana-metricsdrilldown-app-dev',
+      ],
+      // ops
+      [
+        'foobar.grafana-ops.net',
+        'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/d65ab91eb9c5e8c51b474d9313ba28f4',
+        'grafana-metricsdrilldown-app-ops',
+      ],
+      [
+        'grafana-ops.net',
+        'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/d65ab91eb9c5e8c51b474d9313ba28f4',
+        'grafana-metricsdrilldown-app-ops',
+      ],
+      // prod
+      [
+        'foobar.grafana.net',
+        'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/0f4f1bbc97c9e2db4fa85ef75a559885',
+        'grafana-metricsdrilldown-app-prod',
+      ],
+      [
+        'grafana.net',
+        'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/0f4f1bbc97c9e2db4fa85ef75a559885',
+        'grafana-metricsdrilldown-app-prod',
+      ],
+    ])('initializes Faro for the host "%s"', (host, faroUrl, appName) => {
+      const { initializeFaro } = setup({ host });
+
+      initFaro();
+
+      expect(initializeFaro).toHaveBeenCalledTimes(1);
+      expect(initializeFaro.mock.lastCall[0].url).toBe(faroUrl);
+      expect(initializeFaro.mock.lastCall[0].app.name).toBe(appName);
+    });
+
+    test('initializes Faro with the proper configuration', () => {
+      const { initializeFaro } = setup({ host: 'grafana.net' });
+
+      initFaro();
+
+      const { app, user, instrumentations, isolate, beforeSend } = initializeFaro.mock.lastCall[0];
+
+      expect(app).toStrictEqual({
+        name: 'grafana-metricsdrilldown-app-prod',
+        release: 'v1-test',
+        version: GIT_COMMIT,
+        environment: 'prod',
+        namespace: 'v11.6.0 (Enterprise)',
+      });
+
+      expect(user).toStrictEqual({ email: 'sixty.four@grafana.com' });
+
+      expect(getWebInstrumentations).toHaveBeenCalledWith({
+        captureConsole: false,
+      });
+      expect(instrumentations).toBeInstanceOf(Array);
+      expect(instrumentations.length).toBe(1);
+
+      expect(isolate).toBe(true);
+      expect(beforeSend).toBeInstanceOf(Function);
+    });
+  });
+
+  describe('when called several times', () => {
+    test('initializes Faro only once', () => {
+      const { initializeFaro } = setup({ host: 'grafana.net' });
+
+      initFaro();
+      initFaro();
+
+      expect(initializeFaro).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/tracking/faro/faro-environments.ts
+++ b/src/tracking/faro/faro-environments.ts
@@ -3,14 +3,14 @@ import { type FaroEnvironment } from './getFaroEnvironment';
 
 export const FARO_ENVIRONMENTS = new Map<Environment, FaroEnvironment>([
   // Uncomment this map entry to test from your local machine
-  [
-    'local',
-    {
-      environment: 'local',
-      appName: 'grafana-metricsdrilldown-app-local',
-      faroUrl: 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/b854cd2319527968f415fd44ea01fe8a',
-    },
-  ],
+  // [
+  //   'local',
+  //   {
+  //     environment: 'local',
+  //     appName: 'grafana-metricsdrilldown-app-local',
+  //     faroUrl: 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/b854cd2319527968f415fd44ea01fe8a',
+  //   },
+  // ],
   // Always keep the options below
   [
     'dev',

--- a/src/tracking/faro/faro-environments.ts
+++ b/src/tracking/faro/faro-environments.ts
@@ -1,0 +1,39 @@
+import { type Environment } from '../getEnvironment';
+import { type FaroEnvironment } from './getFaroEnvironment';
+
+export const FARO_ENVIRONMENTS = new Map<Environment, FaroEnvironment>([
+  // Uncomment this map entry to test from your local machine
+  [
+    'local',
+    {
+      environment: 'local',
+      appName: 'grafana-metricsdrilldown-app-local',
+      faroUrl: 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/b854cd2319527968f415fd44ea01fe8a',
+    },
+  ],
+  // Always keep the options below
+  [
+    'dev',
+    {
+      environment: 'dev',
+      appName: 'grafana-metricsdrilldown-app-dev',
+      faroUrl: 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/8c57b32175ba39d35dfaccee7cd793c7',
+    },
+  ],
+  [
+    'ops',
+    {
+      environment: 'ops',
+      appName: 'grafana-metricsdrilldown-app-ops',
+      faroUrl: 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/d65ab91eb9c5e8c51b474d9313ba28f4',
+    },
+  ],
+  [
+    'prod',
+    {
+      environment: 'prod',
+      appName: 'grafana-metricsdrilldown-app-prod',
+      faroUrl: 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/0f4f1bbc97c9e2db4fa85ef75a559885',
+    },
+  ],
+]);

--- a/src/tracking/faro/faro.ts
+++ b/src/tracking/faro/faro.ts
@@ -1,0 +1,55 @@
+import { getWebInstrumentations, initializeFaro, type Faro } from '@grafana/faro-web-sdk';
+import { config } from '@grafana/runtime';
+
+import { getFaroEnvironment } from './getFaroEnvironment';
+import { PLUGIN_BASE_URL, PLUGIN_ID } from '../../constants';
+import { GIT_COMMIT } from '../../version';
+
+let faro: Faro | null = null;
+
+export const getFaro = () => faro;
+export const setFaro = (instance: Faro | null) => (faro = instance);
+
+export function initFaro() {
+  if (getFaro()) {
+    return;
+  }
+
+  const faroEnvironment = getFaroEnvironment();
+  if (!faroEnvironment) {
+    return;
+  }
+
+  const { environment, faroUrl, appName } = faroEnvironment;
+  const { apps, bootData } = config;
+  const appRelease = apps[PLUGIN_ID].version;
+  const userEmail = bootData.user.email;
+
+  setFaro(
+    initializeFaro({
+      url: faroUrl,
+      app: {
+        name: appName,
+        release: appRelease,
+        version: GIT_COMMIT,
+        environment,
+      },
+      user: {
+        email: userEmail,
+      },
+      instrumentations: [
+        ...getWebInstrumentations({
+          captureConsole: false,
+        }),
+      ],
+      isolate: true,
+      beforeSend: (event) => {
+        if ((event.meta.page?.url ?? '').includes(PLUGIN_BASE_URL)) {
+          return event;
+        }
+
+        return null;
+      },
+    })
+  );
+}

--- a/src/tracking/faro/getFaroEnvironment.ts
+++ b/src/tracking/faro/getFaroEnvironment.ts
@@ -1,0 +1,14 @@
+import { getEnvironment, type Environment } from '../getEnvironment';
+import { FARO_ENVIRONMENTS } from './faro-environments';
+
+export type FaroEnvironment = { environment: Environment; appName: string; faroUrl: string };
+
+export function getFaroEnvironment() {
+  const environment = getEnvironment();
+
+  if (!environment || !FARO_ENVIRONMENTS.has(environment)) {
+    return;
+  }
+
+  return FARO_ENVIRONMENTS.get(environment) as FaroEnvironment;
+}

--- a/src/tracking/getEnvironment.ts
+++ b/src/tracking/getEnvironment.ts
@@ -1,0 +1,30 @@
+export type Environment = 'local' | 'dev' | 'ops' | 'prod';
+
+const MATCHERS: Array<{ regExp: RegExp; environment: Environment }> = [
+  {
+    regExp: /localhost/,
+    environment: 'local',
+  },
+  {
+    regExp: /grafana-dev\.net/,
+    environment: 'dev',
+  },
+  {
+    regExp: /grafana-ops\.net/,
+    environment: 'ops',
+  },
+  {
+    regExp: /grafana\.net/,
+    environment: 'prod',
+  },
+];
+
+export function getEnvironment(): Environment | null {
+  if (!window?.location?.host) {
+    return null;
+  }
+
+  const found = MATCHERS.find(({ regExp }) => regExp.test(window.location.host));
+
+  return found ? found.environment : null;
+}


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** resolves https://github.com/grafana/metrics-drilldown/issues/226

This PR adds [Faro instrumentation](https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/).

### 📖 Summary of the changes

4 different frontend applications have been created in ops:
- **local:** for local tests
- **dev:** for capturing data from `grafana-dev.net`
- **ops:** for capturing data from `grafana-ops.net`
- **prod:** for capturing data from `grafana.net`

When the app is started, Faro is initialized with useful metadata (app name, release, git commit, environment, user email). 
During a user session, the browser's URL host is used to determine to which collector the tracking data should be sent. 

Some unit tests have been provided to prevent changes in the collector's URLs .

### 🧪 How to test?

- Locally by uncommenting the local environment config in `src/tracking/faro/faro-environments.ts` and visiting the app.
- Once deployed to dev/ops/prod, we should see data in our frontend observability applications