### PR TITLE
ci: generate main branch bundle stats daily

### DIFF
--- a/.github/workflows/bundle-stats-create.yml
+++ b/.github/workflows/bundle-stats-create.yml
@@ -2,6 +2,8 @@ name: create bundle stats
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Run once per day at midnight UTC
   push:
     branches:
       - main


### PR DESCRIPTION
### ✨ Description

Although we specify `retention-days: 90` for `main-branch-stats` in `.github/workflows/bundle-stats-create.yml`, the bundle size stats inexplicably cannot be found if the `main` branch hasn't been updated recently. This PR doesn't address the unknown root cause of that issue, but it provides a workaround: generate the bundle size stats once per day. This should help prevent erroneous [failures](https://github.com/grafana/metrics-drilldown/actions/workflows/bundle-stats-compare.yml?query=is%3Afailure) of the Bundle Stats workflow.