### PR TITLE
ci: upgrade playwright to 1.52.0

### DIFF
--- a/docs/end-to-end-testing.md
+++ b/docs/end-to-end-testing.md
@@ -94,6 +94,6 @@ In build time (PR and main branch), we run the same [dockerized Prometheus with 
 
 - Identify the current Playwright version, e.g. `1.50.0`
 - Identify the new Playwright version, e.g. `1.51.0`
-- In a terminal, execute: `./scripts/upgrade-playwright 1.50.0 1.51.0`
+- In a terminal, execute: `./scripts/upgrade-playwright.sh 1.50.0 1.51.0`
 - Launch the E2E tests locally with Docker to verify that the new version works: `npm run e2e:ci:server:up && npm run e2e:ci`
 - Push the modified files to the PR

--- a/e2e/docker/Dockerfile.playwright
+++ b/e2e/docker/Dockerfile.playwright
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/playwright:v1.51.0
+FROM mcr.microsoft.com/playwright:v1.52.0
 
 WORKDIR /app
 
 # required by the e2e test code
-RUN npm install "@playwright/test@^1.51.0" "dotenv@^16.3.1" "@grafana/plugin-e2e"
+RUN npm install "@playwright/test@^1.52.0" "dotenv@^16.3.1" "@grafana/plugin-e2e"
 
 ENV TZ=Europe/Madrid
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@grafana/eslint-config": "^8.0.0",
         "@grafana/plugin-e2e": "^1.17.0",
         "@grafana/tsconfig": "^2.0.0",
-        "@playwright/test": "^1.51.0",
+        "@playwright/test": "^1.52.0",
         "@stylistic/eslint-plugin-ts": "^2.9.0",
         "@swc/core": "^1.3.90",
         "@swc/helpers": "^0.5.0",
@@ -4071,13 +4071,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
-      "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.51.1"
+        "playwright": "1.52.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13265,13 +13265,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
-      "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.51.1"
+        "playwright-core": "1.52.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13284,9 +13284,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
-      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@grafana/eslint-config": "^8.0.0",
     "@grafana/plugin-e2e": "^1.17.0",
     "@grafana/tsconfig": "^2.0.0",
-    "@playwright/test": "^1.51.0",
+    "@playwright/test": "^1.52.0",
     "@stylistic/eslint-plugin-ts": "^2.9.0",
     "@swc/core": "^1.3.90",
     "@swc/helpers": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "e2e:local": "playwright test -c ./e2e/config/playwright.config.local.ts",
     "e2e:local:watch": "npm run e2e:local -- --ui",
     "e2e:local:codegen": "playwright codegen",
+    "e2e:ci:prepare": "docker build --progress=auto -t metrics-drilldown-e2e:latest -f e2e/docker/Dockerfile.playwright .",
     "e2e:ci:server:up": "docker compose -f e2e/docker/docker-compose.e2e.yaml up --build -d",
     "e2e:ci:server:down": "docker compose down",
     "e2e:ci": "docker compose -f e2e/docker/docker-compose.playwright.yaml up --build"

--- a/scripts/upgrade-playwright.sh
+++ b/scripts/upgrade-playwright.sh
@@ -7,8 +7,8 @@ if [ -z "$OLD_VERSION" ] || [ -z "$NEW_VERSION" ]; then
     exit 1
 fi
 
-npm up @playwright/test
+npm up @playwright/test --save
 
-find ./e2e/docker/Dockerfile.plugin -type f -exec sed -i "" "s/$OLD_VERSION/$NEW_VERSION/g" {} \;
+find ./e2e/docker/Dockerfile.playwright -type f -exec sed -i "" "s/$OLD_VERSION/$NEW_VERSION/g" {} \;
 
 npm run e2e:ci:prepare


### PR DESCRIPTION
### ✨ Description

There were [e2e test failures](https://github.com/grafana/metrics-drilldown/actions/runs/14577635867/job/40887321320) related to the Playwright version being out-of-date.

<img width="923" alt="playwright version error" src="https://github.com/user-attachments/assets/252a2a13-a292-4bce-8728-f4d02755389a" />

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

- Upgrades Playwright from 1.51.0 to 1.52.0
- Fixes `scripts/upgrade-playwright.sh` to properly upgrade dependencies and rebuild containers

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

1. Check out the `ci/upgrade-playwright` branch.
2. Run `e2e:local:prepare` to upgrade your local Playwright's Chromium version
3. Ensure that Docker Desktop is running.
4. Run `npm run e2e:local:server` to spin up the requisite containers.
5. Run `npm run e2e:ci` to confirm that all e2e tests pass.
