### PR TITLE
test(E2E): Add more WingMan tests

### DIFF
--- a/e2e/fixtures/css/hide-app-controls.css
+++ b/e2e/fixtures/css/hide-app-controls.css
@@ -1,0 +1,7 @@
+.main-view > header {
+  display: none;
+}
+
+[data-testid='app-controls'] {
+  display: none;
+}

--- a/e2e/fixtures/views/MetricsReducerView.ts
+++ b/e2e/fixtures/views/MetricsReducerView.ts
@@ -19,6 +19,50 @@ export class MetricsReducerView extends DrilldownView {
     return this.getByTestId('header-controls');
   }
 
+  async assertHeaderControls(variant: 'filters' | 'pills' | 'labels') {
+    const headerControls = this.getHeaderControls();
+
+    if (variant === 'filters') {
+      // pills should not be visible
+      await expect(headerControls.getByRole('button', { name: 'Metric prefixes' })).not.toBeVisible();
+      await expect(headerControls.getByRole('button', { name: 'Metric categories' })).not.toBeVisible();
+
+      await expect(headerControls.getByText('Group by label')).toBeVisible();
+      await expect(headerControls.getByText('Sort by')).toBeVisible();
+
+      await expect(this.getQuickFilterInput()).toBeVisible();
+      await expect(this.getLayoutSwitcher()).toBeVisible();
+      await this.assertSelectedLayout('Grid');
+      return;
+    }
+
+    if (variant === 'pills') {
+      // pills should be visible
+      await expect(headerControls.getByRole('button', { name: 'Metric prefixes' })).toBeVisible();
+      await expect(headerControls.getByRole('button', { name: 'Metric categories' })).toBeVisible();
+
+      await expect(headerControls.getByText('Group by label')).toBeVisible();
+      await expect(headerControls.getByText('Sort by')).toBeVisible();
+
+      await expect(this.getQuickFilterInput()).toBeVisible();
+      await expect(this.getLayoutSwitcher()).toBeVisible();
+      await this.assertSelectedLayout('Grid');
+      return;
+    }
+
+    /* Labels */
+    // pills should not be visible
+    await expect(headerControls.getByRole('button', { name: 'Metric prefixes' })).not.toBeVisible();
+    await expect(headerControls.getByRole('button', { name: 'Metric categories' })).not.toBeVisible();
+
+    await expect(headerControls.getByText('Group by label')).not.toBeVisible();
+    await expect(headerControls.getByText('Sort by')).toBeVisible();
+
+    await expect(this.getQuickFilterInput()).toBeVisible();
+    await expect(this.getLayoutSwitcher()).toBeVisible();
+    await this.assertSelectedLayout('Grid');
+  }
+
   /* Quick filter */
 
   getQuickFilterInput() {
@@ -54,9 +98,110 @@ export class MetricsReducerView extends DrilldownView {
     return this.getLayoutSwitcher().getByLabel(layoutName).click();
   }
 
+  /* Side bars */
+
+  async assertSidebar(variant: 'filters' | 'pills' | 'labels') {
+    const sidebar = this.getByTestId('sidebar');
+
+    if (variant === 'filters') {
+      // Metric prefix filters
+      const metricPrefixFilters = sidebar.getByTestId('metric-prefix-filters');
+
+      await expect(
+        metricPrefixFilters.getByRole('heading', { name: /metric prefix filters/i, level: 5 })
+      ).toBeVisible();
+      await expect(metricPrefixFilters.getByRole('switch', { name: /hide empty/i })).toBeChecked();
+
+      await expect(metricPrefixFilters.getByText('0 selected')).toBeVisible();
+      await expect(metricPrefixFilters.getByRole('button', { name: 'clear', exact: true })).toBeVisible();
+
+      const prefixesListItemsCount = await metricPrefixFilters
+        .getByTestId('checkbox-filters-list')
+        .locator('li')
+        .count();
+      expect(prefixesListItemsCount).toBeGreaterThan(0);
+
+      // Categories filters
+      const categoriesFilters = sidebar.getByTestId('categories-filters');
+
+      await expect(categoriesFilters.getByRole('heading', { name: /categories filters/i, level: 5 })).toBeVisible();
+      await expect(categoriesFilters.getByRole('switch', { name: /hide empty/i })).toBeChecked();
+
+      await expect(categoriesFilters.getByText('0 selected')).toBeVisible();
+      await expect(categoriesFilters.getByRole('button', { name: 'clear', exact: true })).toBeVisible();
+
+      const categoriesListItemsCount = await categoriesFilters
+        .getByTestId('checkbox-filters-list')
+        .locator('li')
+        .count();
+      expect(categoriesListItemsCount).toBeGreaterThan(0);
+      return;
+    }
+
+    if (variant === 'pills') {
+      await expect(sidebar).not.toBeVisible();
+      return;
+    }
+
+    /* Labels */
+
+    // Metric prefix filters
+    const metricPrefixFilters = sidebar.getByTestId('metric-prefix-filters');
+
+    await expect(metricPrefixFilters.getByRole('heading', { name: /metric prefix filters/i, level: 5 })).toBeVisible();
+    await expect(metricPrefixFilters.getByRole('switch', { name: /hide empty/i })).toBeChecked();
+
+    await expect(metricPrefixFilters.getByText('0 selected')).toBeVisible();
+    await expect(metricPrefixFilters.getByRole('button', { name: 'clear', exact: true })).toBeVisible();
+
+    const prefixesListItemsCount = await metricPrefixFilters.getByTestId('checkbox-filters-list').locator('li').count();
+    expect(prefixesListItemsCount).toBeGreaterThan(0);
+
+    // Labels browser
+    const labelsBrowser = sidebar.getByTestId('labels-browser');
+
+    await expect(labelsBrowser.getByRole('heading', { name: /group by label/i, level: 5 })).toBeVisible();
+
+    await expect(labelsBrowser.getByText('No selection')).toBeVisible();
+    await expect(labelsBrowser.getByRole('button', { name: 'clear', exact: true })).toBeVisible();
+
+    const labelsCount = await labelsBrowser.getByTestId('labels-list').locator('label').count();
+    expect(labelsCount).toBeGreaterThan(0);
+  }
+
   /* Metrics list */
 
   getMetricsList() {
     return this.getByTestId('metrics-list');
+  }
+
+  async assertMetricsList() {
+    const metricsList = this.getMetricsList();
+
+    await expect(metricsList).toBeVisible();
+
+    // we have to wait... if not, the assertion below (on the count) will fail without waiting for elements to be in the DOM
+    // AFAIK, Playwright does not have an API to wait for multiple elements to be visible
+    await expect(metricsList.locator('[data-viz-panel-key]').first()).toBeVisible();
+
+    const panelsCount = await metricsList.locator('[data-viz-panel-key]').count();
+    expect(panelsCount).toBeGreaterThan(0);
+  }
+
+  getMetricsGroupByList() {
+    return this.getByTestId('metrics-groupby-list');
+  }
+
+  async assertMetricsGroupByList() {
+    const metricsList = this.getMetricsGroupByList();
+
+    await expect(metricsList).toBeVisible();
+
+    // we have to wait... if not, the assertion below (on the count) will fail without waiting for elements to be in the DOM
+    // AFAIK, Playwright does not have an API to wait for multiple elements to be visible
+    await expect(metricsList.locator('[data-viz-panel-key]').first()).toBeVisible();
+
+    const panelsCount = await metricsList.locator('[data-viz-panel-key]').count();
+    expect(panelsCount).toBeGreaterThan(0);
   }
 }

