### PR TITLE
feat(GroupBy): Change "Include/Exclude" buttons for a single "Select" button

### DIFF
--- a/src/WingmanDataTrail/GroupBy/MetricsGroupByRow.tsx
+++ b/src/WingmanDataTrail/GroupBy/MetricsGroupByRow.tsx
@@ -172,7 +172,7 @@ export class MetricsGroupByRow extends SceneObjectBase<MetricsGroupByRowState> {
       <div className={styles.container}>
         <div className={styles.containerHeader}>
           <div className={styles.headerButtons}>
-            <Button variant="secondary" fill="outline" onClick={onClickSelect}>
+            <Button variant="secondary" onClick={onClickSelect}>
               Select
             </Button>
           </div>

--- a/src/WingmanDataTrail/GroupBy/MetricsGroupByRow.tsx
+++ b/src/WingmanDataTrail/GroupBy/MetricsGroupByRow.tsx
@@ -172,7 +172,7 @@ export class MetricsGroupByRow extends SceneObjectBase<MetricsGroupByRowState> {
       <div className={styles.container}>
         <div className={styles.containerHeader}>
           <div className={styles.headerButtons}>
-            <Button variant="secondary" onClick={onClickSelect}>
+            <Button className={styles.selectButton} variant="secondary" onClick={onClickSelect}>
               Select
             </Button>
           </div>
@@ -242,11 +242,14 @@ function getStyles(theme: GrafanaTheme2) {
       borderBottom: `1px solid ${theme.colors.border.medium}`,
     }),
     headerButtons: css({
-      display: 'flex',
-      gap: '8px',
+      position: 'relative',
+      top: '2px',
       marginLeft: 'auto',
       marginRight: '30px',
       zIndex: 100,
+    }),
+    selectButton: css({
+      height: '28px',
     }),
     collapsableSectionBody: css({
       display: 'flex',

--- a/src/WingmanDataTrail/GroupBy/MetricsGroupByRow.tsx
+++ b/src/WingmanDataTrail/GroupBy/MetricsGroupByRow.tsx
@@ -67,6 +67,7 @@ export class MetricsGroupByRow extends SceneObjectBase<MetricsGroupByRowState> {
       }),
       body: new SceneByVariableRepeater({
         variableName: VAR_METRIC_WITH_LABEL_VALUE,
+        initialPageSize: 3,
         body: new SceneCSSGridLayout({
           children: [],
           isLazy: true,
@@ -156,7 +157,7 @@ export class MetricsGroupByRow extends SceneObjectBase<MetricsGroupByRowState> {
       body.increaseBatchSize();
     };
 
-    const onClickInclude = () => {
+    const onClickSelect = () => {
       const adHocFiltersVariable = sceneGraph.lookupVariable(VAR_FILTERS, model) as AdHocFiltersVariable;
 
       adHocFiltersVariable.setState({
@@ -167,24 +168,12 @@ export class MetricsGroupByRow extends SceneObjectBase<MetricsGroupByRowState> {
       (sceneGraph.lookupVariable(VAR_WINGMAN_GROUP_BY, model) as LabelsVariable)?.changeValueTo(NULL_GROUP_BY_VALUE);
     };
 
-    const onClickExclude = () => {
-      const adHocFiltersVariable = sceneGraph.lookupVariable(VAR_FILTERS, model) as AdHocFiltersVariable;
-
-      adHocFiltersVariable.setState({
-        // TOOD: keep unique filters
-        filters: [...adHocFiltersVariable.state.filters, { key: labelName, operator: '!=', value: labelValue }],
-      });
-    };
-
     return (
       <div className={styles.container}>
         <div className={styles.containerHeader}>
           <div className={styles.headerButtons}>
-            <Button variant="secondary" fill="outline" className={styles.includeButton} onClick={onClickInclude}>
-              Include
-            </Button>
-            <Button variant="secondary" fill="outline" className={styles.excludeButton} onClick={onClickExclude}>
-              Exclude
+            <Button variant="secondary" fill="outline" onClick={onClickSelect}>
+              Select
             </Button>
           </div>
         </div>
@@ -259,9 +248,6 @@ function getStyles(theme: GrafanaTheme2) {
       marginRight: '30px',
       zIndex: 100,
     }),
-    filterButton: css({}),
-    includeButton: css({}),
-    excludeButton: css({}),
     collapsableSectionBody: css({
       display: 'flex',
       flexDirection: 'column',


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** solves https://github.com/grafana/metrics-drilldown/issues/252

We still need to figure exactly how the UX should work for the "Include/Exclude" buttons.

So, in the meantime, this PR changes them for a single "Select" button which, once clicked, updates the AdHoc filters on top of the page and resets the "Group by" option to `(none)`:

| Before | After |
|  ---   |  ---  |
| <img width="1703" alt="image" src="https://github.com/user-attachments/assets/43fc084d-47f4-43e1-92ec-1e7c5e2e4e8f" /> | <img width="1703" alt="image" src="https://github.com/user-attachments/assets/e685a108-b46a-4c51-a7af-eafb587b55ed" /> |

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

`-`
