### PR TITLE
Chore: Disable quick search clear button when there's no input

### DIFF
--- a/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx
+++ b/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx
@@ -176,7 +176,13 @@ export class QuickSearch extends SceneObjectBase<QuickSearchState> {
             <Tooltip content={tooltipContent} placement="top">
               <Tag className={styles.counts} name={tagName} colorIndex={9} />
             </Tooltip>
-            <IconButton name="times" variant="secondary" tooltip="Clear search" onClick={model.clear} />
+            <IconButton
+              name="times"
+              variant="secondary"
+              tooltip="Clear search"
+              onClick={model.clear}
+              disabled={!value}
+            />
           </>
         }
       />


### PR DESCRIPTION
### ✨ Description

Disable quick search clear button when there's no input

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/80c35d54-d5f8-4477-85ca-e5114e7b9374" />

### 🧪 How to test?

Don't type anything into the search bar, see that the clear search button is disabled