--- a/e2e/fixtures/views/SelectMetricView.ts
+++ b/e2e/fixtures/views/SelectMetricView.ts
@@ -10,11 +10,12 @@ export class SelectMetricView extends DrilldownView {
   }
 
   goto(urlSearchParams = new URLSearchParams()) {
-    return super.goto(new URLSearchParams([...this.urlParams, ...new URLSearchParams(urlSearchParams)]));
+    // the spread order is important to override the default params (e.g. overriding "from" and "to")
+    return super.goto(new URLSearchParams([...urlSearchParams, ...this.urlParams]));
   }
 
   getControls() {
-    return this.getByTestId('controls');
+    return this.getByTestId('app-controls');
   }
 
   async assertTopControls() {

--- a/src/DataTrail.tsx
+++ b/src/DataTrail.tsx
@@ -655,7 +655,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
         {showHeaderForFirstTimeUsers && <MetricsHeader />}
         <history.Component model={history} />
         {controls && (
-          <div className={styles.controls} data-testid="controls">
+          <div className={styles.controls} data-testid="app-controls">
             {controls.map((control) => (
               <control.Component key={control.state.key} model={control} />
             ))}

--- a/src/WingmanDataTrail/GroupBy/MetricsGroupByList.tsx
+++ b/src/WingmanDataTrail/GroupBy/MetricsGroupByList.tsx
@@ -110,7 +110,7 @@ export class MetricsGroupByList extends SceneObjectBase<MetricsGroupByListState>
     };
 
     return (
-      <>
+      <div data-testid="metrics-groupby-list">
         <body.Component model={body} />
 
         {shouldDisplayShowMoreButton && (
@@ -125,7 +125,7 @@ export class MetricsGroupByList extends SceneObjectBase<MetricsGroupByListState>
         <div className={styles.variable}>
           <variable.Component key={variable.state.name} model={variable} />
         </div>
-      </>
+      </div>
     );
   };
 }

--- a/src/WingmanDataTrail/MetricsList/SimpleMetricsList.tsx
+++ b/src/WingmanDataTrail/MetricsList/SimpleMetricsList.tsx
@@ -129,7 +129,7 @@ export class SimpleMetricsList extends SceneObjectBase<SimpleMetricsListState> {
     };
 
     return (
-      <>
+      <div data-testid="metrics-list">
         <div className={styles.container}>
           <body.Component model={body} />
         </div>
@@ -140,7 +140,7 @@ export class SimpleMetricsList extends SceneObjectBase<SimpleMetricsListState> {
             </Button>
           </div>
         )}
-      </>
+      </div>
     );
   };
 }

