### PR TITLE
poc: other metric filters

### DIFF
--- a/src/DataTrail.tsx
+++ b/src/DataTrail.tsx
@@ -64,6 +64,7 @@ import {
   VAR_OTEL_GROUP_LEFT,
   VAR_OTEL_JOIN_QUERY,
   VAR_OTEL_RESOURCES,
+  VAR_OTHER_METRIC_FILTERS,
 } from './shared';
 import { getTrailStore } from './TrailStore/TrailStore';
 import { getTrailFor, limitAdhocProviders } from './utils';
@@ -704,6 +705,16 @@ function getVariableSet(initialDS?: string, metric?: string, initialFilters?: Ad
             .map((filter) => `${utf8Support(filter.key)}${filter.operator}"${filter.value}"`)
             .join(',');
         },
+      }),
+      new AdHocFiltersVariable({
+        name: VAR_OTHER_METRIC_FILTERS,
+        readOnly: true,
+        skipUrlSync: true,
+        datasource: null,
+        hide: VariableHide.hideLabel,
+        layout: 'combobox',
+        applyMode: 'manual',
+        allowCustomValue: true,
       }),
       ...getVariablesWithOtelJoinQueryConstant(),
       new ConstantVariable({

--- a/src/DataTrail.tsx
+++ b/src/DataTrail.tsx
@@ -64,7 +64,6 @@ import {
   VAR_OTEL_GROUP_LEFT,
   VAR_OTEL_JOIN_QUERY,
   VAR_OTEL_RESOURCES,
-  VAR_OTHER_METRIC_FILTERS,
 } from './shared';
 import { getTrailStore } from './TrailStore/TrailStore';
 import { getTrailFor, limitAdhocProviders } from './utils';
@@ -705,16 +704,6 @@ function getVariableSet(initialDS?: string, metric?: string, initialFilters?: Ad
             .map((filter) => `${utf8Support(filter.key)}${filter.operator}"${filter.value}"`)
             .join(',');
         },
-      }),
-      new AdHocFiltersVariable({
-        name: VAR_OTHER_METRIC_FILTERS,
-        readOnly: true,
-        skipUrlSync: true,
-        datasource: null,
-        hide: VariableHide.hideLabel,
-        layout: 'combobox',
-        applyMode: 'manual',
-        allowCustomValue: true,
       }),
       ...getVariablesWithOtelJoinQueryConstant(),
       new ConstantVariable({

--- a/src/WingmanDataTrail/SideBar/SideBar.tsx
+++ b/src/WingmanDataTrail/SideBar/SideBar.tsx
@@ -1,17 +1,18 @@
 import { css, cx } from '@emotion/css';
 import { VariableHide, type GrafanaTheme2 } from '@grafana/data';
 import {
+  AdHocFiltersVariable,
   sceneGraph,
   SceneObjectBase,
   type AdHocFilterWithLabels,
   type SceneComponentProps,
   type SceneObjectState,
-  type SceneVariable,
 } from '@grafana/scenes';
 import { IconButton, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { VAR_OTHER_METRIC_FILTERS } from 'shared';
+import { getTrailFor } from 'utils';
 import { isAdHocFiltersVariable } from 'utils/utils.variables';
 import { NULL_GROUP_BY_VALUE } from 'WingmanDataTrail/Labels/LabelsDataSource';
 import { VAR_WINGMAN_GROUP_BY } from 'WingmanDataTrail/Labels/LabelsVariable';
@@ -110,47 +111,72 @@ export class SideBar extends SceneObjectBase<SideBarState> {
   }
 
   private onActivate() {
-    const otherMetricFiltersVar = sceneGraph.lookupVariable(VAR_OTHER_METRIC_FILTERS, this);
+    this.initOtherMetricsVar();
     this._subs.add(
       this.subscribeToEvent(EventSectionValueChanged, (event) => {
         const { key, values } = event.payload;
         const { sectionValues } = this.state;
         const newSectionValues = new Map(sectionValues).set(key, values);
-
-        this.setOtherMetricFilters(newSectionValues, otherMetricFiltersVar);
+        this.setOtherMetricFilters(newSectionValues);
         this.setState({ sectionValues: newSectionValues });
       })
     );
   }
 
-  private setOtherMetricFilters(sectionValues: Map<string, string[]>, otherMetricFiltersVar: SceneVariable | null) {
-    if (isAdHocFiltersVariable(otherMetricFiltersVar)) {
-      const varToTextMap: Record<MetricFiltersVariable, string> = {
-        'filters-rule': 'rule group',
-        'filters-prefix': 'prefix',
-        'filters-suffix': 'suffix',
-      };
-      const newFilters = Array.from(sectionValues.entries()).reduce<Array<AdHocFilterWithLabels<{}>>>(
-        (acc, [key, value]) => {
-          if (value.length && metricFiltersVariables.includes(key as MetricFiltersVariable)) {
-            acc.push({
-              key,
-              operator: '=',
-              value: value.join(', '),
-              keyLabel: varToTextMap[key as MetricFiltersVariable],
-            });
-          }
-
-          return acc;
-        },
-        []
-      );
-
-      otherMetricFiltersVar.setState({
-        filters: newFilters,
-        hide: newFilters.length ? VariableHide.hideLabel : VariableHide.hideVariable,
-      });
+  private setOtherMetricFilters(sectionValues: Map<string, string[]>) {
+    const otherMetricFiltersVar = sceneGraph.lookupVariable(VAR_OTHER_METRIC_FILTERS, this);
+    if (!isAdHocFiltersVariable(otherMetricFiltersVar)) {
+      console.log('otherMetricFiltersVar is not an AdHocFiltersVariable');
+      return;
     }
+
+    const varToTextMap: Record<MetricFiltersVariable, string> = {
+      'filters-rule': 'rule group',
+      'filters-prefix': 'prefix',
+      'filters-suffix': 'suffix',
+    };
+    const newFilters = Array.from(sectionValues.entries()).reduce<Array<AdHocFilterWithLabels<{}>>>(
+      (acc, [key, value]) => {
+        if (value.length && metricFiltersVariables.includes(key as MetricFiltersVariable)) {
+          acc.push({
+            key,
+            operator: '=',
+            value: value.join(', '),
+            keyLabel: varToTextMap[key as MetricFiltersVariable],
+          });
+        }
+
+        return acc;
+      },
+      []
+    );
+
+    otherMetricFiltersVar.setState({
+      filters: newFilters,
+      hide: newFilters.length ? VariableHide.hideLabel : VariableHide.hideVariable,
+    });
+  }
+
+  private initOtherMetricsVar() {
+    const otherMetricFiltersVar = new AdHocFiltersVariable({
+      name: VAR_OTHER_METRIC_FILTERS,
+      readOnly: true,
+      skipUrlSync: true,
+      datasource: null,
+      hide: VariableHide.hideLabel,
+      layout: 'combobox',
+      applyMode: 'manual',
+      allowCustomValue: true,
+    });
+    const trail = getTrailFor(this);
+    const currentVariableSet = trail.state.$variables;
+    if (!currentVariableSet) {
+      return;
+    }
+    currentVariableSet.setState({
+      variables: [...currentVariableSet.state.variables, otherMetricFiltersVar],
+    });
+    this.setOtherMetricFilters(this.state.sectionValues);
   }
 
   private static getSectionValuesFromUrl() {

--- a/src/WingmanDataTrail/SideBar/SideBar.tsx
+++ b/src/WingmanDataTrail/SideBar/SideBar.tsx
@@ -126,7 +126,6 @@ export class SideBar extends SceneObjectBase<SideBarState> {
   private setOtherMetricFilters(sectionValues: Map<string, string[]>) {
     const otherMetricFiltersVar = sceneGraph.lookupVariable(VAR_OTHER_METRIC_FILTERS, this);
     if (!isAdHocFiltersVariable(otherMetricFiltersVar)) {
-      console.log('otherMetricFiltersVar is not an AdHocFiltersVariable');
       return;
     }
 
@@ -157,6 +156,12 @@ export class SideBar extends SceneObjectBase<SideBarState> {
     });
   }
 
+  /**
+   * Initialize the other metrics variable and set the filters from the current sidebar selections.
+   * This powers the read-only, "other metric filters" UI next to the label filters.
+   * The purpose of this is to provide users with at-a-glance feedback about the current sidebar
+   * selections, without needing to interact with the sidebar.
+   */
   private initOtherMetricsVar() {
     const otherMetricFiltersVar = new AdHocFiltersVariable({
       name: VAR_OTHER_METRIC_FILTERS,

--- a/src/WingmanDataTrail/SideBar/SideBar.tsx
+++ b/src/WingmanDataTrail/SideBar/SideBar.tsx
@@ -1,9 +1,17 @@
 import { css, cx } from '@emotion/css';
-import { type GrafanaTheme2 } from '@grafana/data';
-import { SceneObjectBase, type SceneComponentProps, type SceneObjectState } from '@grafana/scenes';
+import { VariableHide, type GrafanaTheme2 } from '@grafana/data';
+import {
+  sceneGraph,
+  SceneObjectBase,
+  type AdHocFilterWithLabels,
+  type SceneComponentProps,
+  type SceneObjectState,
+} from '@grafana/scenes';
 import { IconButton, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
+import { VAR_OTHER_METRIC_FILTERS } from 'shared';
+import { isAdHocFiltersVariable } from 'utils/utils.variables';
 import { NULL_GROUP_BY_VALUE } from 'WingmanDataTrail/Labels/LabelsDataSource';
 import { VAR_WINGMAN_GROUP_BY } from 'WingmanDataTrail/Labels/LabelsVariable';
 import { computeMetricPrefixGroups } from 'WingmanDataTrail/MetricsVariables/computeMetricPrefixGroups';
@@ -25,6 +33,9 @@ interface SideBarState extends SceneObjectState {
   visibleSection: Section | null;
   sectionValues: Map<string, string[]>;
 }
+
+export const metricFiltersVariables = ['filters-rule', 'filters-prefix', 'filters-suffix'] as const;
+type MetricFiltersVariable = (typeof metricFiltersVariables)[number];
 
 export class SideBar extends SceneObjectBase<SideBarState> {
   constructor(state: Partial<SideBarState>) {
@@ -106,13 +117,49 @@ export class SideBar extends SceneObjectBase<SideBarState> {
         this.setState({ sectionValues: new Map(sectionValues).set(key, values) });
       })
     );
+
+    const otherMetricFiltersVar = sceneGraph.lookupVariable(VAR_OTHER_METRIC_FILTERS, this);
+
+    const varToTextMap: Record<MetricFiltersVariable, string> = {
+      'filters-rule': 'rule group',
+      'filters-prefix': 'prefix',
+      'filters-suffix': 'suffix',
+    };
+    this._subs.add(
+      this.subscribeToState(({ sectionValues }) => {
+        if (isAdHocFiltersVariable(otherMetricFiltersVar)) {
+          const newFilters = Array.from(sectionValues.entries()).reduce<Array<AdHocFilterWithLabels<{}>>>(
+            (acc, [key, value]) => {
+              if (!value.length || !metricFiltersVariables.includes(key as MetricFiltersVariable)) {
+                return acc;
+              }
+
+              acc.push({
+                key,
+                operator: '=',
+                value: value.join(', '),
+                keyLabel: varToTextMap[key as MetricFiltersVariable],
+              });
+
+              return acc;
+            },
+            []
+          );
+
+          otherMetricFiltersVar.setState({
+            filters: newFilters,
+            hide: newFilters.length ? VariableHide.hideLabel : VariableHide.hideVariable,
+          });
+        }
+      })
+    );
   }
 
   private static getSectionValuesFromUrl() {
     const urlSearchParams = new URLSearchParams(window.location.search);
     const sectionValues = new Map();
 
-    for (const filterKey of ['filters-rule', 'filters-prefix', 'filters-suffix']) {
+    for (const filterKey of metricFiltersVariables) {
       const filterValueFromUrl = urlSearchParams.get(filterKey);
       sectionValues.set(filterKey, filterValueFromUrl ? filterValueFromUrl.split(',').map((v) => v.trim()) : []);
     }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -30,6 +30,7 @@ export const VAR_MISSING_OTEL_TARGETS_EXPR = '${missing_otel_targets}';
 // for consolidating otel and metric filters into one adhoc filter set
 export const VAR_OTEL_AND_METRIC_FILTERS = 'otel_and_metric_filters';
 export const VAR_OTEL_AND_METRIC_FILTERS_EXPR = '${otel_and_metric_filters}';
+export const VAR_OTHER_METRIC_FILTERS = 'other_metric_filters';
 
 export const LOGS_METRIC = '$__logs__';
 export const KEY_SQR_METRIC_VIZ_QUERY = 'sqr-metric-viz-query';


### PR DESCRIPTION
### ✨ Description

This PR is a POC of an idea that we'd like to test and get feedback on.

#### Problem statement

When using metric filters from the MetricsReducer sidebar (metric name prefix, suffix, or rule type), you must interact with the sidebar (either by hovering over selected filter icons, or opening the sidebar) to see the current filter selections. It'd be nice to have at-a-glance feedback about the filters that have been applied, without any sidebar interaction. Or so we think! Let's get feedback on this :)

### 📖 Summary of the changes

- Adds a new read-only `VAR_OTHER_METRIC_FILTERS` variable
- `VAR_OTHER_METRIC_FILTERS`'s filters are kept in sync with the currently-applied prefix, suffix, and rule group filters
- When no prefix, suffix, or rule group filters are applied, the `VAR_OTHER_METRIC_FILTERS` variable is hidden

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

1. Check out the `poc/other-metric-filters` branch
2. Spin up the app with `npm run server` and `npm run dev`
3. Navigate to `/trail-filters-sidebar`
4. Apply and remove prefix, suffix, and rule type filters

### Demo

https://github.com/user-attachments/assets/abeb571b-5066-457d-ace6-20467a043fb7
