### PR TITLE
fix(ListControls): Fix extra padding between sort and layout switch

### DIFF
--- a/src/WingmanDataTrail/ListControls/ListControls.tsx
+++ b/src/WingmanDataTrail/ListControls/ListControls.tsx
@@ -37,7 +37,7 @@ export class ListControls extends EmbeddedScene {
             body: new QuickSearch(),
           }),
           new SceneFlexItem({
-            maxWidth: '240px',
+            width: 'auto',
             body: new MetricsSorter({}),
           }),
           new SceneFlexItem({


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** fixes https://github.com/grafana/metrics-drilldown/issues/332

### 📖 Summary of the changes

| Before | After |
|  ---   |  ---  |
| <img width="1699" alt="image" src="https://github.com/user-attachments/assets/0d9ebaa7-7270-4ae5-a391-c3eb7f68fbad" /> | <img width="1701" alt="image" src="https://github.com/user-attachments/assets/2773de5b-7935-4f27-86a9-3c37d15c5d3c" /> |

### 🧪 How to test?

`-`