--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -174,7 +174,7 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
               )}
             </div>
           )}
-          <div className={styles.list} data-testid="metrics-list">
+          <div className={styles.list}>
             <body.Component model={body} />
           </div>
         </div>

--- a/src/WingmanDataTrail/SideBar/LabelsBrowser.tsx
+++ b/src/WingmanDataTrail/SideBar/LabelsBrowser.tsx
@@ -52,7 +52,7 @@ export class LabelsBrowser extends SceneObjectBase<LabelsBrowserState> {
     };
 
     return (
-      <div className={styles.container}>
+      <div className={styles.container} data-testid="labels-browser">
         <h5 className={styles.header}>
           Group by label
           <span className={styles.count}>({loading ? '0' : labels.length})</span>
@@ -87,13 +87,14 @@ export class LabelsBrowser extends SceneObjectBase<LabelsBrowserState> {
                 clear
               </Button>
             </div>
-            <RadioButtonList
-              name="labels-list"
-              className={styles.list}
-              options={filteredList}
-              onChange={model.onClickLabel}
-              value={value as string}
-            />
+            <div className={styles.list} data-testid="labels-list">
+              <RadioButtonList
+                name="labels-list"
+                options={filteredList}
+                onChange={model.onClickLabel}
+                value={value as string}
+              />
+            </div>
           </>
         )}
       </div>
