### PR TITLE
fix(App): Remove the ErrorBoundary component

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { type AppRootProps, type GrafanaTheme2 } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
-import { ErrorBoundary, useStyles2 } from '@grafana/ui';
+import { useStyles2 } from '@grafana/ui';
 import React, { createContext, useState } from 'react';
 
 import { type DataTrail } from 'DataTrail';
@@ -32,8 +32,7 @@ function App(props: AppRootProps) {
     setTrail(trail);
   };
 
-  const [error, setError] = useCatchExceptions();
-
+  const [error] = useCatchExceptions();
   if (error) {
     return (
       <div className={styles.appContainer} data-testid="metrics-drilldown-app">
@@ -44,15 +43,11 @@ function App(props: AppRootProps) {
 
   return (
     <div className={styles.appContainer} data-testid="metrics-drilldown-app">
-      <ErrorBoundary onError={setError}>
-        {() => (
-          <PluginPropsContext.Provider value={props}>
-            <MetricsContext.Provider value={{ trail, goToUrlForTrail }}>
-              <AppRoutes />
-            </MetricsContext.Provider>
-          </PluginPropsContext.Provider>
-        )}
-      </ErrorBoundary>
+      <PluginPropsContext.Provider value={props}>
+        <MetricsContext.Provider value={{ trail, goToUrlForTrail }}>
+          <AppRoutes />
+        </MetricsContext.Provider>
+      </PluginPropsContext.Provider>
     </div>
   );
 }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** follow-up of https://github.com/grafana/metrics-drilldown/pull/230

This PR removes the `ErrorBoundary` component (but keeps the global error handlers) as an attempt to prevent the errors that occur when trying to async load the JS chunks. E.g.:

<img width="1041" alt="image" src="https://github.com/user-attachments/assets/39637e0f-4203-429d-995c-11614b58568a" />

It's a shot in the dark as the root cause of the error has not yet been identified.

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The uncaught exceptions / unhandled promise rejections should still be reported and, hopefully, there shouldn't be any "loading chunk" errors.
