### PR TITLE
fix: hide other metrics var by default

### DIFF
--- a/src/WingmanDataTrail/SideBar/SideBar.tsx
+++ b/src/WingmanDataTrail/SideBar/SideBar.tsx
@@ -168,7 +168,7 @@ export class SideBar extends SceneObjectBase<SideBarState> {
       readOnly: true,
       skipUrlSync: true,
       datasource: null,
-      hide: VariableHide.hideLabel,
+      hide: VariableHide.hideVariable,
       layout: 'combobox',
       applyMode: 'manual',
       allowCustomValue: true,


### PR DESCRIPTION
### ✨ Description

This fixes an issue where the "other metric filters" variable shows up when it's not supposed to.

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

We hide the other metric filters variable by default.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

Have faith in this demo, which shows that the "other metric filters" variable doesn't show up as an empty combobox when navigating back to the Metrics Reducer from a selected metric:

https://github.com/user-attachments/assets/9b72c4c6-20c8-41c5-a32b-a73c7a853487


