### PR TITLE
feat(ErrorView): Provide a link for a clean page reload

### DIFF
--- a/src/App/ErrorView.tsx
+++ b/src/App/ErrorView.tsx
@@ -1,19 +1,44 @@
 import { css } from '@emotion/css';
 import { type GrafanaTheme2 } from '@grafana/data';
-import { useStyles2 } from '@grafana/ui';
-import React from 'react';
+import { TextLink, useStyles2 } from '@grafana/ui';
+import React, { useCallback } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import { InlineBanner } from './InlineBanner';
 
 export function ErrorView({ error }: { error: Error }) {
   const styles = useStyles2(getStyles);
 
+  const history = useHistory();
+  const { pathname, search } = useLocation();
+
+  const onClickReload = useCallback(() => {
+    const searchParams = new URLSearchParams(search);
+    const newSearchParams = new URLSearchParams();
+
+    // these are safe keys to keep
+    ['from', 'to', 'timezone']
+      .filter((key) => searchParams.has(key))
+      .forEach((key) => newSearchParams.set(key, searchParams.get(key)!));
+
+    history.push({ pathname, search: newSearchParams.toString() });
+    window.location.reload();
+  }, [history, pathname, search]);
+
   return (
     <div className={styles.container}>
       <InlineBanner
         severity="error"
         title="Fatal error!"
-        message="Please try reloading the page or, if the problem persists, contact your organization admin. Sorry for the inconvenience."
+        message={
+          <>
+            Please{' '}
+            <TextLink href="#" onClick={onClickReload}>
+              try reloading the page
+            </TextLink>{' '}
+            or, if the problem persists, contact your organization admin. Sorry for the inconvenience.
+          </>
+        }
         error={error}
         errorContext={{ handheldBy: 'React error boundary' }}
       />


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Whenever a runtime error occurs, we display a banner suggesting to the user to reload the page. But if the error comes from some incorrect values of the URL search parameters, reloading does not have any effect. 

This PR is an attempt to fix this situation by providing a link to reload the page properly:

| Before | After |
|  ---   |  ---  |
| <img width="887" alt="image" src="https://github.com/user-attachments/assets/ea6d9417-a40a-4c05-abe8-9a3e8593542f" /> | <img width="874" alt="image" src="https://github.com/user-attachments/assets/c3f5ed5b-0ad3-403d-9819-79c3517c041e" />  |

In a future PR, we'll handle the specific case where a data source is set in the URL search parameters, but does not exist.

### 📖 Summary of the changes

The link generated keeps only the timerange parameters `from`, `to` and `timezone`.

### 🧪 How to test?

- Manually, provoke a runtime error and check that clicking on the "reload" link works
