### PR TITLE
refactor(Variables): Decouple metric variables from the UI component used for sorting

### DIFF
--- a/src/WingmanDataTrail/GroupBy/MetricsWithLabelValue/MetricsWithLabelValueVariable.ts
+++ b/src/WingmanDataTrail/GroupBy/MetricsWithLabelValue/MetricsWithLabelValueVariable.ts
@@ -1,15 +1,7 @@
 import { VariableHide, VariableRefresh } from '@grafana/data';
-import { QueryVariable, sceneGraph, type CustomVariable, type MultiValueVariable } from '@grafana/scenes';
-import { isEqual } from 'lodash';
+import { QueryVariable, sceneGraph } from '@grafana/scenes';
 
 import { VAR_FILTERS } from 'shared';
-import { EventSortByChanged } from 'WingmanDataTrail/HeaderControls/MetricsSorter/EventSortByChanged';
-import {
-  MetricsSorter,
-  VAR_WINGMAN_SORT_BY,
-  type SortingOption,
-} from 'WingmanDataTrail/HeaderControls/MetricsSorter/MetricsSorter';
-import { MetricsVariableSortEngine } from 'WingmanDataTrail/MetricsVariables/MetricsVariableSortEngine';
 import { withLifecycleEvents } from 'WingmanDataTrail/MetricsVariables/withLifecycleEvents';
 
 import { MetricsWithLabelValueDataSource } from './MetricsWithLabelValueDataSource';
@@ -17,8 +9,6 @@ import { MetricsWithLabelValueDataSource } from './MetricsWithLabelValueDataSour
 export const VAR_METRIC_WITH_LABEL_VALUE = 'metrics-with-label-value';
 
 export class MetricsWithLabelValueVariable extends QueryVariable {
-  private sortEngine: MetricsVariableSortEngine;
-
   constructor({
     labelName,
     labelValue,
@@ -44,52 +34,23 @@ export class MetricsWithLabelValueVariable extends QueryVariable {
       includeAll: true,
     });
 
-    this.sortEngine = new MetricsVariableSortEngine(this as unknown as MultiValueVariable);
-
     this.addActivationHandler(this.onActivate.bind(this, labelName, labelValue, removeRules));
 
     // required for filtering and sorting
     return withLifecycleEvents<MetricsWithLabelValueVariable>(this);
   }
 
-  private static buildQuery(labelName: string, labelValue: string, removeRules?: boolean) {
-    return removeRules ? `removeRules{${labelName}="${labelValue}"}` : `{${labelName}="${labelValue}"}`;
-  }
-
   protected onActivate(labelName: string, labelValue: string, removeRules?: boolean) {
     const adHocFiltersVariable = sceneGraph.lookupVariable(VAR_FILTERS, this);
+
     if (adHocFiltersVariable?.state.hide !== VariableHide.hideVariable) {
       this.setState({
         query: MetricsWithLabelValueVariable.buildQuery(labelName, labelValue, removeRules),
       });
     }
+  }
 
-    // wrapped in a try/catch to support the different variants / prevents runtime errors in WingMan's onboarding screen
-    try {
-      const metricsSorter = sceneGraph.findByKeyAndType(this, 'metrics-sorter', MetricsSorter);
-      const sortByVariable = metricsSorter.state.$variables.getByName(VAR_WINGMAN_SORT_BY) as CustomVariable;
-
-      this._subs.add(
-        metricsSorter.subscribeToEvent(EventSortByChanged, (event) => {
-          this.sortEngine.sort(event.payload.sortBy);
-        })
-      );
-
-      this._subs.add(
-        this.subscribeToState((newState, prevState) => {
-          if (newState.loading === false && prevState.loading === true) {
-            this.sortEngine.sort(sortByVariable.state.value as SortingOption);
-            return;
-          }
-
-          if (!isEqual(newState.options, prevState.options)) {
-            this.sortEngine.sort(sortByVariable.state.value as SortingOption);
-            return;
-          }
-        })
-      );
-    } catch (error) {
-      console.warn('MetricsSorter not found - no worries, gracefully degrading...', error);
-    }
+  private static buildQuery(labelName: string, labelValue: string, removeRules?: boolean) {
+    return removeRules ? `removeRules{${labelName}="${labelValue}"}` : `{${labelName}="${labelValue}"}`;
   }
 }

