### PR TITLE
Bug fix: __name__ bug continued

### DIFF
--- a/src/DataTrail.tsx
+++ b/src/DataTrail.tsx
@@ -723,7 +723,10 @@ function getVariableSet(
         applyMode: 'manual',
         allowCustomValue: true,
         expressionBuilder: (filters: AdHocVariableFilter[]) => {
-          return [...getBaseFiltersForMetric(metric), ...filters]
+          // remove any filters that include __name__ key in the expression
+          // to prevent the metric name from being set twice in the query and causing an error.
+          const filtersWithoutMetricName = filters.filter((filter) => filter.key !== '__name__');
+          return [...getBaseFiltersForMetric(metric), ...filtersWithoutMetricName]
             .map((filter) => `${filter.key}${filter.operator}"${filter.value}"`)
             .join(',');
         },


### PR DESCRIPTION
### ✨ Description

See this issue for full context 🙏🏻  https://github.com/grafana/metrics-drilldown/pull/235

This PR fixes a regression from the above bug fix. The regression was that `variableDependency` in MetricSelectScene only listened for changes in the `expr`. Since we filtered `__name__` from that, the metrics list was not being refreshed correctly. 

### 📖 Summary of the changes

The fix for this is to listen to state changes on the VAR_FILTERS variable instead. This will show when the __name__ label is updated, event though it is no longer interpolated in the expression.

### 🧪 How to test?

Open the Metrics Drilldown app.
Select the legacy drilldown experience.
Select a filter __name__ and choose a metric name.
See that the list of metrics filters for that metric.
See that the query does not break with the error "metric name set twice."
Confirm that __name__ is not used in the query by looking at the query expr in the developer tools
