### PR TITLE
feat(Faro): Better error reporting

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { type AppRootProps, type GrafanaTheme2 } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { ErrorBoundary, useStyles2 } from '@grafana/ui';
-import React, { createContext, useEffect, useState } from 'react';
+import React, { createContext, useState } from 'react';
 
 import { type DataTrail } from 'DataTrail';
 import { initFaro } from 'tracking/faro/faro';
@@ -10,6 +10,7 @@ import { getUrlForTrail, newMetricsTrail } from 'utils';
 
 import { ErrorView } from './ErrorView';
 import { AppRoutes } from './Routes';
+import { useCatchExceptions } from './useCatchExceptions';
 import { PluginPropsContext } from '../utils/utils.plugin';
 initFaro();
 
@@ -31,25 +32,7 @@ function App(props: AppRootProps) {
     setTrail(trail);
   };
 
-  const [error, setError] = useState<Error>();
-
-  useEffect(() => {
-    // even though we wrap the app in an ErrorBoundary, some errors are not caught,
-    // so we have to set a global onerror handler to catch these (e.g. error thrown from some click handlers)
-    const onError = (errorEvent: ErrorEvent) => {
-      setError(errorEvent.error);
-    };
-    const onUnHandledRejection = (event: PromiseRejectionEvent) => {
-      setError(new Error(event.reason, { cause: { type: event.type } }));
-    };
-
-    window.addEventListener('error', onError);
-    window.addEventListener('unhandledrejection', onUnHandledRejection);
-    return () => {
-      window.removeEventListener('unhandledrejection', onUnHandledRejection);
-      window.removeEventListener('error', onError);
-    };
-  }, []);
+  const [error, setError] = useCatchExceptions();
 
   if (error) {
     return (

--- a/src/App/InlineBanner.tsx
+++ b/src/App/InlineBanner.tsx
@@ -9,22 +9,32 @@ type InlineBannerProps = {
   message?: string | React.ReactNode;
   error?: Error;
   errorContext?: ErrorContext;
+  children?: React.ReactNode;
 };
 
-export function InlineBanner({ severity, title, message, error, errorContext }: InlineBannerProps) {
+export function InlineBanner({ severity, title, message, error, errorContext, children }: InlineBannerProps) {
+  let errorObject;
+
   if (error) {
-    logger.error(error, errorContext);
+    errorObject = error instanceof Error ? error : new Error(error);
+
+    logger.error(errorObject, {
+      ...(errorObject.cause || {}),
+      ...errorContext,
+      bannerTitle: title,
+    });
   }
 
   return (
     <Alert title={title} severity={severity}>
-      {error && (
+      {errorObject && (
         <>
-          {error.message}
+          {errorObject.message}
           <br />
         </>
       )}
       {message}
+      {children}
     </Alert>
   );
 }

--- a/src/App/InlineBanner.tsx
+++ b/src/App/InlineBanner.tsx
@@ -16,7 +16,7 @@ export function InlineBanner({ severity, title, message, error, errorContext, ch
   let errorObject;
 
   if (error) {
-    errorObject = error instanceof Error ? error : new Error(error);
+    errorObject = typeof error === 'string' ? new Error(error) : error;
 
     logger.error(errorObject, {
       ...(errorObject.cause || {}),
@@ -29,7 +29,7 @@ export function InlineBanner({ severity, title, message, error, errorContext, ch
     <Alert title={title} severity={severity}>
       {errorObject && (
         <>
-          {errorObject.message}
+          {errorObject.message || errorObject.toString()}
           <br />
         </>
       )}

--- a/src/App/useCatchExceptions.ts
+++ b/src/App/useCatchExceptions.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+
+function ensureErrorObject(error: any, defaultMessage: string): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  if (typeof error === 'string') {
+    return new Error(error);
+  }
+  if (typeof error.message === 'string') {
+    return new Error(error.message);
+  }
+  return new Error(defaultMessage);
+}
+
+export function useCatchExceptions(): [Error | undefined, React.Dispatch<React.SetStateAction<Error | undefined>>] {
+  const [error, setError] = useState<Error>();
+
+  // even though we wrap the app in an ErrorBoundary, some errors are not caught,
+  // so we have to set global handlers to catch these (e.g. error thrown from some click handlers)
+  useEffect(() => {
+    const onError = (errorEvent: ErrorEvent) => {
+      // TODO: remove me when move all the variables from the DataTrail Scene object to the WingMan Scene objects
+      // this happens because we add the variables to DataTrail without register WingMan's runtime data sources
+      if (['Datasource grafana-prometheus-labels-datasource was not found'].includes(errorEvent.error.message)) {
+        setError(undefined);
+        return;
+      }
+
+      setError(ensureErrorObject(errorEvent.error, 'Uncaught exception!'));
+    };
+
+    const onUnHandledRejection = (event: PromiseRejectionEvent) => {
+      // TODO: remove me when we remove MetricSelectScene
+      // indeed, it seems there's always  a cancelled request when landing on the view :man_shrug:
+      // Ideally, the code in DataTrail should handle the cancellation but we do it here because it's easier
+      if (event.reason.type === 'cancelled') {
+        setError(undefined);
+        return;
+      }
+
+      setError(ensureErrorObject(event.reason, 'Unhandled rejection!'));
+    };
+
+    window.addEventListener('error', onError);
+    window.addEventListener('unhandledrejection', onUnHandledRejection);
+    return () => {
+      window.removeEventListener('unhandledrejection', onUnHandledRejection);
+      window.removeEventListener('error', onError);
+    };
+  }, []);
+
+  return [error, setError];
+}

--- a/src/WingmanDataTrail/GroupBy/MetricsGroupByList.tsx
+++ b/src/WingmanDataTrail/GroupBy/MetricsGroupByList.tsx
@@ -9,9 +9,10 @@ import {
   type SceneComponentProps,
   type SceneObjectState,
 } from '@grafana/scenes';
-import { Alert, Button, Spinner, useStyles2 } from '@grafana/ui';
+import { Button, Spinner, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
+import { InlineBanner } from 'App/InlineBanner';
 import { LabelValuesVariable, VAR_LABEL_VALUES } from 'WingmanDataTrail/Labels/LabelValuesVariable';
 import { SceneByVariableRepeater } from 'WingmanDataTrail/SceneByVariableRepeater/SceneByVariableRepeater';
 
@@ -66,18 +67,15 @@ export class MetricsGroupByList extends SceneObjectBase<MetricsGroupByListState>
         getLayoutEmpty: () =>
           new SceneReactObject({
             reactNode: (
-              <Alert title="" severity="info">
+              <InlineBanner title="" severity="info">
                 No label values found for label &quot;{labelName}&quot;.
-              </Alert>
+              </InlineBanner>
             ),
           }),
         getLayoutError: (error: Error) =>
           new SceneReactObject({
             reactNode: (
-              <Alert severity="error" title={`Error while loading label "${labelName}" values!`}>
-                <p>&quot;{error.message || error.toString()}&quot;</p>
-                <p>Please try to reload the page. Sorry for the inconvenience.</p>
-              </Alert>
+              <InlineBanner severity="error" title={`Error while loading label "${labelName}" values!`} error={error} />
             ),
           }),
         getLayoutChild: (option, index, options) => {

--- a/src/WingmanDataTrail/GroupBy/MetricsGroupByRow.tsx
+++ b/src/WingmanDataTrail/GroupBy/MetricsGroupByRow.tsx
@@ -12,9 +12,10 @@ import {
   type SceneComponentProps,
   type SceneObjectState,
 } from '@grafana/scenes';
-import { Alert, Button, CollapsableSection, Icon, Spinner, useStyles2 } from '@grafana/ui';
+import { Button, CollapsableSection, Icon, Spinner, useStyles2 } from '@grafana/ui';
 import React, { useState } from 'react';
 
+import { InlineBanner } from 'App/InlineBanner';
 import { WithUsageDataPreviewPanel } from 'MetricSelect/WithUsageDataPreviewPanel';
 import { VAR_FILTERS } from 'shared';
 import { getColorByIndex } from 'utils';
@@ -85,19 +86,14 @@ export class MetricsGroupByRow extends SceneObjectBase<MetricsGroupByRowState> {
         getLayoutEmpty: () =>
           new SceneReactObject({
             reactNode: (
-              <Alert title="" severity="info">
+              <InlineBanner title="" severity="info">
                 No metrics found for the current filters and time range.
-              </Alert>
+              </InlineBanner>
             ),
           }),
         getLayoutError: (error: Error) =>
           new SceneReactObject({
-            reactNode: (
-              <Alert severity="error" title="Error while loading metrics!">
-                <p>&quot;{error.message || error.toString()}&quot;</p>
-                <p>Please try to reload the page. Sorry for the inconvenience.</p>
-              </Alert>
-            ),
+            reactNode: <InlineBanner severity="error" title="Error while loading metrics!" error={error} />,
           }),
         getLayoutChild: (option, colorIndex) => {
           return new SceneCSSGridItem({

--- a/src/WingmanDataTrail/MetricsList/SimpleMetricsList.tsx
+++ b/src/WingmanDataTrail/MetricsList/SimpleMetricsList.tsx
@@ -11,9 +11,10 @@ import {
   type SceneObjectState,
 } from '@grafana/scenes';
 import { DashboardCursorSync } from '@grafana/schema';
-import { Alert, Button, Spinner, useStyles2 } from '@grafana/ui';
+import { Button, Spinner, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
+import { InlineBanner } from 'App/InlineBanner';
 import { WithUsageDataPreviewPanel } from 'MetricSelect/WithUsageDataPreviewPanel';
 import { getColorByIndex } from 'utils';
 import { LayoutSwitcher, LayoutType, type LayoutSwitcherState } from 'WingmanDataTrail/HeaderControls/LayoutSwitcher';
@@ -61,19 +62,14 @@ export class SimpleMetricsList extends SceneObjectBase<SimpleMetricsListState> {
         getLayoutEmpty: () =>
           new SceneReactObject({
             reactNode: (
-              <Alert title="" severity="info">
+              <InlineBanner title="" severity="info">
                 No metrics found for the current filters and time range.
-              </Alert>
+              </InlineBanner>
             ),
           }),
         getLayoutError: (error: Error) =>
           new SceneReactObject({
-            reactNode: (
-              <Alert severity="error" title="Error while loading metrics!">
-                <p>&quot;{error.message || error.toString()}&quot;</p>
-                <p>Please try to reload the page. Sorry for the inconvenience.</p>
-              </Alert>
-            ),
+            reactNode: <InlineBanner severity="error" title="Error while loading metrics!" error={error} />,
           }),
         getLayoutChild: (option, colorIndex) => {
           return new SceneCSSGridItem({

--- a/src/WingmanOnboarding/GroupBy/MetricsGroupByRow.tsx
+++ b/src/WingmanOnboarding/GroupBy/MetricsGroupByRow.tsx
@@ -12,10 +12,11 @@ import {
   type SceneComponentProps,
   type SceneObjectState,
 } from '@grafana/scenes';
-import { Alert, Button, CollapsableSection, Icon, Spinner, useStyles2 } from '@grafana/ui';
+import { Button, CollapsableSection, Icon, Spinner, useStyles2 } from '@grafana/ui';
 import React, { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
+import { InlineBanner } from 'App/InlineBanner';
 import { VAR_FILTERS } from 'shared';
 import { getColorByIndex } from 'utils';
 import {
@@ -80,19 +81,14 @@ export class MetricsGroupByRow extends SceneObjectBase<MetricsGroupByRowState> {
         getLayoutEmpty: () =>
           new SceneReactObject({
             reactNode: (
-              <Alert title="" severity="info">
+              <InlineBanner title="" severity="info">
                 No metrics found for the current filters and time range.
-              </Alert>
+              </InlineBanner>
             ),
           }),
         getLayoutError: (error: Error) =>
           new SceneReactObject({
-            reactNode: (
-              <Alert severity="error" title="Error while loading metrics!">
-                <p>&quot;{error.message || error.toString()}&quot;</p>
-                <p>Please try to reload the page. Sorry for the inconvenience.</p>
-              </Alert>
-            ),
+            reactNode: <InlineBanner severity="error" title="Error while loading metrics!" error={error} />,
           }),
         getLayoutChild: (option, colorIndex) => {
           return new SceneCSSGridItem({

--- a/src/WingmanOnboarding/MetricsOnboarding.tsx
+++ b/src/WingmanOnboarding/MetricsOnboarding.tsx
@@ -53,7 +53,7 @@ export class MetricsOnboarding extends SceneObjectBase<MetricsOnboardingState> {
       if (variable.state.name === VAR_DATASOURCE) {
         (sceneGraph.lookupVariable(VAR_MAIN_LABEL_VARIABLE, this) as MainLabelVariable).setState({ value: undefined });
 
-        this.fetchAndLabelValuesAndUpdateBody();
+        this.fetchLabelValuesAndUpdateBody();
         return;
       }
 
@@ -117,13 +117,13 @@ export class MetricsOnboarding extends SceneObjectBase<MetricsOnboardingState> {
       })
     );
 
-    this.fetchAndLabelValuesAndUpdateBody();
+    this.fetchLabelValuesAndUpdateBody();
   }
 
-  private fetchAndLabelValuesAndUpdateBody() {
+  private fetchLabelValuesAndUpdateBody() {
     const mainLabelVariable = sceneGraph.lookupVariable(VAR_MAIN_LABEL_VARIABLE, this) as MainLabelVariable;
 
-    this.fetchAllLabelardinalities(MainLabelVariable.OPTIONS).then((allLabelCardinalities) => {
+    this.fetchAllLabelCardinalities(MainLabelVariable.OPTIONS).then((allLabelCardinalities) => {
       mainLabelVariable.setState({
         options: allLabelCardinalities.map(([labelName, labelCardinality]) => ({
           value: labelName,
@@ -141,7 +141,7 @@ export class MetricsOnboarding extends SceneObjectBase<MetricsOnboardingState> {
     });
   }
 
-  private async fetchAllLabelardinalities(labelNames: string[]): Promise<Array<[string, number]>> {
+  private async fetchAllLabelCardinalities(labelNames: string[]): Promise<Array<[string, number]>> {
     return Promise.all(
       labelNames.map((labelName) =>
         LabelsDataSource.fetchLabelCardinality(labelName, MetricsOnboarding.LABEL_VALUES_API_LIMIT, this)


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** follow-up of https://github.com/grafana/metrics-drilldown/pull/228

This PR adds some tweaks to ensure that all runtime errors are consistently reported. Unfortunately, we have to bypass specific errors to ensure banners don't appear where they shouldn't. See the comments in  see `src/App/useCatchExceptions.ts`.

In a future PR, we should refactor WingMan to better live alongside DataTrail, namely:
- moving the variables from the `DataTrail` Scene object to the WingMan's Scene objects were they are used
- handle better the request cancellations in DataTrail

I've created a GitHub issue to work on this ASAP: https://github.com/grafana/metrics-drilldown/issues/231

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- Same as described in the linked PR above, all uncaught runtime exceptions _and_ unhandled promise rejections should be reported
