### PR TITLE
fix: add missing link to "Go queryless" toolbar action

### DIFF
--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -38,13 +38,13 @@ export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
         return;
       }
 
-      const datasource = queries[0].datasource;
+      const { datasource, expr } = queries[0];
 
-      if (!(datasource?.type === 'prometheus')) {
+      if (!expr || !(datasource?.type === 'prometheus')) {
         return;
       }
 
-      const query = parsePromQueryRegex(queries[0].expr);
+      const query = parsePromQueryRegex(expr);
 
       const timeRange =
         'timeRange' in context &&

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -13,16 +13,22 @@ const PRODUCT_NAME = 'Grafana Metrics Drilldown';
 const title = `Open in ${PRODUCT_NAME}`;
 const description = `Open current query in the ${PRODUCT_NAME} view`;
 const category = 'metrics-drilldown';
+const icon = 'gf-prometheus';
 
 export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
   {
-    targets: [PluginExtensionPoints.DashboardPanelMenu],
+    targets: [PluginExtensionPoints.DashboardPanelMenu, PluginExtensionPoints.ExploreToolbarAction],
     title,
     description,
+    icon,
     category,
     path: createAppUrl(ROUTES.Trail),
     configure: (context) => {
-      if (typeof context === 'undefined' || !('pluginId' in context) || context.pluginId !== 'timeseries') {
+      if (typeof context === 'undefined') {
+        return;
+      }
+
+      if ('pluginId' in context && context.pluginId !== 'timeseries') {
         return;
       }
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -59,7 +59,7 @@
   "extensions": {
     "addedLinks": [
       {
-        "targets": ["grafana/dashboard/panel/menu"],
+        "targets": ["grafana/dashboard/panel/menu", "grafana/explore/toolbar/action"],
         "title": "Open in Grafana Metrics Drilldown",
         "description": "Open current query in the Grafana Metrics Drilldown view"
       }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** <!-- Paste a GitHub issue URL or another pull request URL --> This PR #298.

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

The goal of this PR is to add a missing [link](https://grafana.com/developers/plugin-tools/how-to-guides/ui-extensions/create-an-extension-point) from Explore to Grafana Metrics Drilldown when a user crafts a PromQL expression in the Prometheus data source.

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

This PR builds on #275 and adapts the `PluginExtensionPoints.DashboardPanelMenu` link's [`configure`](https://grafana.com/developers/plugin-tools/reference/ui-extensions#addlink) function to work for the `PluginExtensionPoints.ExploreToolbarAction` extension point also.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

> [!NOTE]  
> Testing this requires running `grafana/grafana`.

#### Metrics Drilldown App

Simply check out the `298/add-missing-link-to-toolbar-action` branch, then `npm run dev`.

#### `grafana/grafana` setup

1. Start by pulling `grafana/grafana`'s latest `main`.
2. Make your local `grafana-metricsdrilldown-app` available to `grafana/grafana`. Unless you adjust the `plugins` config in `conf/custom.ini`, this is accomplished by symlinking as described here: https://github.com/grafana/metrics-drilldown/wiki/Local-development-guide#running-the-metrics-drilldown-app-in-grafanagrafana.
3. Spin up the back end (`make run`)
4. After the back end is up and running, spin up the front end (`yarn install --immutable` to install the latest deps, then `yarn dev`).
5. Navigate to Explore, and select a Prometheus data source.
6. Note how there is no "Go queryless" CTA next to the data source selector...yet.
7. Write a PromQL query, even as basic as a metric name with no filters.
8. Note that the "Go queryless" CTA appears next to the data source selector. Click it.
9. Click the Metrics Drilldown link, and observe that the metric and time range match the dashboard panel.

### Demo

https://github.com/user-attachments/assets/5746fdaf-ed1c-4ce2-8269-ba8d4de32084

### Future work

As noted in #275:

> One thing that isn't working properly: label filters are somehow lost when navigating. They are present in `pathToMetricView`, but are missing from the URL that we're directed to.