@@ -143,9 +144,13 @@ function getStyles(theme: GrafanaTheme2) {
       gap: 0,
       overflowY: 'auto',
 
+      '& [role="radiogroup"]': {
+        gap: 0,
+      },
+
       '& label': {
         cursor: 'pointer',
-        padding: theme.spacing(0.75, 1),
+        padding: theme.spacing(0.5, 1),
         '&:hover': {
           background: theme.colors.background.secondary,
         },

--- a/src/WingmanOnboarding/HeaderControls/MainLabelVariable.tsx
+++ b/src/WingmanOnboarding/HeaderControls/MainLabelVariable.tsx
@@ -13,14 +13,16 @@ import { MetricsOnboarding } from '../MetricsOnboarding';
 export const VAR_MAIN_LABEL_VARIABLE = 'mainLabelWingman';
 
 export class MainLabelVariable extends CustomVariable {
-  public static OPTIONS = ['cluster', 'job', 'namespace', 'service', 'node', 'instance'];
+  public static readonly OPTIONS = ['cluster', 'job', 'namespace', 'service', 'node', 'instance'];
 
   constructor() {
     super({
       name: VAR_MAIN_LABEL_VARIABLE,
-      query: MainLabelVariable.OPTIONS.join(','),
+      query: [' ', ...MainLabelVariable.OPTIONS].join(','),
       hide: VariableHide.hideVariable,
-      value: undefined,
+      value: ' ',
+      includeAll: false,
+      allowCustomValue: true,
     });
 
     this.addActivationHandler(this.onActivate.bind(this));

--- a/src/WingmanOnboarding/MetricsOnboarding.tsx
+++ b/src/WingmanOnboarding/MetricsOnboarding.tsx
@@ -227,8 +227,8 @@ export class MetricsOnboarding extends SceneObjectBase<MetricsOnboardingState> {
 
     return (
       <div className={styles.container}>
-        <div className={styles.headerControls}>
-          <div className={styles.topControls}>
+        <div className={styles.allControls}>
+          <div className={styles.topControls} data-testid="top-controls">
             <div className={styles.mainLabelVariable}>
               <mainLabelVariable.Component model={mainLabelVariable} />
               <a
@@ -244,7 +244,7 @@ export class MetricsOnboarding extends SceneObjectBase<MetricsOnboardingState> {
             </div>
           </div>
 
-          <div className={styles.listControls}>
+          <div className={styles.headerControls} data-testid="header-controls">
             <headerControls.Component model={headerControls} />
           </div>
         </div>
@@ -265,7 +265,7 @@ function getStyles(theme: GrafanaTheme2, chromeHeaderHeight: number) {
       height: '100%',
       gap: theme.spacing(1),
     }),
-    headerControls: css({
+    allControls: css({
       display: 'flex',
       flexDirection: 'column',
       gap: theme.spacing(2),
@@ -293,7 +293,7 @@ function getStyles(theme: GrafanaTheme2, chromeHeaderHeight: number) {
         color: theme.colors.text.link,
       },
     }),
-    listControls: css({
+    headerControls: css({
       marginBottom: theme.spacing(0.5),
     }),
     body: css({

--- a/tests/metrics-reducer-view.spec.ts
+++ b/tests/metrics-reducer-view.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '../e2e/fixtures';
+import { test } from '../e2e/fixtures';
 
 test.describe('Metrics reducer view', () => {
   test.describe('Variant #1: Side bar with prefixes and categories filters', () => {
@@ -9,68 +9,10 @@ test.describe('Metrics reducer view', () => {
       );
     });
 
-    test.describe('Header controls', () => {
-      test('Core UI elements', async ({ metricsReducerView }) => {
-        await expect(metricsReducerView.getQuickFilterInput()).toBeVisible();
-        await expect(metricsReducerView.getByText('Group by label')).toBeVisible();
-        await expect(metricsReducerView.getByText('Sort by')).toBeVisible();
-        await expect(metricsReducerView.getLayoutSwitcher()).toBeVisible();
-        await metricsReducerView.assertSelectedLayout('Grid');
-      });
-    });
-
-    test.describe('Side bar', () => {
-      test('Core UI elements', async ({ metricsReducerView }) => {
-        const sidebar = metricsReducerView.getByTestId('sidebar');
-
-        // Metric prefix filters
-        const metricPrefixFilters = sidebar.getByTestId('metric-prefix-filters');
-
-        await expect(
-          metricPrefixFilters.getByRole('heading', { name: /metric prefix filters/i, level: 5 })
-        ).toBeVisible();
-        await expect(metricPrefixFilters.getByRole('switch', { name: /hide empty/i })).toBeChecked();
-
-        await expect(metricPrefixFilters.getByText('0 selected')).toBeVisible();
-        await expect(metricPrefixFilters.getByRole('button', { name: 'clear', exact: true })).toBeVisible();
-
-        const prefixesListItemsCount = await metricPrefixFilters
-          .getByTestId('checkbox-filters-list')
-          .locator('li')
-          .count();
-        expect(prefixesListItemsCount).toBeGreaterThan(0);
-
-        // Categories filters
-        const categoriesFilters = sidebar.getByTestId('categories-filters');
-
-        await expect(categoriesFilters.getByRole('heading', { name: /categories filters/i, level: 5 })).toBeVisible();
-        await expect(categoriesFilters.getByRole('switch', { name: /hide empty/i })).toBeChecked();
-
-        await expect(categoriesFilters.getByText('0 selected')).toBeVisible();
-        await expect(categoriesFilters.getByRole('button', { name: 'clear', exact: true })).toBeVisible();
-
-        const categoriesListItemsCount = await categoriesFilters
-          .getByTestId('checkbox-filters-list')
-          .locator('li')
-          .count();
-        expect(categoriesListItemsCount).toBeGreaterThan(0);
-      });
-    });
-
-    test.describe('Metrics list', () => {
-      test('Core UI elements', async ({ metricsReducerView }) => {
-        const metricsList = metricsReducerView.getMetricsList();
-
-        await expect(metricsList).toBeVisible();
-
-        // we have to wait for at least the first element
-        // if not, the assertion below (on the count) will fail without waiting for elements to be in the DOM
-        // AFAIK, Playwright does not have an API to wait for a count of elements to be visible
-        await expect(metricsList.locator('[data-viz-panel-key]').first()).toBeVisible();
-
-        const panelsCount = await metricsList.locator('[data-viz-panel-key]').count();
-        expect(panelsCount).toBeGreaterThan(0);
-      });
+    test('Core UI elements', async ({ metricsReducerView }) => {
+      await metricsReducerView.assertHeaderControls('filters');
+      await metricsReducerView.assertSidebar('filters');
+      await metricsReducerView.assertMetricsList();
     });
   });
 
@@ -78,11 +20,23 @@ test.describe('Metrics reducer view', () => {
     test.beforeEach(async ({ metricsReducerView }) => {
       await metricsReducerView.gotoVariant('/trail-filters-pills');
     });
+
+    test('Core UI elements', async ({ metricsReducerView }) => {
+      await metricsReducerView.assertHeaderControls('pills');
+      await metricsReducerView.assertSidebar('pills');
+      await metricsReducerView.assertMetricsList();
+    });
   });
 
   test.describe('Variant #3: Side bar with prefixes filters and group by labels', () => {
     test.beforeEach(async ({ metricsReducerView }) => {
       await metricsReducerView.gotoVariant('/trail-filters-labels');
+    });
+
+    test('Core UI elements', async ({ metricsReducerView }) => {
+      await metricsReducerView.assertHeaderControls('labels');
+      await metricsReducerView.assertSidebar('labels');
+      await metricsReducerView.assertMetricsList();
     });
   });
 });

--- a/tests/onboarding-view.spec.ts
+++ b/tests/onboarding-view.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '../e2e/fixtures';
+
+test.describe('Onboarding reducer view', () => {
+  test.describe('Variant #1: Side bar with prefixes and categories filters', () => {
+    test.beforeEach(async ({ metricsReducerView }) => {
+      await metricsReducerView.gotoVariant(
+        '/onboard-filters-sidebar',
+        new URLSearchParams({ 'var-variant': 'onboard-filters-sidebar' })
+      );
+    });
+
+    test('Core UI elements and navigation to the metrics reducer view', async ({ metricsReducerView }) => {
+      await expect(metricsReducerView.getQuickFilterInput()).toBeVisible();
+      await expect(metricsReducerView.getLayoutSwitcher()).toBeVisible();
+
+      await metricsReducerView.assertMetricsList();
+
+      await metricsReducerView.getByTestId('top-controls').getByRole('button').nth(1).click();
+      await metricsReducerView.assertMetricsGroupByList();
+
+      // go to the metrics reducer view
+      await metricsReducerView
+        .getByRole('button', { name: /show all metrics/i })
+        .first()
+        .click();
+
+      await metricsReducerView.assertHeaderControls('filters');
+      await metricsReducerView.assertSidebar('filters');
+      await metricsReducerView.assertMetricsList();
+    });
+  });
+
+  test.describe('Variant #2: Pills with prefixes and categories filters', () => {
+    test.beforeEach(async ({ metricsReducerView }) => {
+      await metricsReducerView.gotoVariant('/onboard-filters-pills');
+    });
+
+    test('Core UI elements and navigation to the metrics reducer view', async ({ metricsReducerView }) => {
+      await expect(metricsReducerView.getQuickFilterInput()).toBeVisible();
+      await expect(metricsReducerView.getLayoutSwitcher()).toBeVisible();
+
+      await metricsReducerView.assertMetricsList();
+
+      await metricsReducerView.getByTestId('top-controls').getByRole('button').first().click();
+      await metricsReducerView.assertMetricsGroupByList();
+
+      // go to the metrics reducer view
+      await metricsReducerView
+        .getByRole('button', { name: /show all metrics/i })
+        .first()
+        .click();
+
+      await metricsReducerView.assertHeaderControls('pills');
+      await metricsReducerView.assertSidebar('pills');
+      await metricsReducerView.assertMetricsList();
+    });
+  });
+
+  test.describe('Variant #3: Side bar with prefixes filters and group by labels', () => {
+    test.beforeEach(async ({ metricsReducerView }) => {
+      await metricsReducerView.gotoVariant('/onboard-filters-labels');
+    });
+
+    test('Core UI elements and navigation to the metrics reducer view', async ({ metricsReducerView }) => {
+      await expect(metricsReducerView.getQuickFilterInput()).toBeVisible();
+      await expect(metricsReducerView.getLayoutSwitcher()).toBeVisible();
+
+      await metricsReducerView.assertMetricsList();
+
+      await metricsReducerView.getByTestId('top-controls').getByRole('button').first().click();
+      await metricsReducerView.assertMetricsGroupByList();
+
+      // go to the metrics reducer view
+      await metricsReducerView
+        .getByRole('button', { name: /show all metrics/i })
+        .first()
+        .click();
+
+      await metricsReducerView.assertHeaderControls('labels');
+      await metricsReducerView.assertSidebar('labels');
+      await metricsReducerView.assertMetricsList();
+    });
+  });
+});


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** relates to https://github.com/grafana/metrics-drilldown/issues/188

This PR adds 2 missing variant tests for the metrics reducer and new tests for the onboarding flow

### 📖 Summary of the changes

Generally speaking, we duplicate quite some code, knowing that we'll DRY as soon as we have a winning variant.

See diff tab for specific comments.

### 🧪 How to test?

- The build should pass