--- a/src/WingmanDataTrail/MetricsVariables/EventMetricsVariableLoaded.ts
+++ b/src/WingmanDataTrail/MetricsVariables/EventMetricsVariableLoaded.ts
@@ -1,0 +1,11 @@
+import { BusEventWithPayload } from '@grafana/data';
+import { type VariableValueOption } from '@grafana/scenes';
+
+export interface EventMetricsVariableLoadedPayload {
+  key: string;
+  options: VariableValueOption[];
+}
+
+export class EventMetricsVariableLoaded extends BusEventWithPayload<EventMetricsVariableLoadedPayload> {
+  public static type = 'metrics-variable-loaded';
+}

--- a/src/WingmanDataTrail/MetricsVariables/EventMetricsVariableUpdated.ts
+++ b/src/WingmanDataTrail/MetricsVariables/EventMetricsVariableUpdated.ts
@@ -1,9 +1,7 @@
 import { BusEventWithPayload } from '@grafana/data';
-import { type VariableValueOption } from '@grafana/scenes';
 
 export interface EventMetricsVariableUpdatedPayload {
   key: string;
-  options: VariableValueOption[];
 }
 
 export class EventMetricsVariableUpdated extends BusEventWithPayload<EventMetricsVariableUpdatedPayload> {

--- a/src/WingmanDataTrail/MetricsVariables/FilteredMetricsVariable.ts
+++ b/src/WingmanDataTrail/MetricsVariables/FilteredMetricsVariable.ts
@@ -1,24 +1,12 @@
-import { sceneGraph, type CustomVariable, type MultiValueVariable } from '@grafana/scenes';
-import { isEqual } from 'lodash';
-
 import { VAR_FILTERS } from 'shared';
-import { EventSortByChanged } from 'WingmanDataTrail/HeaderControls/MetricsSorter/EventSortByChanged';
-import {
-  MetricsSorter,
-  VAR_WINGMAN_SORT_BY,
-  type SortingOption,
-} from 'WingmanDataTrail/HeaderControls/MetricsSorter/MetricsSorter';
 import { NULL_GROUP_BY_VALUE } from 'WingmanDataTrail/Labels/LabelsDataSource';
 
 import { MetricsVariable } from './MetricsVariable';
-import { MetricsVariableSortEngine } from './MetricsVariableSortEngine';
 import { withLifecycleEvents } from './withLifecycleEvents';
 
 export const VAR_FILTERED_METRICS_VARIABLE = 'filtered-metrics-wingman';
 
 export class FilteredMetricsVariable extends MetricsVariable {
-  private sortEngine: MetricsVariableSortEngine;
-
   constructor() {
     super({
       key: VAR_FILTERED_METRICS_VARIABLE,
@@ -26,42 +14,8 @@ export class FilteredMetricsVariable extends MetricsVariable {
       label: 'Filtered Metrics',
     });
 
-    this.sortEngine = new MetricsVariableSortEngine(this as unknown as MultiValueVariable);
-
-    this.addActivationHandler(this.onActivate.bind(this));
-
     // required for filtering and sorting
     return withLifecycleEvents<FilteredMetricsVariable>(this);
-  }
-
-  protected onActivate() {
-    // wrapped in a try/catch to support the different variants / prevents runtime errors in WingMan's onboarding screen
-    try {
-      const metricsSorter = sceneGraph.findByKeyAndType(this, 'metrics-sorter', MetricsSorter);
-      const sortByVariable = metricsSorter.state.$variables.getByName(VAR_WINGMAN_SORT_BY) as CustomVariable;
-
-      this._subs.add(
-        metricsSorter.subscribeToEvent(EventSortByChanged, (event) => {
-          this.sortEngine.sort(event.payload.sortBy);
-        })
-      );
-
-      this._subs.add(
-        this.subscribeToState((newState, prevState) => {
-          if (newState.loading === false && prevState.loading === true) {
-            this.sortEngine.sort(sortByVariable.state.value as SortingOption);
-            return;
-          }
-
-          if (!isEqual(newState.options, prevState.options)) {
-            this.sortEngine.sort(sortByVariable.state.value as SortingOption);
-            return;
-          }
-        })
-      );
-    } catch (error) {
-      console.warn('MetricsSorter not found - no worries, gracefully degrading...', error);
-    }
   }
 
   public updateGroupByQuery(groupByValue: string) {
@@ -74,9 +28,5 @@ export class FilteredMetricsVariable extends MetricsVariable {
       this.setState({ query });
       this.refreshOptions();
     }
-  }
-
-  public sort() {
-    this.sortEngine.sort();
   }
 }

--- a/src/WingmanDataTrail/MetricsVariables/withLifecycleEvents.ts
+++ b/src/WingmanDataTrail/MetricsVariables/withLifecycleEvents.ts
@@ -19,6 +19,12 @@ import { EventMetricsVariableUpdated } from './EventMetricsVariableUpdated';
 export function withLifecycleEvents<T extends MultiValueVariable>(variable: T): T {
   const key = variable.state.key as string;
 
+  if (!key) {
+    throw new TypeError(
+      `Variable "${variable.state.name}" has no key. Please provide a key in order to publish its lifecycle events.`
+    );
+  }
+
   variable.addActivationHandler(() => {
     variable.publishEvent(new EventMetricsVariableActivated({ key }), true);
 

--- a/src/WingmanDataTrail/MetricsVariables/withLifecycleEvents.ts
+++ b/src/WingmanDataTrail/MetricsVariables/withLifecycleEvents.ts
@@ -1,15 +1,19 @@
 import { type MultiValueVariable, type MultiValueVariableState } from '@grafana/scenes';
+import { isEqual } from 'lodash';
+import { type Unsubscribable } from 'rxjs';
 
 import { EventMetricsVariableActivated } from './EventMetricsVariableActivated';
 import { EventMetricsVariableDeactivated } from './EventMetricsVariableDeactivated';
+import { EventMetricsVariableLoaded } from './EventMetricsVariableLoaded';
 import { EventMetricsVariableUpdated } from './EventMetricsVariableUpdated';
 
 /**
  * Adds the publication of lifecycle events to a metrics variable:
  *
  * - `EventMetricsVariableActivated`
- * - `EventMetricsVariableUpdated`
  * - `EventMetricsVariableDeactivated`
+ * - `EventMetricsVariableLoaded`
+ * - `EventMetricsVariableUpdated`
  *
  * This is particularly useful for filtering and sorting the variable options, while keeping the
  * different pieces of code decoupled.
@@ -30,7 +34,21 @@ export function withLifecycleEvents<T extends MultiValueVariable>(variable: T): 
 
     variable.subscribeToState((newState: MultiValueVariableState, prevState: MultiValueVariableState) => {
       if (!newState.loading && prevState.loading) {
-        variable.publishEvent(new EventMetricsVariableUpdated({ key, options: newState.options }), true);
+        variable.publishEvent(new EventMetricsVariableLoaded({ key, options: newState.options }), true);
+
+        // we subscribe only after loading in order to prevent EventMetricsVariableUpdated to be published
+        // indeed, EventMetricsVariableLoaded might trigger an initial filtering and sorting (see MetricsReducer),
+        // which would lead to the publication of an unneccessary EventMetricsVariableUpdated
+        let updateSub: Unsubscribable | undefined;
+        if (updateSub) {
+          updateSub.unsubscribe();
+        }
+
+        updateSub = variable.subscribeToState((newState, prevState) => {
+          if (newState.options.length !== prevState.options.length || !isEqual(newState.options, prevState.options)) {
+            variable.publishEvent(new EventMetricsVariableUpdated({ key }), true);
+          }
+        });
       }
     });
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** follow-up of https://github.com/grafana/metrics-drilldown/pull/271

This PR is the 2nd part of the refactor we discussed in our ensemble session. 

### 📖 Summary of the changes

See diff tab for specific comments.

### 🧪 How to test?

Same as in https://github.com/grafana/metrics-drilldown/pull/271, but taking also in consideration sorting options

We'll add E2E tests in a future PR.
