### PR TITLE
chore: homepage deprecation warning

### DIFF
--- a/src/DataTrailsHome.tsx
+++ b/src/DataTrailsHome.tsx
@@ -8,6 +8,7 @@ import { testIds } from 'App/testIds';
 import { UI_TEXT } from 'constants/ui';
 
 import { DarkModeRocket, LightModeRocket } from './assets/rockets';
+import { HomepageDeprecationBanner } from './banners/HomepageDeprecationBanner';
 import { type DataTrail } from './DataTrail';
 import { DataTrailsBookmarks } from './DataTrailBookmarks';
 import { DataTrailsRecentMetrics } from './DataTrailsRecentMetrics';
@@ -56,41 +57,44 @@ export class DataTrailsHome extends SceneObjectBase<DataTrailsHomeState> {
     };
 
     return (
-      <article className={styles.container} data-testid={testIds.pageHome.container}>
-        <section className={styles.homepageBox}>
-          <Stack direction="column" alignItems="center">
-            <div>{theme.isDark ? <DarkModeRocket /> : <LightModeRocket />}</div>
-            <Text element="h1" textAlignment="center" weight="medium">
-              {UI_TEXT.HOME.TITLE}
-            </Text>
-            <Box>
-              <Text element="p" textAlignment="center" color="secondary">
-                {UI_TEXT.HOME.SUBTITLE}
-                <TextLink
-                  href="https://grafana.com/docs/grafana/latest/explore/explore-metrics/"
-                  external
-                  style={{ marginLeft: '8px' }}
-                >
-                  Learn more
-                </TextLink>
+      <>
+        <article className={styles.container} data-testid={testIds.pageHome.container}>
+          <HomepageDeprecationBanner />
+          <section className={styles.homepageBox}>
+            <Stack direction="column" alignItems="center">
+              <div>{theme.isDark ? <DarkModeRocket /> : <LightModeRocket />}</div>
+              <Text element="h1" textAlignment="center" weight="medium">
+                {UI_TEXT.HOME.TITLE}
               </Text>
-            </Box>
-            <div className={styles.gap24}>
-              <Button
-                size="lg"
-                variant="primary"
-                onClick={model.onNewMetricsTrail}
-                data-testid={testIds.pageHome.startButton}
-              >
-                <div className={styles.startButton}>{UI_TEXT.HOME.START_BUTTON}</div>
-                <Icon name="arrow-right" size="lg" style={{ marginLeft: '8px' }} />
-              </Button>
-            </div>
-          </Stack>
-        </section>
-        <DataTrailsRecentMetrics onSelect={model.onSelectRecentTrail} />
-        <DataTrailsBookmarks onSelect={model.onSelectBookmark} onDelete={onDelete} />
-      </article>
+              <Box>
+                <Text element="p" textAlignment="center" color="secondary">
+                  {UI_TEXT.HOME.SUBTITLE}
+                  <TextLink
+                    href="https://grafana.com/docs/grafana/latest/explore/explore-metrics/"
+                    external
+                    style={{ marginLeft: '8px' }}
+                  >
+                    Learn more
+                  </TextLink>
+                </Text>
+              </Box>
+              <div className={styles.gap24}>
+                <Button
+                  size="lg"
+                  variant="primary"
+                  onClick={model.onNewMetricsTrail}
+                  data-testid={testIds.pageHome.startButton}
+                >
+                  <div className={styles.startButton}>{UI_TEXT.HOME.START_BUTTON}</div>
+                  <Icon name="arrow-right" size="lg" style={{ marginLeft: '8px' }} />
+                </Button>
+              </div>
+            </Stack>
+          </section>
+          <DataTrailsRecentMetrics onSelect={model.onSelectRecentTrail} />
+          <DataTrailsBookmarks onSelect={model.onSelectBookmark} onDelete={onDelete} />
+        </article>
+      </>
     );
   };
 }

--- a/src/banners/HomepageDeprecationBanner.tsx
+++ b/src/banners/HomepageDeprecationBanner.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { Alert, useStyles2 } from '@grafana/ui';
 import React, { useEffect, useState } from 'react';
 
