### PR TITLE
fix: grafana 12 dev e2e

### DIFF
--- a/e2e/tests/metrics-reducer-view.spec.ts
+++ b/e2e/tests/metrics-reducer-view.spec.ts
@@ -40,6 +40,7 @@ test.describe('Metrics reducer view', () => {
       }
 
       await searchInput.clear();
+      await metricsReducerView.assertMetricsList();
       await expect(page).toHaveScreenshot({
         stylePath: './e2e/fixtures/css/hide-app-controls.css',
       });

--- a/src/WingmanDataTrail/Labels/LabelsDataSource.ts
+++ b/src/WingmanDataTrail/Labels/LabelsDataSource.ts
@@ -73,11 +73,11 @@ export class LabelsDataSource extends RuntimeDataSource {
       const timeRange = sceneGraph.getTimeRange(sceneObject).state.value;
       let response: Record<string, string[]> = {};
 
-      if (ds.languageProvider.fetchLabelsWithMatch.length === 3) {
+      if (ds.languageProvider.fetchLabelsWithMatch.length === 2) {
+        response = await ds.languageProvider.fetchLabelsWithMatch(matcher);
+      } else {
         // @ts-ignore: Ignoring type error due to breaking change in fetchLabelValues signature
         response = await ds.languageProvider.fetchLabelsWithMatch(timeRange, matcher);
-      } else {
-        response = await ds.languageProvider.fetchLabelsWithMatch(matcher);
       }
 
       labelOptions = this.processLabelOptions(


### PR DESCRIPTION
### ✨ Description

This PR aims to fix recent `grafana-dev@12.x` e2e test failures.

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

1. Adjusts the handling of `@grafana/prometheus`' `languageProvider.fetchLabelsWithMatch` function, which acquired another new parameter in https://github.com/grafana/grafana/pull/101705. The way this PR handles the conditional statement should accommodate any further addition of parameters to this function.
2. Adds a new assertion to `e2e/tests/metrics-reducer-view.spec.ts` to reduce flakiness.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

All CI should pass.
