### PR TITLE
fix(MetricsReducer): Apply ad hoc filters when group by is active

### DIFF
--- a/src/WingmanDataTrail/GroupBy/MetricsWithLabelValue/MetricsWithLabelValueDataSource.ts
+++ b/src/WingmanDataTrail/GroupBy/MetricsWithLabelValue/MetricsWithLabelValueDataSource.ts
@@ -56,7 +56,7 @@ export class MetricsWithLabelValueDataSource extends RuntimeDataSource {
     const timeRange = sceneGraph.getTimeRange(sceneObject).state.value;
     let metricsList: string[] = [];
 
-    let removeRules = query.startsWith('removeRules');
+    const removeRules = query.startsWith('removeRules');
     const matcher = removeRules ? query.replace('removeRules', '') : query;
 
     if (ds.languageProvider.fetchLabelValues.length === 2) {

--- a/src/WingmanDataTrail/GroupBy/MetricsWithLabelValue/MetricsWithLabelValueVariable.ts
+++ b/src/WingmanDataTrail/GroupBy/MetricsWithLabelValue/MetricsWithLabelValueVariable.ts
@@ -1,7 +1,7 @@
 import { VariableHide, VariableRefresh } from '@grafana/data';
 import { QueryVariable, sceneGraph } from '@grafana/scenes';
 
-import { VAR_FILTERS } from 'shared';
+import { VAR_FILTERS, VAR_FILTERS_EXPR } from 'shared';
 import { withLifecycleEvents } from 'WingmanDataTrail/MetricsVariables/withLifecycleEvents';
 
 import { MetricsWithLabelValueDataSource } from './MetricsWithLabelValueDataSource';
@@ -51,6 +51,8 @@ export class MetricsWithLabelValueVariable extends QueryVariable {
   }
 
   private static buildQuery(labelName: string, labelValue: string, removeRules?: boolean) {
-    return removeRules ? `removeRules{${labelName}="${labelValue}"}` : `{${labelName}="${labelValue}"}`;
+    return removeRules
+      ? `removeRules{${labelName}="${labelValue}",${VAR_FILTERS_EXPR}}`
+      : `{${labelName}="${labelValue}",${VAR_FILTERS_EXPR}}`;
   }
 }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `.`

Before this PR, the ad hoc filters were not applied when a "group by" label had been selected.

| Before | After |
|  ---   |  ---  |
|<img width="1703" alt="image" src="https://github.com/user-attachments/assets/77fb5f26-c9e2-4aed-9954-1d414cf4ed65" />  | <img width="1703" alt="image" src="https://github.com/user-attachments/assets/2c469b12-5e93-43b9-8109-669aecda3c71" /> |

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- Open the side bar to select a "group by" label
- Add some filters in the app header
- The metrics for each label should correspond to the selected filters
