### PR TITLE
ci: prevent publishing from non-default branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,8 +44,8 @@ jobs:
     if: |
       github.repository == 'grafana/metrics-drilldown' &&
       (
-        (github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.ref, 'refs/tags/v')) ||
-        (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/v')))
+        (github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'npm version')) ||
+        (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
       )
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
     with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,9 @@ description: Upload new plugin artifact to GCS & publish to plugin catalog
 # 2. Get your feature PR approved
 # 3. Create a separate version bump PR:
 #    - git switch -c bump-version-vX.Y.Z
+#    - update CHANGELOG.md with a link to the forthcoming tag's release notes
 #    - npm version <type>  # this creates the commit and tag (see https://docs.npmjs.com/cli/commands/npm-version for <type> options, e.g. patch, minor, major, prerelease, etc.)
-#    - git push origin bump-version-vX.Y.Z --tags
-#    - update CHANGELOG.md with a link to the tag's release notes
+#    - git push origin bump-version-vX.Y.Z --follow-tags
 # 4. Get version bump PR approved
 # 5. Merge feature PR first
 # 6. Merge version bump PR
@@ -29,8 +29,8 @@ on:
         type: boolean
         default: false
   push:
-    tags:
-      - 'v*' # Run workflow on version tags, e.g. v1.0.0.
+    branches:
+      - main
 
 permissions:
   contents: 'write'
@@ -44,7 +44,7 @@ jobs:
     if: |
       github.repository == 'grafana/metrics-drilldown' &&
       (
-        (github.event_name == 'push' && contains(github.ref, 'refs/tags/v')) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.ref, 'refs/tags/v')) ||
         (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/v')))
       )
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main


### PR DESCRIPTION
### ✨ Description

This prevents undesired runs of `publish.yml` from a non-`main` branch, when pushing tags along with a commit.

### 📖 Summary of the changes

In our publish workflow:
- Update the instructions for creating a new version, for accuracy & reproducibility
- In response to a `push`, the workflow runs only when the branch is `main` and the ref contains a `v*` tag

### 🧪 How to test?

This is a case of "merge it, then we'll see."
