### PR TITLE
fix(LabelBreakdownScene): prevent runtime error

### DIFF
--- a/src/Breakdown/LabelBreakdownScene.tsx
+++ b/src/Breakdown/LabelBreakdownScene.tsx
@@ -668,8 +668,8 @@ function fixLegendForUnspecifiedLabelValueBehavior(vizPanel: VizPanel) {
       const label = legendFormat.slice(2, -2);
 
       newState.data?.series.forEach((series) => {
-        if (!series.fields[1].labels?.[label]) {
-          const labels = series.fields[1].labels;
+        if (!series.fields[1]?.labels?.[label]) {
+          const labels = series.fields[1]?.labels;
           if (labels) {
             labels[label] = `<unspecified ${label}>`;
           }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR prevents [this runtime error](https://ops.grafana-ops.net/a/grafana-kowalski-app/apps/48/errors?from=now-24h&to=now&timezone=utc&frameIndex=0&var-error_text=e.fields%5B1%5D%20is%20undefined&var-error_hash=7388802338371670933&var-show_errors_drawer=1&var-error_session_id=Lqpv0aw9qH) to occur.

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

`-`
