### PR TITLE
refactor(Variables): 

### DIFF
--- a/src/DataTrail.tsx
+++ b/src/DataTrail.tsx
@@ -34,9 +34,6 @@ import React, { useEffect, useRef } from 'react';
 
 import { PluginInfo } from 'PluginInfo/PluginInfo';
 import { getOtelExperienceToggleState } from 'services/store';
-import { LabelsVariable } from 'WingmanDataTrail/Labels/LabelsVariable';
-import { FilteredMetricsVariable } from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
-import { MetricsVariable } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
 
 import { NativeHistogramBanner } from './banners/NativeHistogramBanner';
 import { DataTrailSettings } from './DataTrailSettings';
@@ -785,9 +782,6 @@ function getVariableSet(initialDS?: string, metric?: string, initialFilters?: Ad
         placeholder: 'Select',
         isMulti: true,
       }),
-      new MetricsVariable({}),
-      new FilteredMetricsVariable(),
-      new LabelsVariable(),
     ],
   });
 }

--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -7,7 +7,9 @@ import {
   SceneCSSGridLayout,
   sceneGraph,
   SceneObjectBase,
+  SceneVariableSet,
   VariableDependencyConfig,
+  type QueryVariable,
   type SceneComponentProps,
   type SceneObjectState,
 } from '@grafana/scenes';
@@ -19,18 +21,26 @@ import { getColorByIndex, getTrailFor } from 'utils';
 import { MetricsGroupByList } from './GroupBy/MetricsGroupByList';
 import { MetricsWithLabelValueDataSource } from './GroupBy/MetricsWithLabelValue/MetricsWithLabelValueDataSource';
 import { HeaderControls } from './HeaderControls/HeaderControls';
+import { EventQuickSearchChanged } from './HeaderControls/QuickSearch/EventQuickSearchChanged';
+import { QuickSearch } from './HeaderControls/QuickSearch/QuickSearch';
 import { registerRuntimeDataSources } from './helpers/registerRuntimeDataSources';
 import { LabelsDataSource, NULL_GROUP_BY_VALUE } from './Labels/LabelsDataSource';
-import { VAR_WINGMAN_GROUP_BY, type LabelsVariable } from './Labels/LabelsVariable';
+import { LabelsVariable, VAR_WINGMAN_GROUP_BY } from './Labels/LabelsVariable';
 import { GRID_TEMPLATE_COLUMNS, SimpleMetricsList } from './MetricsList/SimpleMetricsList';
+import { EventMetricsVariableActivated } from './MetricsVariables/EventMetricsVariableActivated';
+import { EventMetricsVariableDeactivated } from './MetricsVariables/EventMetricsVariableDeactivated';
+import { EventMetricsVariableUpdated } from './MetricsVariables/EventMetricsVariableUpdated';
+import { FilteredMetricsVariable } from './MetricsVariables/FilteredMetricsVariable';
+import { MetricsVariable } from './MetricsVariables/MetricsVariable';
+import { MetricsVariableFilterEngine } from './MetricsVariables/MetricsVariableFilterEngine';
 import { ApplyAction } from './MetricVizPanel/actions/ApplyAction';
 import { ConfigureAction } from './MetricVizPanel/actions/ConfigureAction';
 import { EventApplyFunction } from './MetricVizPanel/actions/EventApplyFunction';
 import { EventConfigureFunction } from './MetricVizPanel/actions/EventConfigureFunction';
 import { METRICS_VIZ_PANEL_HEIGHT_SMALL, MetricVizPanel } from './MetricVizPanel/MetricVizPanel';
 import { SceneDrawer } from './SceneDrawer';
+import { EventFiltersChanged } from './SideBar/EventFiltersChanged';
 import { SideBar } from './SideBar/SideBar';
