### PR TITLE
deprecate OTel message

### DIFF
--- a/src/MetricSelect/MetricSelectScene.tsx
+++ b/src/MetricSelect/MetricSelectScene.tsx
@@ -29,7 +29,6 @@ import {
   Input,
   Tooltip,
   useStyles2,
-} from '@grafana/ui';
 import { debounce, isEqual } from 'lodash';
 import React, { useReducer, type SyntheticEvent } from 'react';
 

--- a/src/MetricSelect/MetricSelectScene.tsx
+++ b/src/MetricSelect/MetricSelectScene.tsx
@@ -18,7 +18,19 @@ import {
   type SceneObjectUrlValues,
   type SceneObjectWithUrlSync,
 } from '@grafana/scenes';
-import { Alert, Badge, Combobox, Field, Icon, IconButton, InlineSwitch, Input, Tooltip, useStyles2 } from '@grafana/ui';
+import {
+  Alert,
+  Badge,
+  Combobox,
+  Field,
+  Icon,
+  IconButton,
+  InlineSwitch,
+  Input,
+  Tooltip,
+  useStyles2,
+  useTheme2,
+} from '@grafana/ui';
 import { debounce, isEqual } from 'lodash';
 import React, { useReducer, type SyntheticEvent } from 'react';
 
@@ -576,14 +588,46 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
                 <>
                   <div className={styles.displayOptionTooltip}>
                     Filter by
-                    <IconButton
-                      name={'info-circle'}
-                      size="sm"
-                      variant={'secondary'}
-                      tooltip="This switch enables filtering by OTel resources for OTel native data sources."
-                    />
+                    <Tooltip
+                      content={
+                        <div>
+                          <p>The OTel experience is deprecated in Grafana Metrics Drilldown.</p>
+                          <p>
+                            Please use the following docs to promote your OTel resource attributes to metrics with{' '}
+                            <a
+                              href="https://grafana.com/docs/mimir/latest/configure/configure-otel-collector/#work-with-default-opentelemetry-labels"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              style={{ textDecoration: 'underline' }}
+                            >
+                              Mimir
+                            </a>{' '}
+                            and{' '}
+                            <a
+                              href="https://prometheus.io/docs/guides/opentelemetry/#promoting-resource-attributes"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              style={{ textDecoration: 'underline' }}
+                            >
+                              Prometheus
+                            </a>
+                            .
+                          </p>
+                        </div>
+                      }
+                      placement="bottom"
+                      interactive={true}
+                    >
+                      <IconButton
+                        name={'info-circle'}
+                        size="sm"
+                        variant={'secondary'}
+                        aria-label="Information about OTel experience"
+                      />
+                    </Tooltip>
                     <div>
-                      <Badge text="New" color={'blue'} className={styles.badgeStyle}></Badge>
+                      {/* badge color does not align with theme warning color so we explicitly set it here */}
+                      <Badge text="Deprecated" color={'orange'} className={styles.badgeStyle}></Badge>
                     </div>
                   </div>
                 </>
@@ -674,7 +718,9 @@ function getStyles(theme: GrafanaTheme2) {
       padding: '0rem 0.25rem 0 0.30rem',
       alignItems: 'center',
       borderRadius: theme.shape.radius.pill,
-      border: `1px solid ${theme.colors.info.text}`,
+      border: `1px solid ${theme.colors.warning.text}`,
+      // badge color does not align with theme warning color so we explicitly set it here
+      color: `${theme.colors.warning.text}`,
       background: theme.colors.info.transparent,
       marginTop: '4px',
       marginLeft: '-3px',

--- a/src/MetricSelect/MetricSelectScene.tsx
+++ b/src/MetricSelect/MetricSelectScene.tsx
@@ -29,7 +29,6 @@ import {
   Input,
   Tooltip,
   useStyles2,
-  useTheme2,
 } from '@grafana/ui';
 import { debounce, isEqual } from 'lodash';
 import React, { useReducer, type SyntheticEvent } from 'react';

--- a/src/MetricSelect/MetricSelectScene.tsx
+++ b/src/MetricSelect/MetricSelectScene.tsx
@@ -18,17 +18,7 @@ import {
   type SceneObjectUrlValues,
   type SceneObjectWithUrlSync,
 } from '@grafana/scenes';
-import {
-  Alert,
-  Badge,
-  Combobox,
-  Field,
-  Icon,
-  IconButton,
-  InlineSwitch,
-  Input,
-  Tooltip,
-  useStyles2,
+import { Alert, Badge, Combobox, Field, Icon, IconButton, InlineSwitch, Input, Tooltip, useStyles2 } from '@grafana/ui';
 import { debounce, isEqual } from 'lodash';
 import React, { useReducer, type SyntheticEvent } from 'react';
 


### PR DESCRIPTION
### ✨ Description

Deprecate OTel, add new tooltip info with links and update the badge color

### 📖 Summary of the changes

OTel is being deprecated. [See slack thread for more context](https://raintank-corp.slack.com/archives/C0630AYC4SY/p1745251701160449)

1. [The label promotion initiative is complete and we are promoting resource attributes labels](https://grafana.com/docs/mimir/latest/configure/configure-otel-collector/#work-with-default-opentelemetry-labels)
  a. [more discussion here with promoting resource attributes in Mimir](https://raintank-corp.slack.com/archives/C080PBH5RDX/p1745248945524559?thread_ts=1741679535.372499&cid=C080PBH5RDX)

2. Deprecating the join query supports the [Grafana Drilldown Principal 2](https://docs.google.com/document/d/14WWJ1yF2oN1GLLxD_nCeksa9MOWtaajZeQK0pLoZYtI/edit?tab=t.0#heading=h.cfa5lf38g7md), “Metrics and Logs must remain general purpose”
  a. There are not a lot of customers using OTel in metrics at the moment.
  b . target_info is a special info metric
  c. Future work in Metrics Drilldown can include a feature for creating joins on any info metric as a more general purpose solution

3. The additional resource attributes variables, join query builder and application of these does not migrate well to Metrics Reducer, which is our no. 1 priority this quarter.

### 🧪 How to test?

See the badge is updated and the tooltip links to promoting resources in Mimir and Prometheus.

![Screenshot 2025-04-21 at 12 56 37 PM](https://github.com/user-attachments/assets/c7971cd2-41b1-44c9-a760-e21d3db5c799)
![Screenshot 2025-04-21 at 12 56 48 PM](https://github.com/user-attachments/assets/ed5a2f27-a773-4f21-9504-144fbf8e4f67)

