### PR TITLE
Bug fix: Remove __name__ from query filters expression

### DIFF
--- a/src/DataTrail.tsx
+++ b/src/DataTrail.tsx
@@ -723,7 +723,10 @@ function getVariableSet(
         applyMode: 'manual',
         allowCustomValue: true,
         expressionBuilder: (filters: AdHocVariableFilter[]) => {
-          return [...getBaseFiltersForMetric(metric), ...filters]
+          // remove any filters that include __name__ key in the expression
+          // to prevent the metric name from being set twice in the query and causing an error.
+          const filtersWithoutMetricName = filters.filter((filter) => filter.key !== '__name__');
+          return [...getBaseFiltersForMetric(metric), ...filtersWithoutMetricName]
             .map((filter) => `${filter.key}${filter.operator}"${filter.value}"`)
             .join(',');
         },


### PR DESCRIPTION
### ✨ Description

Bug fix
<img width="859" alt="Screenshot 2025-03-31 at 12 46 57 PM" src="https://github.com/user-attachments/assets/03ca66c5-c28c-4b9b-abc7-7c43dcfb2128" />


**Related issue(s):** <!-- Paste a GitHub issue URL or another pull request URL -->
Fixes https://github.com/grafana/support-escalations/issues/14997
Fixes https://github.com/grafana/metrics-drilldown/issues/234
Fixes https://github.com/grafana/grafana/issues/101556

This PR removes `__name__` from the Prometheus label filters that are interpolated in the query. 

### 📖 Summary of the changes

This only changes the filters in the query and does not change the behavior of the `MetricSelectScene` that uses filters that may include __name__ to reduce the list of metric names.

We will have to keep an eye on the Metrics Reducer and how it uses the filters. If it gets the expression, we will have to explicitly use the filters.filters to get access to `__name__` to use that to reduce the list of metrics names.

### 🧪 How to test?

1. Open the Metrics Drilldown app.
2. Select the legacy drilldown experience.
3. Select a filter `__name__` and choose a metric name.
4. See that the list of metrics filters for that metric.
5. See that the query does not break with the error "metric name set twice."
6. Confirm that `__name__` is not used in the query by looking at the query expr in the developer tools