-const HP_BANNER_KEY = 'homepageDeprecationBanner';
+const HP_BANNER_KEY = 'metricsDrilldownHomepageDeprecationBanner';
 
 export const HomepageDeprecationBanner = () => {
   const [showBanner, setShowBanner] = useState(false);

--- a/src/banners/HomepageDeprecationBanner.tsx
+++ b/src/banners/HomepageDeprecationBanner.tsx
@@ -1,28 +1,39 @@
 import { Alert } from '@grafana/ui';
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 const HP_BANNER_KEY = 'homepageDeprecationBanner';
 
 export const HomepageDeprecationBanner = () => {
-  if (bannerHasBeenShown()) {
+  const [showBanner, setShowBanner] = useState(false);
+
+  useEffect(() => {
+    setShowBanner(!bannerHasBeenShown());
+  }, []);
+
+  if (!showBanner || bannerHasBeenShown()) {
     return null;
   }
 
   const onBannerRemove = () => {
-    bannerHasBeenShown();
+    setBannerHasBeenShown();
+    setShowBanner(false);
   };
 
   return (
-    <Alert title="Homepage deprecation warning" severity="warning" elevated onRemove={onBannerRemove}>
-      This page will be removed soon. Bookmarks will move alongside your list of metrics.
-    </Alert>
+    <div>
+      <Alert title="Homepage deprecation" severity="warning" elevated onRemove={onBannerRemove}>
+        This page will be removed soon.
+        <br />
+        Bookmarks will move alongside your list of metrics.
+      </Alert>
+    </div>
   );
 };
 
-export function setBannerHasBeenShown() {
+function setBannerHasBeenShown() {
   localStorage.setItem(HP_BANNER_KEY, 'true');
 }
 
-export function bannerHasBeenShown() {
+function bannerHasBeenShown() {
   return localStorage.getItem(HP_BANNER_KEY) ?? false;
 }

--- a/src/banners/HomepageDeprecationBanner.tsx
+++ b/src/banners/HomepageDeprecationBanner.tsx
@@ -1,0 +1,28 @@
+import { Alert } from '@grafana/ui';
+import React from 'react';
+
+const HP_BANNER_KEY = 'homepageDeprecationBanner';
+
+export const HomepageDeprecationBanner = () => {
+  if (bannerHasBeenShown()) {
+    return null;
+  }
+
+  const onBannerRemove = () => {
+    bannerHasBeenShown();
+  };
+
+  return (
+    <Alert title="Homepage deprecation warning" severity="warning" elevated onRemove={onBannerRemove}>
+      This page will be removed soon. Bookmarks will move alongside your list of metrics.
+    </Alert>
+  );
+};
+
+export function setBannerHasBeenShown() {
+  localStorage.setItem(HP_BANNER_KEY, 'true');
+}
+
+export function bannerHasBeenShown() {
+  return localStorage.getItem(HP_BANNER_KEY) ?? false;
+}

--- a/src/banners/HomepageDeprecationBanner.tsx
+++ b/src/banners/HomepageDeprecationBanner.tsx
@@ -1,10 +1,12 @@
-import { Alert } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { Alert, useStyles2 } from '@grafana/ui';
 import React, { useEffect, useState } from 'react';
 
 const HP_BANNER_KEY = 'homepageDeprecationBanner';
 
 export const HomepageDeprecationBanner = () => {
   const [showBanner, setShowBanner] = useState(false);
+  const styles = useStyles2(getStyles);
 
   useEffect(() => {
     setShowBanner(!bannerHasBeenShown());
@@ -20,11 +22,13 @@ export const HomepageDeprecationBanner = () => {
   };
 
   return (
-    <div>
+    <div className={styles.container}>
       <Alert title="Homepage deprecation" severity="warning" elevated onRemove={onBannerRemove}>
-        This page will be removed soon.
-        <br />
-        Bookmarks will move alongside your list of metrics.
+        <div className={styles.banner}>
+          This page will be removed soon.
+          <br />
+          Bookmarks will move alongside your list of metrics.
+        </div>
       </Alert>
     </div>
   );
@@ -36,4 +40,19 @@ function setBannerHasBeenShown() {
 
 function bannerHasBeenShown() {
   return localStorage.getItem(HP_BANNER_KEY) ?? false;
+}
+
+function getStyles() {
+  return {
+    container: css({
+      maxWidth: '904px',
+      width: '100%',
+      margin: '0 auto',
+      textAlign: 'center',
+    }),
+    banner: css({
+      maxWidth: '500px',
+      margin: '0 auto',
+    }),
+  };
 }

--- a/src/banners/HomepageDeprecationBanner.tsx
+++ b/src/banners/HomepageDeprecationBanner.tsx
@@ -23,12 +23,9 @@ export const HomepageDeprecationBanner = () => {
 
   return (
     <div className={styles.container}>
-      <Alert title="Homepage deprecation" severity="warning" elevated onRemove={onBannerRemove}>
-        <div className={styles.banner}>
-          This page will be removed soon.
-          <br />
-          Bookmarks will move alongside your list of metrics.
-        </div>
+      <Alert title="Homepage deprecation" severity="info" elevated onRemove={onBannerRemove}>
+        This page will be removed in Grafana Metrics Drilldown v1.0.0. Bookmarks will move alongside your list of
+        metrics.
       </Alert>
     </div>
   );

--- a/src/banners/HomepageDeprecationBanner.tsx
+++ b/src/banners/HomepageDeprecationBanner.tsx
@@ -45,11 +45,6 @@ function getStyles() {
       maxWidth: '904px',
       width: '100%',
       margin: '0 auto',
-      textAlign: 'center',
-    }),
-    banner: css({
-      maxWidth: '500px',
-      margin: '0 auto',
     }),
   };
 }

--- a/src/banners/HomepageDeprecationBanner.tsx
+++ b/src/banners/HomepageDeprecationBanner.tsx
@@ -1,5 +1,5 @@
 import { Alert } from '@grafana/ui';
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 const HP_BANNER_KEY = 'homepageDeprecationBanner';
 


### PR DESCRIPTION
Supports: https://github.com/grafana/metrics-drilldown/issues/255

Uses localStorage to only show it once

<img width="1063" alt="image" src="https://github.com/user-attachments/assets/32dca3a7-2c8b-4216-9017-d0bfb5a94fb6" />


