### PR TITLE
feat(AppHeader): Hide settings button in the Metrics Reducer view

### DIFF
--- a/src/DataTrailSettings.tsx
+++ b/src/DataTrailSettings.tsx
@@ -38,7 +38,11 @@ export class DataTrailSettings extends SceneObjectBase<DataTrailSettingsState> {
     const trail = getTrailFor(model);
     const { topScene } = trail.useState();
 
-    const isButtonEnabled = topScene instanceof MetricScene;
+    const isButtonVisible = topScene instanceof MetricScene;
+
+    if (!isButtonVisible) {
+      return null;
+    }
 
     const renderPopover = () => {
       return (
@@ -56,13 +60,7 @@ export class DataTrailSettings extends SceneObjectBase<DataTrailSettingsState> {
 
     return (
       <Dropdown overlay={renderPopover} placement="bottom" onVisibleChange={model.onToggleOpen}>
-        <ToolbarButton
-          icon="cog"
-          variant="canvas"
-          isOpen={isOpen}
-          data-testid="settings-button"
-          disabled={!isButtonEnabled}
-        />
+        <ToolbarButton icon="cog" variant="canvas" isOpen={isOpen} data-testid="settings-button" />
       </Dropdown>
     );
   };


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

The side bar of the Metrics Reducer view has already a "Settings" section, so this PR hides the settings button in the app header.

| Before | After |
|  ---   |  ---  |
| <img width="1705" alt="image" src="https://github.com/user-attachments/assets/f19f405d-fcaf-4ab7-acb7-d27dcd750aca" />| <img width="1704" alt="image" src="https://github.com/user-attachments/assets/f7a88715-9b29-41ff-a0f5-f46e550f8169" /> |

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

The settings button should be hidden in the Metrics Reducer view and visible in the Metric Scene
