### PR TITLE
feat(*): Add error boundary + logger

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,13 +1,14 @@
 import { css } from '@emotion/css';
 import { type AppRootProps, type GrafanaTheme2 } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
-import { useStyles2 } from '@grafana/ui';
+import { ErrorBoundary, useStyles2 } from '@grafana/ui';
 import React, { createContext, useState } from 'react';
 
 import { type DataTrail } from 'DataTrail';
 import { initFaro } from 'tracking/faro/faro';
 import { getUrlForTrail, newMetricsTrail } from 'utils';
 
+import { ErrorView } from './ErrorView';
 import { AppRoutes } from './Routes';
 import { PluginPropsContext } from '../utils/utils.plugin';
 
@@ -31,13 +32,26 @@ function App(props: AppRootProps) {
     setTrail(trail);
   };
 
+  const [error, setError] = useState<Error>();
+  if (error) {
+    return (
+      <div className={styles.appContainer} data-testid="metrics-drilldown-app">
+        <ErrorView error={error} />
+      </div>
+    );
+  }
+
   return (
     <div className={styles.appContainer} data-testid="metrics-drilldown-app">
-      <PluginPropsContext.Provider value={props}>
-        <MetricsContext.Provider value={{ trail, goToUrlForTrail }}>
-          <AppRoutes />
-        </MetricsContext.Provider>
-      </PluginPropsContext.Provider>
+      <ErrorBoundary onError={setError}>
+        {() => (
+          <PluginPropsContext.Provider value={props}>
+            <MetricsContext.Provider value={{ trail, goToUrlForTrail }}>
+              <AppRoutes />
+            </MetricsContext.Provider>
+          </PluginPropsContext.Provider>
+        )}
+      </ErrorBoundary>
     </div>
   );
 }

--- a/src/App/ErrorView.tsx
+++ b/src/App/ErrorView.tsx
@@ -1,0 +1,30 @@
+import { css } from '@emotion/css';
+import { type GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+import React from 'react';
+
+import { InlineBanner } from './InlineBanner';
+
+export function ErrorView({ error }: { error: Error }) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.container}>
+      <InlineBanner
+        severity="error"
+        title="Fatal error!"
+        message="Please try reloading the page or, if the problem persists, contact your organization admin. Sorry for the inconvenience."
+        error={error}
+        errorContext={{ handheldBy: 'React error boundary' }}
+      />
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    container: css({
+      margin: theme.spacing(2),
+    }),
+  };
+}

--- a/src/App/InlineBanner.tsx
+++ b/src/App/InlineBanner.tsx
@@ -1,0 +1,30 @@
+import { Alert, type AlertVariant } from '@grafana/ui';
+import React from 'react';
+
+import { logger, type ErrorContext } from '../tracking/logger/logger';
+
+type InlineBannerProps = {
+  severity: AlertVariant;
+  title: string;
+  message?: string | React.ReactNode;
+  error?: Error;
+  errorContext?: ErrorContext;
+};
+
+export function InlineBanner({ severity, title, message, error, errorContext }: InlineBannerProps) {
+  if (error) {
+    logger.error(error, errorContext);
+  }
+
+  return (
+    <Alert title={title} severity={severity}>
+      {error && (
+        <>
+          {error.message}
+          <br />
+        </>
+      )}
+      {message}
+    </Alert>
+  );
+}

--- a/src/tracking/logger/logger.ts
+++ b/src/tracking/logger/logger.ts
@@ -1,0 +1,88 @@
+import { LogLevel } from '@grafana/faro-web-sdk';
+
+import { getFaro } from '../faro/faro';
+import { getEnvironment, type Environment } from '../getEnvironment';
+
+export type ErrorContext = Record<string, string>;
+
+/**
+ * Logger class that handles logging to both console and Grafana Faro.
+ *
+ * This class provides a unified logging interface that:
+ * - Logs to console in non-production environments
+ * - Sends logs to Faro for remote monitoring and error tracking
+ * - Supports different log levels (trace, debug, info, log, warn, error)
+ * - Handles error contexts for better error tracking
+ *
+ * Used throughout the application for consistent logging and error reporting.
+ */
+
+export class Logger {
+  #environment: Environment | null;
+
+  constructor() {
+    this.#environment = getEnvironment();
+  }
+
+  #callConsole(methodName: 'trace' | 'debug' | 'info' | 'log' | 'warn' | 'error', args: any[]) {
+    // silence console in production
+    if (this.#environment !== 'prod') {
+      console[methodName](...args); // eslint-disable-line no-console
+    }
+  }
+
+  trace() {
+    this.#callConsole('trace', []);
+
+    getFaro()?.api.pushLog([], {
+      level: LogLevel.TRACE,
+    });
+  }
+
+  debug(...args: any) {
+    this.#callConsole('debug', args);
+
+    getFaro()?.api.pushLog(args, {
+      level: LogLevel.DEBUG,
+    });
+  }
+
+  info(...args: any) {
+    this.#callConsole('info', args);
+
+    getFaro()?.api.pushLog(args, {
+      level: LogLevel.INFO,
+    });
+  }
+
+  log(...args: any) {
+    this.#callConsole('log', args);
+
+    getFaro()?.api.pushLog(args, {
+      level: LogLevel.LOG,
+    });
+  }
+
+  warn(...args: any) {
+    this.#callConsole('warn', args);
+
+    getFaro()?.api.pushLog(args, {
+      level: LogLevel.WARN,
+    });
+  }
+
+  error(error: Error, context?: ErrorContext) {
+    this.#callConsole('error', [error]);
+
+    if (context) {
+      this.#callConsole('error', ['Error context', context]);
+    }
+
+    // does not report an error, but an exception ;)
+    getFaro()?.api.pushError(error, {
+      context,
+    });
+  }
+}
+
+export const logger = new Logger();


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** resolves https://github.com/grafana/metrics-drilldown/issues/195

This PR adds an error boundary to the app:
- to capture any runtime exception or unhandled promise rejection,
- to present a human-friendly message to the user

![image](https://github.com/user-attachments/assets/cd86fde5-8071-43cb-bf32-c15f2b4ca758)

This PR also introduces a `Logger` class for consistent logging and error reporting.

### 📖 Summary of the changes

The changes are pretty straightforward, see the diff tab.

### 🧪 How to test?

- Manually, by enabling [Faro in local](https://github.com/grafana/metrics-drilldown/blob/staging/src/tracking/faro/faro-environments.ts#L5-L13) and adding a statement in the code to throw an error: an error inline banner should be displayed and the error should appear in our FE O11Y app in ops
