### PR TITLE
refactor: rule group labels

### DIFF
--- a/src/WingmanDataTrail/MetricsVariables/computeRulesGroups.ts
+++ b/src/WingmanDataTrail/MetricsVariables/computeRulesGroups.ts
@@ -1,3 +1,9 @@
+export const ruleGroupLabels = {
+  metrics: 'Non-rules metrics',
+  rules: 'Recording rules',
+  alerts: 'Alerting rules',
+} as const;
+export type RuleGroupLabel = (typeof ruleGroupLabels)[keyof typeof ruleGroupLabels];
 type MetricType = 'metrics' | 'rules' | 'alerts';
 
 export function computeRulesGroups(options: Array<{ label: string; value: string }>) {
@@ -23,8 +29,8 @@ export function computeRulesGroups(options: Array<{ label: string; value: string
   }
 
   return [
-    { value: '^(?!alert)(?!.*:.*)', label: 'Non-rules metrics', count: rulesMap.get('metrics')!.length },
-    { value: ':', label: 'Recording rules', count: rulesMap.get('rules')!.length },
-    { value: '^alert', label: 'Alerting rules', count: rulesMap.get('alerts')!.length },
+    { value: '^(?!alert)(?!.*:.*)', label: ruleGroupLabels.metrics, count: rulesMap.get('metrics')!.length },
+    { value: ':', label: ruleGroupLabels.rules, count: rulesMap.get('rules')!.length },
+    { value: '^alert', label: ruleGroupLabels.alerts, count: rulesMap.get('alerts')!.length },
   ];
 }

--- a/src/WingmanDataTrail/SideBar/sections/MetricsFilterSection/CheckBoxList.tsx
+++ b/src/WingmanDataTrail/SideBar/sections/MetricsFilterSection/CheckBoxList.tsx
@@ -3,6 +3,8 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { Button, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
+import { type RuleGroupLabel } from 'WingmanDataTrail/MetricsVariables/computeRulesGroups';
+
 import { CheckboxWithCount } from './CheckboxWithCount';
 import { type MetricsFilterSectionState } from './MetricsFilterSection';
 
@@ -38,7 +40,7 @@ export function CheckBoxList({
                 checked={selectedGroups.some((g) => g.value === group.value)}
                 onChange={(e) => {
                   const newGroups = e.currentTarget.checked
-                    ? [...selectedGroups, { label: group.label, value: group.value }]
+                    ? [...selectedGroups, { label: group.label as RuleGroupLabel, value: group.value }]
                     : selectedGroups.filter((v) => v.value !== group.value);
 
                   onSelectionChange(newGroups);

--- a/src/WingmanDataTrail/SideBar/sections/MetricsFilterSection/MetricsFilterSection.tsx
+++ b/src/WingmanDataTrail/SideBar/sections/MetricsFilterSection/MetricsFilterSection.tsx
@@ -13,6 +13,7 @@ import { Icon, IconButton, Input, Spinner, Switch, useStyles2 } from '@grafana/u
 import React, { useMemo, useState, type KeyboardEventHandler } from 'react';
 
 import { EventFiltersChanged } from 'WingmanDataTrail/ListControls/QuickSearch/EventFiltersChanged';
+import { ruleGroupLabels, type RuleGroupLabel } from 'WingmanDataTrail/MetricsVariables/computeRulesGroups';
 import {
   VAR_FILTERED_METRICS_VARIABLE,
   type FilteredMetricsVariable,
@@ -43,7 +44,7 @@ export interface MetricsFilterSectionState extends SideBarSectionState {
   showHideEmpty: boolean;
   showSearch: boolean;
   groups: Array<{ label: string; value: string; count: number }>;
-  selectedGroups: Array<{ label: string; value: string }>; // we need labels for displaying tooltips in `SideBar.tsx`
+  selectedGroups: Array<{ label: RuleGroupLabel; value: string }>; // we need labels for displaying tooltips in `SideBar.tsx`
   loading: boolean;
 }
 
@@ -81,7 +82,7 @@ export class MetricsFilterSection extends SceneObjectBase<MetricsFilterSectionSt
     ) {
       stateUpdate.selectedGroups = (values[this.state.key] as string)
         .split(',')
-        .map((v) => ({ label: v, value: v })) as Array<{ label: string; value: string }>;
+        .map((v) => ({ label: v as RuleGroupLabel, value: v })) as Array<{ label: RuleGroupLabel; value: string }>;
     }
 
     this.setState(stateUpdate);
@@ -187,13 +188,13 @@ export class MetricsFilterSection extends SceneObjectBase<MetricsFilterSectionSt
         let filterType: 'non_rules_metrics' | 'recording_rules' | 'alerting_rules';
 
         switch (group.label) {
-          case LABEL_METRICS:
+          case ruleGroupLabels.metrics:
             filterType = 'non_rules_metrics';
             break;
-          case LABEL_RULES:
+          case ruleGroupLabels.rules:
             filterType = 'recording_rules';
             break;
-          case LABEL_ALERTS:
+          case ruleGroupLabels.alerts:
             filterType = 'alerting_rules';
             break;
           default:


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** This PR supports https://github.com/grafana/metrics-drilldown/pull/310 (and by extension, https://github.com/grafana/metrics-drilldown/issues/304).

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

This refactor aims to reduce the likelihood of disagreements between the rule group labels defined in `src/WingmanDataTrail/MetricsVariables/computeRulesGroups.ts` and the rule group handling logic (see the `switch` statement) in `src/WingmanDataTrail/SideBar/sections/MetricsFilterSection/MetricsFilterSection.tsx`.
