### PR TITLE
chore: create rudderstack event for sidebar toggle

### DIFF
--- a/src/WingmanDataTrail/SideBar/SideBar.tsx
+++ b/src/WingmanDataTrail/SideBar/SideBar.tsx
@@ -189,13 +189,7 @@ export class SideBar extends SceneObjectBase<SideBarState> {
               aria-label="Close"
               tooltip="Close"
               tooltipPlacement="top"
-              onClick={() => {
-                reportExploreMetrics('metrics_sidebar_toggled', {
-                  action: 'closed',
-                  section: visibleSection.state.key,
-                });
-                model.setActiveSection('');
-              }}
+              onClick={() => model.setActiveSection('')}
             />
             {/* TODO: find a better way */}
             {visibleSection instanceof MetricsFilterSection && <visibleSection.Component model={visibleSection} />}

--- a/src/WingmanDataTrail/SideBar/SideBar.tsx
+++ b/src/WingmanDataTrail/SideBar/SideBar.tsx
@@ -131,7 +131,7 @@ export class SideBar extends SceneObjectBase<SideBarState> {
 
     if (!sectionKey || sectionKey === visibleSection?.state.key) {
       // Report closing the sidebar
-      reportExploreMetrics('wingman_sidebar_toggled', {
+      reportExploreMetrics('metrics_sidebar_toggled', {
         action: 'closed',
         section: visibleSection?.state.key,
       });
@@ -141,7 +141,7 @@ export class SideBar extends SceneObjectBase<SideBarState> {
     }
 
     // Report opening the sidebar with the selected section
-    reportExploreMetrics('wingman_sidebar_toggled', {
+    reportExploreMetrics('metrics_sidebar_toggled', {
       action: 'opened',
       section: sectionKey,
     });
@@ -190,7 +190,7 @@ export class SideBar extends SceneObjectBase<SideBarState> {
               tooltip="Close"
               tooltipPlacement="top"
               onClick={() => {
-                reportExploreMetrics('wingman_sidebar_toggled', {
+                reportExploreMetrics('metrics_sidebar_toggled', {
                   action: 'closed',
                   section: visibleSection.state.key,
                 });

--- a/src/WingmanDataTrail/SideBar/SideBar.tsx
+++ b/src/WingmanDataTrail/SideBar/SideBar.tsx
@@ -10,6 +10,7 @@ import { computeMetricPrefixGroups } from 'WingmanDataTrail/MetricsVariables/com
 import { computeMetricSuffixGroups } from 'WingmanDataTrail/MetricsVariables/computeMetricSuffixGroups';
 import { computeRulesGroups } from 'WingmanDataTrail/MetricsVariables/computeRulesGroups';
 
+import { reportExploreMetrics } from '../../interactions';
 import { BookmarksList } from './sections/BookmarksList';
 import { EventSectionValueChanged } from './sections/EventSectionValueChanged';
 import { LabelsBrowser } from './sections/LabelsBrowser/LabelsBrowser';
@@ -129,9 +130,21 @@ export class SideBar extends SceneObjectBase<SideBarState> {
     const { visibleSection, sections } = this.state;
 
     if (!sectionKey || sectionKey === visibleSection?.state.key) {
+      // Report closing the sidebar
+      reportExploreMetrics('wingman_sidebar_toggled', {
+        action: 'closed',
+        section: visibleSection?.state.key,
+      });
+
       this.setState({ visibleSection: null });
       return;
     }
+
+    // Report opening the sidebar with the selected section
+    reportExploreMetrics('wingman_sidebar_toggled', {
+      action: 'opened',
+      section: sectionKey,
+    });
 
     this.setState({
       visibleSection: sections.find((section) => section.state.key === sectionKey) ?? null,
@@ -176,7 +189,13 @@ export class SideBar extends SceneObjectBase<SideBarState> {
               aria-label="Close"
               tooltip="Close"
               tooltipPlacement="top"
-              onClick={() => model.setActiveSection('')}
+              onClick={() => {
+                reportExploreMetrics('wingman_sidebar_toggled', {
+                  action: 'closed',
+                  section: visibleSection.state.key,
+                });
+                model.setActiveSection('');
+              }}
             />
             {/* TODO: find a better way */}
             {visibleSection instanceof MetricsFilterSection && <visibleSection.Component model={visibleSection} />}

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -17,7 +17,7 @@ export type Interactions = {
     );
     otel_resource_attribute?: boolean;
   };
-  // User changed a label filter.
+  // User changed a label filter
   label_filter_changed: {
     label: string;
     action: 'added' | 'removed' | 'changed';

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -126,7 +126,7 @@ export type Interactions = {
     metric: string;
   },
   // User toggles the Wingman sidebar
-  wingman_sidebar_toggled: {
+  metrics_sidebar_toggled: {
     action: (
       // Opens the sidebar section
       | 'opened'

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -125,6 +125,16 @@ export type Interactions = {
   native_histogram_example_clicked: {
     metric: string;
   },
+  // User toggles the Wingman sidebar
+  wingman_sidebar_toggled: {
+    action: (
+      // Opens the sidebar section
+      | 'opened'
+      // Closes the sidebar section
+      | 'closed'
+    ),
+    section?: string
+  },
 };
 
 const PREFIX = 'grafana_explore_metrics_';


### PR DESCRIPTION
### ✨ Description

create rudderstack event for sidebar toggle

Ref https://github.com/grafana/metrics-drilldown/issues/304

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

### 📖 Summary of the changes

1. Added a new event type `metrics_sidebar_toggled ` to the `Interactions` interface in `src/interactions.ts` with these properties:
  - `action`: Either 'opened' or 'closed'
  - `section`: Optional string indicating which section was opened/closed
2. Updated the `SideBar` component to report the event in two places:
  - In the `setActiveSection` method when a section is opened or closed
  - In the close button's onClick handler to capture when the X button is clicked


### 🧪 How to test?

I added `console.log`s in the code locally and saw them appear when toggling the sidebar in the UI
![Screenshot 2025-04-16 at 2 09 34 PM](https://github.com/user-attachments/assets/4239c566-dfe9-4845-875a-a0634684c7ac)

https://github.com/user-attachments/assets/55188403-7211-4500-b7d0-88e121c21c13


