### PR TITLE
Bug: native histogram banner not showing in e2e tests

### DIFF
--- a/src/banners/NativeHistogramBanner.tsx
+++ b/src/banners/NativeHistogramBanner.tsx
@@ -249,9 +249,15 @@ function getStyles(theme: GrafanaTheme2, _chromeHeaderHeight: number) {
 }
 
 export function setBannerHasBeenShown() {
+  if (!localStorage) {
+    return;
+  }
   localStorage.setItem('nativeHistogramBanner', 'true');
 }
 
 export function bannerHasBeenShown() {
+  if (!localStorage) {
+    return false;
+  }
   return localStorage.getItem('nativeHistogramBanner') ?? false;
 }


### PR DESCRIPTION
### ✨ Description

There is a banner shown for native histograms on loading a DataTrail. 

It is only shown once and we use local storage.

But what if there is no local storage in our e2e test environment? The banner is not being shown in e2e tests.

> Without localStorage:
localStorage.setItem() will throw an error
localStorage.getItem() will throw an error
This means that in e2e tests where localStorage is not available, the code will throw errors and the banner's visibility behavior would be unpredictable. The banner might not show at all due to the errors, or the application might crash when trying to access localStorage.

### 📖 Summary of the changes

We check for local storage before setting `nativeHistogramBanner`

### 🧪 How to test?

Run e2e tests and see that the histogram banner is shown regardless of local storage or not.
