### PR TITLE
Bug: fix race condition bug with loading metadata for native histograms

### DIFF
--- a/src/helpers/MetricDatasourceHelper.ts
+++ b/src/helpers/MetricDatasourceHelper.ts
@@ -105,8 +105,10 @@ export class MetricDatasourceHelper {
         this._classicHistograms[m.text] = 1;
       });
 
-      if (!this._metricsMetadata && !ds.languageProvider.metricsMetadata) {
-        await ds.languageProvider.loadMetricsMetadata();
+      if (!this._metricsMetadata) {
+        if (!ds.languageProvider.metricsMetadata) {
+          await ds.languageProvider.loadMetricsMetadata();
+        }
         this._metricsMetadata = ds.languageProvider.metricsMetadata;
       }
 


### PR DESCRIPTION
### ✨ Description

When navigating from Grafana side menu => metrics drilldown => let's start there is a race condition when loading metadata in the `MetricDatasourceHelper`. Sometimes metadata is already loaded due to DataTrail being initialized at least 2 times (which is still a mystery). This fixes the logic so that metadata can be loaded earlier, then stored on the `MetricDatasourceHelper`, then accessed correctly for native histogram checks.

### 📖 Summary of the changes

Check for metadata loaded on the ds separately from loaded in the `MetricDatasourceHelper`.

### 🧪 How to test?

1. Open Grafana
2. Click the side menu
3. Click metric drilldown
4. Click Let's start
5. gdev-prometheus data source should be loaded (it has native histograms)
6. See the banner for native histograms