-
 interface MetricsReducerState extends SceneObjectState {
   headerControls: HeaderControls;
   sidebar: SideBar;
@@ -48,6 +58,9 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
 
   public constructor() {
     super({
+      $variables: new SceneVariableSet({
+        variables: [new MetricsVariable(), new FilteredMetricsVariable(), new LabelsVariable()],
+      }),
       headerControls: new HeaderControls({}),
       sidebar: new SideBar({}),
       body: new SimpleMetricsList() as unknown as SceneObjectBase,
@@ -60,13 +73,16 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
   }
 
   private onActivate() {
-    const labelsVariable = sceneGraph.lookupVariable(VAR_WINGMAN_GROUP_BY, this) as LabelsVariable;
-    this.updateBodyBasedOnGroupBy(labelsVariable.state.value as string);
+    this.updateBodyBasedOnGroupBy(
+      (sceneGraph.lookupVariable(VAR_WINGMAN_GROUP_BY, this) as LabelsVariable).state.value as string
+    );
 
     this.subscribeToEvents();
   }
 
   private subscribeToEvents() {
+    this.subscribeToFiltersEvents();
+
     this._subs.add(
       this.subscribeToEvent(EventConfigureFunction, (event) => {
         this.openDrawer(event.payload.metricName);
@@ -76,6 +92,65 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
     this._subs.add(
       this.subscribeToEvent(EventApplyFunction, (event) => {
         this.state.drawer.close();
+      })
+    );
+  }
+
+  private subscribeToFiltersEvents() {
+    const filterEnginesMap = new Map<string, MetricsVariableFilterEngine>();
+
+    this._subs.add(
+      this.subscribeToEvent(EventMetricsVariableActivated, (event) => {
+        const { key } = event.payload;
+        const filteredMetricsVariable = sceneGraph.findByKey(this, key) as QueryVariable;
+        filterEnginesMap.set(key, new MetricsVariableFilterEngine(filteredMetricsVariable));
+      })
+    );
+
+    this._subs.add(
+      this.subscribeToEvent(EventMetricsVariableDeactivated, (event) => {
+        filterEnginesMap.delete(event.payload.key);
+      })
+    );
+
+    this._subs.add(
+      this.subscribeToEvent(EventMetricsVariableUpdated, (event) => {
+        const { key, options } = event.payload;
+        const filterEngine = filterEnginesMap.get(key)!;
+
+        filterEngine.setInitOptions(options);
+
+        const quickSearch = sceneGraph.findByKeyAndType(this, 'quick-search', QuickSearch);
+        const sideBar = sceneGraph.findByKeyAndType(this, 'sidebar', SideBar);
+
+        filterEngine.applyFilters(
+          {
+            names: quickSearch.state.value ? [quickSearch.state.value] : [],
+            prefixes: sideBar.state.selectedMetricPrefixes,
+            categories: sideBar.state.selectedMetricCategories,
+          },
+          true
+        );
+      })
+    );
+
+    this._subs.add(
+      this.subscribeToEvent(EventQuickSearchChanged, (event) => {
+        const { searchText } = event.payload;
+
+        for (const [, filterEngine] of filterEnginesMap) {
+          filterEngine.applyFilters({ names: searchText ? [searchText] : [] });
+        }
+      })
+    );
+
+    this._subs.add(
+      this.subscribeToEvent(EventFiltersChanged, (event) => {
+        const { type, filters } = event.payload;
+
+        for (const [, filterEngine] of filterEnginesMap) {
+          filterEngine.applyFilters({ [type]: filters });
+        }
       })
     );
   }
@@ -135,7 +210,7 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
     const chromeHeaderHeight = useChromeHeaderHeight() ?? 0;
     const styles = useStyles2(getStyles, chromeHeaderHeight);
 
-    const { body, headerControls, drawer, sidebar } = model.useState();
+    const { $variables, body, headerControls, drawer, sidebar } = model.useState();
 
     return (
       <>
@@ -149,6 +224,11 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
           <div className={styles.list}>
             <body.Component model={body} />
           </div>
+        </div>
+        <div className={styles.variables}>
+          {$variables?.state.variables.map((variable) => (
+            <variable.Component key={variable.state.name} model={variable} />
+          ))}
         </div>
         <drawer.Component model={drawer} />
       </>
@@ -174,6 +254,9 @@ function getStyles(theme: GrafanaTheme2, chromeHeaderHeight: number) {
     sidebar: css({
       flex: '0 0 320px',
       overflowY: 'hidden',
+    }),
+    variables: css({
+      display: 'none',
     }),
   };
 }

--- a/src/WingmanDataTrail/MetricsVariables/EventMetricsVariableActivated.ts
+++ b/src/WingmanDataTrail/MetricsVariables/EventMetricsVariableActivated.ts
@@ -1,0 +1,9 @@
+import { BusEventWithPayload } from '@grafana/data';
+
+export interface EventMetricsVariableActivatedPayload {
+  key: string;
+}
+
+export class EventMetricsVariableActivated extends BusEventWithPayload<EventMetricsVariableActivatedPayload> {
+  public static type = 'metrics-variable-activated';
+}

--- a/src/WingmanDataTrail/MetricsVariables/EventMetricsVariableDeactivated.ts
+++ b/src/WingmanDataTrail/MetricsVariables/EventMetricsVariableDeactivated.ts
@@ -1,0 +1,9 @@
+import { BusEventWithPayload } from '@grafana/data';
+
+export interface EventMetricsVariableDeactivatedPayload {
+  key: string;
+}
+
+export class EventMetricsVariableDeactivated extends BusEventWithPayload<EventMetricsVariableDeactivatedPayload> {
+  public static type = 'metrics-variable-deactivated';
+}

--- a/src/WingmanDataTrail/MetricsVariables/EventMetricsVariableUpdated.ts
+++ b/src/WingmanDataTrail/MetricsVariables/EventMetricsVariableUpdated.ts
@@ -1,0 +1,11 @@
+import { BusEventWithPayload } from '@grafana/data';
+import { type VariableValueOption } from '@grafana/scenes';
+
+export interface EventMetricsVariableUpdatedPayload {
+  key: string;
+  options: VariableValueOption[];
+}
+
+export class EventMetricsVariableUpdated extends BusEventWithPayload<EventMetricsVariableUpdatedPayload> {
+  public static type = 'metrics-variable-updated';
+}

--- a/src/WingmanDataTrail/MetricsVariables/FilteredMetricsVariable.ts
+++ b/src/WingmanDataTrail/MetricsVariables/FilteredMetricsVariable.ts
@@ -8,95 +8,42 @@ import {
   VAR_WINGMAN_SORT_BY,
   type SortingOption,
 } from 'WingmanDataTrail/HeaderControls/MetricsSorter/MetricsSorter';
-import { EventQuickSearchChanged } from 'WingmanDataTrail/HeaderControls/QuickSearch/EventQuickSearchChanged';
-import { QuickSearch } from 'WingmanDataTrail/HeaderControls/QuickSearch/QuickSearch';
 import { NULL_GROUP_BY_VALUE } from 'WingmanDataTrail/Labels/LabelsDataSource';
-import { EventFiltersChanged } from 'WingmanDataTrail/SideBar/EventFiltersChanged';
-import { SideBar } from 'WingmanDataTrail/SideBar/SideBar';
 
+import { EventMetricsVariableActivated } from './EventMetricsVariableActivated';
+import { EventMetricsVariableDeactivated } from './EventMetricsVariableDeactivated';
+import { EventMetricsVariableUpdated } from './EventMetricsVariableUpdated';
 import { MetricsVariable } from './MetricsVariable';
-import { MetricsVariableFilterEngine, type MetricFilters } from './MetricsVariableFilterEngine';
 import { MetricsVariableSortEngine } from './MetricsVariableSortEngine';
+
 export const VAR_FILTERED_METRICS_VARIABLE = 'filtered-metrics-wingman';
 
 export class FilteredMetricsVariable extends MetricsVariable {
-  private filterEngine: MetricsVariableFilterEngine;
   private sortEngine: MetricsVariableSortEngine;
 
   constructor() {
     super({
+      key: VAR_FILTERED_METRICS_VARIABLE,
       name: VAR_FILTERED_METRICS_VARIABLE,
       label: 'Filtered Metrics',
     });
 
-    this.filterEngine = new MetricsVariableFilterEngine(this as unknown as MultiValueVariable);
     this.sortEngine = new MetricsVariableSortEngine(this as unknown as MultiValueVariable);
 
     this.addActivationHandler(this.onActivate.bind(this));
   }
 
   protected onActivate() {
-    // wrapped in a try/catch to prevent breaking the app as this variable is added to the DataTrail Scene object
-    try {
-      const quickSearch = sceneGraph.findByKeyAndType(this, 'quick-search', QuickSearch);
+    this.publishEvent(new EventMetricsVariableActivated({ key: this.state.key as string }), true);
 
-      this._subs.add(
-        this.subscribeToState((newState, prevState) => {
-          if (newState.loading === false && prevState.loading === true) {
-            this.filterEngine.setInitOptions(newState.options);
-
-            // TODO: use events publishing and subscribe in the main Wingman Scene?
-            this.filterEngine.applyFilters(
-              {
-                names: quickSearch.state.value ? [quickSearch.state.value] : [],
-              },
-              false
-            );
-            return;
-          }
-        })
-      );
-
-      this._subs.add(
-        quickSearch.subscribeToEvent(EventQuickSearchChanged, (event) => {
-          this.filterEngine.applyFilters({
-            names: event.payload.searchText ? [event.payload.searchText] : [],
-          });
-        })
-      );
-    } catch (error) {
-      console.warn('QuickSearch not found - no worries, gracefully degrading...', error);
-    }
-
-    // wrapped in a try/catch to prevent breaking WingMan in the pills variant
-    try {
-      const sideBar = sceneGraph.findByKeyAndType(this, 'sidebar', SideBar);
-
-      this._subs.add(
-        this.subscribeToState((newState, prevState) => {
-          if (newState.loading === false && prevState.loading === true) {
-            this.filterEngine.applyFilters(
-              {
-                prefixes: sideBar.state.selectedMetricPrefixes,
-                categories: sideBar.state.selectedMetricCategories,
-              },
-              false
-            );
-            return;
-          }
-        })
-      );
-
-      this._subs.add(
-        sideBar.subscribeToEvent(EventFiltersChanged, (event) => {
-          this.filterEngine.applyFilters({
-            [event.payload.type]: event.payload.filters,
-          });
-        })
-      );
-    } catch (error) {
-      console.warn('SideBar not found - no worries, gracefully degrading...', error);
-    }
+    this.subscribeToState((newState, prevState) => {
+      if (!newState.loading && prevState.loading) {
+        this.publishEvent(
+          new EventMetricsVariableUpdated({ key: this.state.key as string, options: newState.options }),
+          true
+        );
+      }
+    });
 
     // wrapped in a try/catch to support the different variants / prevents runtime errors in WingMan's onboarding screen
     try {
@@ -125,6 +72,10 @@ export class FilteredMetricsVariable extends MetricsVariable {
     } catch (error) {
       console.warn('MetricsSorter not found - no worries, gracefully degrading...', error);
     }
+
+    return () => {
+      this.publishEvent(new EventMetricsVariableDeactivated({ key: this.state.key as string }), true);
+    };
   }
 
   public updateGroupByQuery(groupByValue: string) {
@@ -137,10 +88,6 @@ export class FilteredMetricsVariable extends MetricsVariable {
       this.setState({ query });
       this.refreshOptions();
     }
-  }
-
-  public applyFilters(filters: Partial<MetricFilters>, notify = true, forceUpdate = false) {
-    this.filterEngine.applyFilters(filters, notify, forceUpdate);
   }
 
   public sort() {

--- a/src/WingmanDataTrail/MetricsVariables/MetricsVariable.ts
+++ b/src/WingmanDataTrail/MetricsVariables/MetricsVariable.ts
@@ -8,13 +8,15 @@ export const VAR_METRICS_VARIABLE = 'metrics-wingman';
 export type MetricOptions = Array<{ label: string; value: string }>;
 
 interface MetricsVariableState extends SceneObjectState {
+  key: string;
   name?: string;
   label?: string;
 }
 
 export class MetricsVariable extends QueryVariable {
-  constructor(state: Partial<MetricsVariableState>) {
+  constructor(state?: MetricsVariableState) {
     super({
+      key: VAR_METRICS_VARIABLE,
       name: VAR_METRICS_VARIABLE,
       label: 'Metrics',
       ...state,

--- a/src/WingmanDataTrail/MetricsVariables/MetricsVariableFilterEngine.ts
+++ b/src/WingmanDataTrail/MetricsVariables/MetricsVariableFilterEngine.ts
@@ -1,4 +1,4 @@
-import { SceneVariableValueChangedEvent, type MultiValueVariable, type VariableValueOption } from '@grafana/scenes';
+import { type QueryVariable, type VariableValueOption } from '@grafana/scenes';
 import { cloneDeep, isEqual } from 'lodash';
 
 import { type MetricOptions } from './MetricsVariable';
@@ -10,7 +10,7 @@ export type MetricFilters = {
 };
 
 export class MetricsVariableFilterEngine {
-  private variable: MultiValueVariable;
+  private variable: QueryVariable;
   private initOptions: VariableValueOption[] = [];
   private filters: MetricFilters = {
     prefixes: [],
@@ -18,7 +18,7 @@ export class MetricsVariableFilterEngine {
     names: [],
   };
 
-  constructor(variable: MultiValueVariable) {
+  constructor(variable: QueryVariable) {
     this.variable = variable;
   }
 
@@ -26,7 +26,7 @@ export class MetricsVariableFilterEngine {
     this.initOptions = cloneDeep(options);
   }
 
-  public applyFilters(filters: Partial<MetricFilters> = this.filters, notify = true, forceUpdate = false) {
+  public applyFilters(filters: Partial<MetricFilters> = this.filters, forceUpdate = false) {
     const updatedFilters = {
       ...this.filters,
       ...filters,
@@ -41,10 +41,6 @@ export class MetricsVariableFilterEngine {
 
       this.variable.setState({ options: this.initOptions });
 
-      if (notify) {
-        this.notifyUpdate();
-      }
-
       return;
     }
 
@@ -52,27 +48,23 @@ export class MetricsVariableFilterEngine {
     let filteredOptions = allOptions as MetricOptions;
 
     if (updatedFilters.prefixes.length > 0) {
-      filteredOptions = this.applyPrefixFilters(filteredOptions, updatedFilters.prefixes);
+      filteredOptions = MetricsVariableFilterEngine.applyPrefixFilters(filteredOptions, updatedFilters.prefixes);
     }
 
     if (updatedFilters.categories.length > 0) {
-      filteredOptions = this.applyCategoriesFilters(filteredOptions, updatedFilters.categories);
+      filteredOptions = MetricsVariableFilterEngine.applyCategoriesFilters(filteredOptions, updatedFilters.categories);
     }
 
     if (updatedFilters.names.length > 0) {
-      filteredOptions = this.applyNamesFilters(filteredOptions, updatedFilters.names);
+      filteredOptions = MetricsVariableFilterEngine.applyNamesFilters(filteredOptions, updatedFilters.names);
     }
 
     this.filters = updatedFilters;
 
     this.variable.setState({ options: filteredOptions });
-
-    if (notify) {
-      this.notifyUpdate();
-    }
   }
 
-  private applyPrefixFilters(options: MetricOptions, prefixes: string[]): MetricOptions {
+  private static applyPrefixFilters(options: MetricOptions, prefixes: string[]): MetricOptions {
     const pattern = prefixes
       .map((prefix) => {
         // catch-all (see computeMetricPrefixGroups)
@@ -92,7 +84,7 @@ export class MetricsVariableFilterEngine {
     return options.filter((option) => prefixesRegex.test(option.value as string));
   }
 
-  private applyCategoriesFilters(options: MetricOptions, categories: string[]): MetricOptions {
+  private static applyCategoriesFilters(options: MetricOptions, categories: string[]): MetricOptions {
     let filteredOptions: MetricOptions = [];
 
     for (const category of categories) {
@@ -103,7 +95,7 @@ export class MetricsVariableFilterEngine {
     return filteredOptions;
   }
 
-  private applyNamesFilters(options: MetricOptions, names: string[]): MetricOptions {
+  private static applyNamesFilters(options: MetricOptions, names: string[]): MetricOptions {
     const [namePatterns] = names;
 
     const regexes = namePatterns
@@ -120,11 +112,6 @@ export class MetricsVariableFilterEngine {
       .filter(Boolean) as RegExp[];
 
     return options.filter((option) => regexes.some((regex) => regex.test(option.value as string)));
-  }
-
-  private notifyUpdate() {
-    // hack to force SceneByVariableRepeater to re-render
-    this.variable.publishEvent(new SceneVariableValueChangedEvent(this.variable), true);
   }
 
   private static buildRegex(pattern: string, flags?: string) {

--- a/src/WingmanDataTrail/SideBar/SideBar.tsx
+++ b/src/WingmanDataTrail/SideBar/SideBar.tsx
@@ -116,7 +116,7 @@ export class SideBar extends SceneObjectBase<SideBarState> {
     const onSelectFilter = (type: 'prefixes' | 'categories', filters: string[]) => {
       const selectedKey = type === 'prefixes' ? 'selectedMetricPrefixes' : 'selectedMetricCategories';
       model.setState({ [selectedKey]: filters });
-      model.publishEvent(new EventFiltersChanged({ type: type, filters }));
+      model.publishEvent(new EventFiltersChanged({ type: type, filters }), true);
     };
 
     return (


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** follow-up of https://github.com/grafana/metrics-drilldown/pull/248

This PR is the refactor we discussed in our ensemble session.

### 📖 Summary of the changes

See diff tab for specific comments.

### 🧪 How to test?

All filters should behave as before:

1. **QuickSearch:**
  - When typing without any "Group by" option selected and with a "Group by" option selected
  - After typing: reloading the page should filter the metrics list
2. **Sidebar filters:** selecting different filters should work as expected
3. **Combining QuickSearch and the sidebar filters** should work as expected
4. **Combining QuickSearch, sidebar filters and "Group by"** should work as expected

In a future PR, we'll add some E2E tests to prevent any regression
