### PR TITLE
chore: versioning for prerelease 1.0.0-6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0-6
+
+See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-6>
+
 ## 1.0.0-5
 
 See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-5>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "1.0.0-5",
+  "version": "1.0.0-6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-metricsdrilldown-app",
-      "version": "1.0.0-5",
+      "version": "1.0.0-6",
       "license": "AGPL-3.0",
       "dependencies": {
         "@bsull/augurs": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "1.0.0-5",
+  "version": "1.0.0-6",
   "author": "Grafana",
   "license": "AGPL-3.0",
   "scripts": {


### PR DESCRIPTION
### ✨ Description

This PR handles the up-versioning to the next prerelease version, by following the steps outlined here (note: versioning only, without association to a particular feature branch):

https://github.com/grafana/metrics-drilldown/blob/f39e3fe138276569af8701042e43dc24d48d7bb3/.github/workflows/publish.yml#L4-L15

### 📖 Summary of the changes

- Updated the changelog with a link to the forthcoming release notes for this version
- Ran `npm version prerelease`, then `git push origin version/1.0.0-6 --follow-tags`

### 🧪 How to test?

N/A
