### PR TITLE
Fix (hack): Show menu always for breakdown panels

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -7,7 +7,6 @@ import React, { createContext, useEffect, useState } from 'react';
 import { type DataTrail } from 'DataTrail';
 import { initFaro } from 'tracking/faro/faro';
 import { getUrlForTrail, newMetricsTrail } from 'utils';
-// Import our custom CSS for panel menu overrides
 import '../showMenuInBreakdown.css';
 
 import { ErrorView } from './ErrorView';

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -7,6 +7,8 @@ import React, { createContext, useEffect, useState } from 'react';
 import { type DataTrail } from 'DataTrail';
 import { initFaro } from 'tracking/faro/faro';
 import { getUrlForTrail, newMetricsTrail } from 'utils';
+// Import our custom CSS for panel menu overrides
+import '../showMenuInBreakdown.css';
 
 import { ErrorView } from './ErrorView';
 import { AppRoutes } from './Routes';

--- a/src/showMenuInBreakdown.css
+++ b/src/showMenuInBreakdown.css
@@ -1,0 +1,28 @@
+/* Override for panel menu buttons to always show */
+.panel-menu-toggle.show-on-hover,
+.panel-menu-toggle,
+div[data-testid='panel-menu-button'],
+button[data-testid='panel-menu-button'],
+button.show-on-hover,
+[class*='css-'][class*='toolbar-button-panel-menu'] {
+  visibility: visible !important;
+  opacity: 1 !important;
+  display: block !important;
+}
+
+/* Fix for panel header hover states */
+.panel-header:hover,
+.panel-header {
+  background-color: transparent;
+}
+
+.panel-title-container,
+.panel-title-text {
+  cursor: auto;
+}
+
+/* Remove any transitions that might affect visibility */
+[class*='panel-menu'],
+[class*='toolbar-button'] {
+  transition: none !important;
+}


### PR DESCRIPTION
### ✨ Description

This is a hack and I don't think it's the best solution. It seems since the breakdown panels use the same logic as the large metric panel, the large metric panel also has the menu visible without hover

#### Before
![image](https://github.com/user-attachments/assets/5d3932ba-833a-48a3-9161-b99a29218e71)


#### After
![image](https://github.com/user-attachments/assets/19d1db19-e081-4abc-8ac5-ca0ab606334e)


Ref https://github.com/grafana/metrics-drilldown/issues/358

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->
