### PR TITLE
fix: e2e test selector

### DIFF
--- a/e2e/fixtures/views/SelectMetricView.ts
+++ b/e2e/fixtures/views/SelectMetricView.ts
@@ -128,7 +128,7 @@ export class SelectMetricView extends DrilldownView {
   /* Otel */
 
   getOtelExperienceSwitch() {
-    return this.page.getByLabel(UI_TEXT.METRIC_SELECT_SCENE.OTEL_LABEL);
+    return this.page.getByLabel(UI_TEXT.METRIC_SELECT_SCENE.OTEL_LABEL, { exact: true });
   }
 
   async assertOtelExperienceSwitchIsVisible() {


### PR DESCRIPTION
This is a one-liner that's required to get e2e tests working after https://github.com/grafana/metrics-drilldown/pull/312 was merged.