### PR TITLE
cd: provide necessary docker inputs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,12 @@ jobs:
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
     with:
       environment: ${{ inputs.environment || 'prod' }}
-      upload-playwright-artifacts: true # IMPORTANT: we must ensure there are no unmasked secrets in the E2E tests
       attestation: true # this guarantees that the plugin was built from the source code provided in the release
+      run-playwright: false
+      run-playwright-docker: true
+      upload-playwright-artifacts: true # IMPORTANT: we must ensure there are no unmasked secrets in the E2E tests
       run-playwright-with-skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image || false }}
+      playwright-report-path: e2e/test-reports/
+      playwright-docker-compose-file: e2e/docker/docker-compose.e2e.yaml
+      playwright-e2e-docker-compose-file: e2e/docker/docker-compose.playwright.yaml
+      playwright-grafana-url: http://localhost:3001


### PR DESCRIPTION
### ✨ Description

This fixes `publish.yml` failures like https://github.com/grafana/metrics-drilldown/actions/runs/14321602690/job/40139564146 which were preventing publishing to the Grafana Plugins Catalog.

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

In our `publish.yml` workflow, Docker-related workflow config wasn't set for `grafana/plugin-ci-workflows/.github/workflows/cd.yml@main`'s call of `grafana/plugin-ci-workflows/.github/workflows/ci.yml@main`.

Now that https://github.com/grafana/plugin-ci-workflows/pull/70 has been merged, we can pass the requisite config.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

N/A
