### PR TITLE
feat(PanelActions): Use outline style buttons throughout the app

### DIFF
--- a/src/Breakdown/AddToFiltersGraphAction.tsx
+++ b/src/Breakdown/AddToFiltersGraphAction.tsx
@@ -78,7 +78,7 @@ export class AddToFiltersGraphAction extends SceneObjectBase<AddToFiltersGraphAc
     }
 
     return (
-      <Button variant="secondary" size="sm" fill="solid" onClick={model.onClick}>
+      <Button variant="secondary" size="sm" fill="outline" onClick={model.onClick}>
         Add to filters
       </Button>
     );

--- a/src/Breakdown/LabelBreakdownScene.tsx
+++ b/src/Breakdown/LabelBreakdownScene.tsx
@@ -640,7 +640,7 @@ export class SelectLabelAction extends SceneObjectBase<SelectLabelActionState> {
 
   public static Component = ({ model }: SceneComponentProps<AddToFiltersGraphAction>) => {
     return (
-      <Button variant="secondary" size="sm" fill="solid" onClick={model.onClick}>
+      <Button variant="secondary" size="sm" fill="outline" onClick={model.onClick}>
         Select
       </Button>
     );

--- a/src/MetricSelect/SelectMetricAction.tsx
+++ b/src/MetricSelect/SelectMetricAction.tsx
@@ -17,7 +17,7 @@ export class SelectMetricAction extends SceneObjectBase<SelectMetricActionState>
   public static Component = ({ model }: SceneComponentProps<SelectMetricAction>) => {
     const { title, metric } = model.useState();
     return (
-      <Button variant="secondary" size="sm" fill="solid" onClick={model.onClick} data-testid={`select ${metric}`}>
+      <Button variant="primary" size="sm" fill="outline" onClick={model.onClick} data-testid={`select ${metric}`}>
         {title}
       </Button>
     );

--- a/src/WingmanDataTrail/MetricVizPanel/actions/ApplyAction.tsx
+++ b/src/WingmanDataTrail/MetricVizPanel/actions/ApplyAction.tsx
@@ -43,7 +43,7 @@ export class ApplyAction extends SceneObjectBase<ApplyActionState> {
     return (
       <Button
         variant="primary"
-        fill="text"
+        fill="outline"
         size="sm"
         className={styles.selectButton}
         onClick={model.onClick}

--- a/src/WingmanDataTrail/MetricVizPanel/actions/SelectAction.tsx
+++ b/src/WingmanDataTrail/MetricVizPanel/actions/SelectAction.tsx
@@ -1,6 +1,5 @@
-import { css } from '@emotion/css';
 import { SceneObjectBase, type SceneComponentProps, type SceneObjectState } from '@grafana/scenes';
-import { Button, useStyles2 } from '@grafana/ui';
+import { Button } from '@grafana/ui';
 import React from 'react';
 
 import { MetricSelectedEvent } from 'shared';
@@ -25,7 +24,7 @@ export class SelectAction extends SceneObjectBase<SelectActionState> {
       key: `select-action-${metricName}`,
       metricName,
       variant: variant || 'primary',
-      fill: fill || 'text',
+      fill: fill || 'outline',
     });
   }
 
@@ -34,7 +33,6 @@ export class SelectAction extends SceneObjectBase<SelectActionState> {
   };
 
   public static Component = ({ model }: SceneComponentProps<SelectAction>) => {
-    const styles = useStyles2(getStyles);
     const { variant, fill } = model.useState();
 
     return (
@@ -42,7 +40,6 @@ export class SelectAction extends SceneObjectBase<SelectActionState> {
         variant={variant}
         fill={fill}
         size="sm"
-        className={styles.selectButton}
         onClick={model.onClick}
         data-testid={`select-action-${model.state.metricName}`}
       >
@@ -51,7 +48,3 @@ export class SelectAction extends SceneObjectBase<SelectActionState> {
     );
   };
 }
-
-const getStyles = () => ({
-  selectButton: css``,
-});


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** solves https://github.com/grafana/metrics-drilldown/issues/345

See [this Slack thread](https://raintank-corp.slack.com/archives/C075BDBTX96/p1745508389865759) for the rationale and consensus.

### 📖 Summary of the changes

**Metrics reducer:**
<img width="1702" alt="image" src="https://github.com/user-attachments/assets/cc2de55c-9149-402e-86cf-5ac194ee3410" />

**Configure drawer:**
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/0f9f339a-ec42-4be0-8760-cf9ec2f18d6f" />

**Breakdown (uses a secondary variant):**
<img width="842" alt="image" src="https://github.com/user-attachments/assets/728d62e1-b3d8-45dd-aae9-774b21bbc782" />

**Related metrics:**
<img width="1126" alt="image" src="https://github.com/user-attachments/assets/227eeab9-9921-4c45-ba8f-9811ed2cdfa9" />

### 🧪 How to test?

`-`
