### PR TITLE
feat: add support for cloud partners Prometheus data sources

### DIFF
--- a/src/MetricsDrilldownDataSourceVariable.ts
+++ b/src/MetricsDrilldownDataSourceVariable.ts
@@ -3,6 +3,7 @@ import { DataSourceVariable } from '@grafana/scenes';
 
 import { VAR_DATASOURCE } from 'shared';
 import { logger } from 'tracking/logger/logger';
+import { isPrometheusDataSource } from 'utils/utils.datasource';
 
 export class MetricsDrilldownDataSourceVariable extends DataSourceVariable {
   private static LOCAL_STORAGE_KEY = 'metricsDrilldownDataSource';
@@ -35,7 +36,7 @@ export class MetricsDrilldownDataSourceVariable extends DataSourceVariable {
   }
 
   private static getCurrentDataSource(): string {
-    const prometheusDataSources = Object.values(config.datasources).filter((ds) => ds.type === 'prometheus');
+    const prometheusDataSources = Object.values(config.datasources).filter((ds) => isPrometheusDataSource(ds));
 
     const uidFromUrl = new URL(window.location.href).searchParams.get(`var-${VAR_DATASOURCE}`);
     const uidFromLocalStorage = localStorage.getItem(MetricsDrilldownDataSourceVariable.LOCAL_STORAGE_KEY);

--- a/src/utils/utils.datasource.test.ts
+++ b/src/utils/utils.datasource.test.ts
@@ -1,0 +1,23 @@
+import { isPrometheusDataSource } from './utils.datasource';
+
+describe('isPrometheusDataSource', () => {
+  it('should return true for a core Prometheus datasource', () => {
+    const ds = { type: 'prometheus', uid: 'prometheus' };
+    expect(isPrometheusDataSource(ds)).toBe(true);
+  });
+
+  it('should return true for a Grafana developed Prometheus datasource', () => {
+    const ds = { type: 'grafana-amazonprometheus-datasource', uid: 'grafana-amazonprometheus-datasource' };
+    expect(isPrometheusDataSource(ds)).toBe(true);
+  });
+
+  it('should return false for non-Prometheus datasource', () => {
+    const ds = { type: 'grafana-test-datasource', uid: 'grafana-test-datasource' };
+    expect(isPrometheusDataSource(ds)).toBe(false);
+  });
+
+  it('should return false for object without type property', () => {
+    const ds = { name: 'prometheus', uid: 'prometheus' };
+    expect(isPrometheusDataSource(ds)).toBe(false);
+  });
+});

--- a/src/utils/utils.datasource.ts
+++ b/src/utils/utils.datasource.ts
@@ -5,6 +5,9 @@ import { getBackendSrv, getDataSourceSrv } from '@grafana/runtime';
 import { logger } from '../tracking/logger/logger';
 export type DataSource = DataSourceInstanceSettings<DataSourceJsonData>;
 
+// This regex matches Grafana developed Prometheus data sources that are compatible with the vanilla Prometheus data source
+const PROMETHEUS_DATA_SOURCE_REGEX = /^grafana-[0-9a-z]+prometheus-datasource$/;
+
 /**
  * Helper function to determine if a datasource is a Prometheus datasource
  */
@@ -13,7 +16,8 @@ export function isPrometheusDataSource(input: unknown): input is PrometheusDatas
     typeof input === 'object' &&
     input !== null &&
     'type' in input &&
-    input.type === 'prometheus' &&
+    typeof input.type === 'string' &&
+    (input.type === 'prometheus' || PROMETHEUS_DATA_SOURCE_REGEX.test(input.type)) &&
     'uid' in input &&
     typeof input.uid === 'string'
   );


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** <!-- Paste a GitHub issue URL or another pull request URL -->
This is follow up work from this comment here https://github.com/grafana/grafana/pull/103482#pullrequestreview-2753315294.

This adds support for cloud partners Prometheus data sources. https://github.com/grafana/grafana-amazonprometheus-datasource and https://github.com/grafana/azure-prometheus-datasource.

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

Updated the `isPrometheusDataSource` in `src/utils/utils.datasource.ts` to check if a data source is a core Prom, or cloud partner Prom data source.

Updated `src/MetricsDrilldownDataSourceVariable.ts` to use `isPrometheusDataSource` so that the following scenario will work correctly:

- Configure a core prometheus data source
- Configure an Amazon or Azure prometheus data source
- Go to the metrics drilldown page and in the data source variable dropdown select the configured Amazon or Azure prometheus data source
- Refresh the page and the data source variable will be set to the core prometheus data source (this is incorrect)

With the changes in this PR, you can refresh the page and the data source variable selection should remain the selected Amazon or Azure prometheus data source.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->