### PR TITLE
ci(Playwright): Add missing params when launching Playwright against main

### DIFF
--- a/.github/workflows/playwright-published.yml
+++ b/.github/workflows/playwright-published.yml
@@ -63,8 +63,12 @@ jobs:
 
   playwright:
     needs: build
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@main
     with:
       id: ${{ github.event.repository.name }}
       version: ${{ needs.build.outputs.plugin-version }}
       upload-artifacts: true
+      report-path: e2e/test-reports/
+      grafana-compose-file: e2e/docker/docker-compose.e2e.yaml
+      playwright-compose-file: e2e/docker/docker-compose.playwright.yaml
+      grafana-url: http://localhost:3001


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** follow-up of https://github.com/grafana/metrics-drilldown/pull/171

This PR ensures we launch Playwright in a Docker container after merging a PR to main

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The build should pass
- After merging this PR, the build in main should pass
