### PR TITLE
chore: create rudderstack event for sidebar rules filters

### DIFF
--- a/src/WingmanDataTrail/SideBar/sections/MetricsFilterSection/CheckBoxList.tsx
+++ b/src/WingmanDataTrail/SideBar/sections/MetricsFilterSection/CheckBoxList.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import { CheckboxWithCount } from './CheckboxWithCount';
 import { type MetricsFilterSectionState } from './MetricsFilterSection';
+import { reportSidebarRulesFilterSelected } from '../../../../interactions';
 
 export function CheckBoxList({
   groups,
@@ -17,11 +18,44 @@ export function CheckBoxList({
 }) {
   const styles = useStyles2(getStyles);
 
+  const isRulesFilter = groups.some(
+    (g) => g.label === 'Non-rules metrics' || g.label === 'Recording rules' || g.label === 'Alerting rules'
+  );
+
+  const handleClearFilters = () => {
+    // If this is a rules filter component and we're clearing the selection
+    if (isRulesFilter && selectedGroups.length > 0) {
+      // Determine which rule types were previously selected
+      selectedGroups.forEach((group) => {
+        let filterType: 'non_rules_metrics' | 'recording_rules' | 'alerting_rules';
+
+        switch (group.label) {
+          case 'Non-rules metrics':
+            filterType = 'non_rules_metrics';
+            break;
+          case 'Recording rules':
+            filterType = 'recording_rules';
+            break;
+          case 'Alerting rules':
+            filterType = 'alerting_rules';
+            break;
+          default:
+            return; // Skip if it's not a recognized rules filter
+        }
+
+        // Report that the filter was unselected
+        reportSidebarRulesFilterSelected(filterType);
+      });
+    }
+
+    onSelectionChange([]);
+  };
+
   return (
     <>
       <div className={styles.checkboxListHeader}>
         <div>{selectedGroups.length} selected</div>
-        <Button variant="secondary" fill="text" onClick={() => onSelectionChange([])} disabled={!selectedGroups.length}>
+        <Button variant="secondary" fill="text" onClick={handleClearFilters} disabled={!selectedGroups.length}>
           clear
         </Button>
       </div>

--- a/src/WingmanDataTrail/SideBar/sections/MetricsFilterSection/MetricsFilterSection.tsx
+++ b/src/WingmanDataTrail/SideBar/sections/MetricsFilterSection/MetricsFilterSection.tsx
@@ -24,6 +24,7 @@ import {
 } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
 import { type MetricFilters } from 'WingmanDataTrail/MetricsVariables/MetricsVariableFilterEngine';
 
+import { reportSidebarRulesFilterSelected } from '../../../../interactions';
 import { EventSectionValueChanged } from '../EventSectionValueChanged';
 import { SectionTitle } from '../SectionTitle';
 import { type SideBarSectionState } from '../types';
@@ -173,6 +174,30 @@ export class MetricsFilterSection extends SceneObjectBase<MetricsFilterSectionSt
       new EventSectionValueChanged({ key: this.state.key, values: selectedGroups.map((g) => g.label) }),
       true
     );
+
+    // Track rule filter selection events
+    if (this.state.key === 'filters-rule' && selectedGroups.length > 0) {
+      // Map the label to the appropriate filter_type for the event
+      selectedGroups.forEach((group) => {
+        let filterType: 'non_rules_metrics' | 'recording_rules' | 'alerting_rules';
+
+        switch (group.label) {
+          case 'Non-rules metrics':
+            filterType = 'non_rules_metrics';
+            break;
+          case 'Recording rules':
+            filterType = 'recording_rules';
+            break;
+          case 'Alerting rules':
+            filterType = 'alerting_rules';
+            break;
+          default:
+            return; // Skip if it's not a recognized rules filter
+        }
+
+        reportSidebarRulesFilterSelected(filterType);
+      });
+    }
   };
 
   public static Component = ({ model }: SceneComponentProps<MetricsFilterSection>) => {

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -135,6 +135,17 @@ export type Interactions = {
     ),
     section?: string
   },
+  // User selects a rules filter from the Wingman sidebar
+  sidebar_rules_filter_selected: {
+    filter_type: (
+      // Standard metrics that are not rules
+      | 'non_rules_metrics'
+      // Recording rules
+      | 'recording_rules'
+      // Alerting rules 
+      | 'alerting_rules'
+    )
+  }
 };
 
 const PREFIX = 'grafana_explore_metrics_';
@@ -195,4 +206,13 @@ export function reportChangeInLabelFilters(
       }
     }
   }
+}
+
+/** Report when a user selects a rules filter from the Wingman sidebar */
+export function reportSidebarRulesFilterSelected(
+  filterType: Interactions['sidebar_rules_filter_selected']['filter_type']
+) {
+  reportExploreMetrics('sidebar_rules_filter_selected', {
+    filter_type: filterType,
+  });
 }


### PR DESCRIPTION
### ✨ Description

create rudderstack event for sidebar rules filters

Ref https://github.com/grafana/metrics-drilldown/issues/304

### 📖 Summary of the changes

1. Added a new event type `sidebar_rules_filter_selected` and a helper function `reportSidebarRulesFilterSelected()` in `interactions.ts`. `sidebar_rules_filter_selected` has 3 filter types:
  - non_rules_metrics
  - recording_rules
  - alerting_rules
2. Update event tracking in 2 places:
  - In the `MetricsFilterSection` component, added tracking to `onSelectionChange` to report when a rules filter is selected
  - In the `CheckBoxList` component, added logic to track when rules filters are cleared

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->
