### PR TITLE
refactor(App): Remove hack on catching the uncaught exception of a cancelled request

### DIFF
--- a/src/App/ErrorView.tsx
+++ b/src/App/ErrorView.tsx
@@ -15,7 +15,7 @@ export function ErrorView({ error }: { error: Error }) {
         title="Fatal error!"
         message="Please try reloading the page or, if the problem persists, contact your organization admin. Sorry for the inconvenience."
         error={error}
-        errorContext={{ handheldBy: 'React error boundary' }}
+        errorContext={{ handheldBy: 'App error view' }}
       />
     </div>
   );

--- a/src/App/useCatchExceptions.ts
+++ b/src/App/useCatchExceptions.ts
@@ -31,14 +31,6 @@ export function useCatchExceptions(): [Error | undefined, React.Dispatch<React.S
     };
 
     const onUnHandledRejection = (event: PromiseRejectionEvent) => {
-      // TODO: remove me when we remove MetricSelectScene
-      // indeed, it seems there's always  a cancelled request when landing on the view :man_shrug:
-      // Ideally, the code in DataTrail should handle the cancellation but we do it here because it's easier
-      if (event.reason.type === 'cancelled') {
-        setError(undefined);
-        return;
-      }
-
       setError(ensureErrorObject(event.reason, 'Unhandled rejection!'));
     };
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** follow-up of https://github.com/grafana/metrics-drilldown/pull/198

@bohandley [PR](https://github.com/grafana/metrics-drilldown/pull/198) solved the issue with the initial cancelled request, so this PR can remove the code required to handle this case in the "error boundary".

### 📖 Summary of the changes

Removing code :)

### 🧪 How to test?

- The app shouldn't display any uncaught exception alert banner when landing on the page
