### PR TITLE
fix(queries): add filters as matchers for each panel

### DIFF
--- a/src/WingmanDataTrail/MetricsList/SimpleMetricsList.tsx
+++ b/src/WingmanDataTrail/MetricsList/SimpleMetricsList.tsx
@@ -16,7 +16,9 @@ import React from 'react';
 
 import { InlineBanner } from 'App/InlineBanner';
 import { WithUsageDataPreviewPanel } from 'MetricSelect/WithUsageDataPreviewPanel';
+import { VAR_FILTERS } from 'shared';
 import { getColorByIndex, getTrailFor } from 'utils';
+import { isAdHocFiltersVariable } from 'utils/utils.variables';
 import { LayoutSwitcher, LayoutType, type LayoutSwitcherState } from 'WingmanDataTrail/ListControls/LayoutSwitcher';
 import {
   VAR_FILTERED_METRICS_VARIABLE,
@@ -27,8 +29,6 @@ import {
   MetricVizPanel,
 } from 'WingmanDataTrail/MetricVizPanel/MetricVizPanel';
 import { SceneByVariableRepeater } from 'WingmanDataTrail/SceneByVariableRepeater/SceneByVariableRepeater';
-import { VAR_FILTERS } from 'shared';
-import { isAdHocFiltersVariable } from 'utils/utils.variables';
 
 export const GRID_TEMPLATE_COLUMNS = 'repeat(auto-fit, minmax(400px, 1fr))';
 export const GRID_TEMPLATE_ROWS = '1fr';


### PR DESCRIPTION
### ✨ Description

Filters are not used in queries with matchers

<img width="1021" alt="Screenshot 2025-04-28 at 4 42 03 PM" src="https://github.com/user-attachments/assets/baca20a2-bb7b-49a2-9b4f-b4b8b211ec58" />

### 📖 Summary of the changes

Get label filters from VAR_FILTERS to pass into the `MetricVizPanel` to use in queries

### 🧪 How to test?

See `duration_seconds` in the otel friendly data source. This metric requires a filter. In this example we see service_name.

Without this filter used ion the query, we get what looks like an empty query

<img width="957" alt="Screenshot 2025-04-28 at 9 07 59 PM" src="https://github.com/user-attachments/assets/092106ca-5917-45ca-b020-05a0d33c728b" />

With the filters in the query we get a normal looking heatmap

<img width="974" alt="Screenshot 2025-04-28 at 9 08 19 PM" src="https://github.com/user-attachments/assets/3481fcb9-03d0-4dbf-b8f4-2a37876b25d9" />


