### PR TITLE
chore: track sort by usage in the metrics reducer

### DIFF
--- a/src/Breakdown/ByFrameRepeater.tsx
+++ b/src/Breakdown/ByFrameRepeater.tsx
@@ -16,6 +16,7 @@ import { Alert, Button } from '@grafana/ui';
 import React from 'react';
 
 import { BreakdownSearchReset } from './BreakdownSearchScene';
+import { type LabelBreakdownSortingOption } from './SortByScene';
 import { findSceneObjectsByType } from './utils';
 import { getLabelValueFromDataFrame } from '../services/levels';
 import { fuzzySearch } from '../services/search';
@@ -32,7 +33,7 @@ type FrameIterateCallback = (frames: DataFrame[], seriesIndex: number) => void;
 
 export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
   private unfilteredChildren: SceneFlexItem[] = [];
-  private sortBy: string;
+  private sortBy: LabelBreakdownSortingOption;
   private sortedSeries: DataFrame[] = [];
   private getFilter: () => string;
 
@@ -40,7 +41,7 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     sortBy,
     getFilter,
     ...state
-  }: ByFrameRepeaterState & { sortBy: string; getFilter: () => string }) {
+  }: ByFrameRepeaterState & { sortBy: LabelBreakdownSortingOption; getFilter: () => string }) {
     super(state);
 
     this.sortBy = sortBy;
@@ -74,7 +75,7 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     });
   }
 
-  public sort = (sortBy: string) => {
+  public sort = (sortBy: LabelBreakdownSortingOption) => {
     const data = sceneGraph.getData(this);
     this.sortBy = sortBy;
     if (data.state.data) {

--- a/src/Breakdown/LabelBreakdownScene.tsx
+++ b/src/Breakdown/LabelBreakdownScene.tsx
@@ -234,7 +234,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
         }
       });
     }
-    reportExploreMetrics('sorting_changed', { sortBy: event.sortBy });
+    reportExploreMetrics('sorting_changed', { from: 'label-breakdown', sortBy: event.sortBy });
   };
 
   private onReferencedVariableValueChanged() {

--- a/src/Breakdown/SortByScene.tsx
+++ b/src/Breakdown/SortByScene.tsx
@@ -1,43 +1,45 @@
 import { css } from '@emotion/css';
-import { BusEventBase, type GrafanaTheme2, type SelectableValue } from '@grafana/data';
+import { BusEventBase, type GrafanaTheme2 } from '@grafana/data';
 import { SceneObjectBase, type SceneComponentProps, type SceneObjectState } from '@grafana/scenes';
-import { Combobox, Field, IconButton, useStyles2 } from '@grafana/ui';
+import { Combobox, Field, IconButton, useStyles2, type ComboboxOption } from '@grafana/ui';
 import React from 'react';
 
 import { getSortByPreference, setSortByPreference } from '../services/store';
 
 export interface SortBySceneState extends SceneObjectState {
   target: 'fields' | 'labels';
-  sortBy: string;
+  sortBy: LabelBreakdownSortingOption;
 }
 
 export class SortCriteriaChanged extends BusEventBase {
-  constructor(public target: 'fields' | 'labels', public sortBy: string) {
+  constructor(public target: 'fields' | 'labels', public sortBy: LabelBreakdownSortingOption) {
     super();
   }
 
   public static type = 'sort-criteria-changed';
 }
 
-export class SortByScene extends SceneObjectBase<SortBySceneState> {
-  public sortingOptions = [
-    {
-      value: 'outliers',
-      label: 'Outlying series',
-      description: 'Prioritizes values that show distinct behavior from others within the same label',
-    },
-    {
-      value: 'alphabetical',
-      label: 'Name [A-Z]',
-      description: 'Alphabetical order',
-    },
-    {
-      value: 'alphabetical-reversed',
-      label: 'Name [Z-A]',
-      description: 'Reversed alphabetical order',
-    },
-  ];
+export type LabelBreakdownSortingOption = 'outliers' | 'alphabetical' | 'alphabetical-reversed';
 
+const sortingOptions: Array<ComboboxOption<LabelBreakdownSortingOption>> = [
+  {
+    value: 'outliers',
+    label: 'Outlying series',
+    description: 'Prioritizes values that show distinct behavior from others within the same label',
+  },
+  {
+    value: 'alphabetical',
+    label: 'Name [A-Z]',
+    description: 'Alphabetical order',
+  },
+  {
+    value: 'alphabetical-reversed',
+    label: 'Name [Z-A]',
+    description: 'Reversed alphabetical order',
+  },
+];
+
+export class SortByScene extends SceneObjectBase<SortBySceneState> {
   constructor(state: Pick<SortBySceneState, 'target'>) {
     const { sortBy } = getSortByPreference(state.target, 'outliers');
     super({
@@ -46,7 +48,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
     });
   }
 
-  public onCriteriaChange = (criteria: SelectableValue<string> | null) => {
+  public onCriteriaChange = (criteria: ComboboxOption<LabelBreakdownSortingOption> | null) => {
     if (!criteria?.value) {
       return;
     }
@@ -58,7 +60,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
   public static Component = ({ model }: SceneComponentProps<SortByScene>) => {
     const styles = useStyles2(getStyles);
     const { sortBy } = model.useState();
-    const value = model.sortingOptions.find((option) => option.value === sortBy);
+    const value = sortingOptions.find((option) => option.value === sortBy);
     return (
       <Field
         htmlFor="sort-by-criteria"
@@ -78,7 +80,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
           id="sort-by-criteria"
           value={value}
           width={20}
-          options={model.sortingOptions}
+          options={sortingOptions}
           placeholder={'Choose criteria'}
           onChange={model.onCriteriaChange}
           isClearable={false}

--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -17,6 +17,7 @@ import {
 import { useStyles2 } from '@grafana/ui';
 import React from 'react';
 
+import { reportExploreMetrics } from 'interactions';
 import { getColorByIndex, getTrailFor } from 'utils';
 
 import { MetricSelectedEvent } from '../shared';
@@ -208,6 +209,8 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
         for (const [, { sortEngine }] of this.state.enginesMap) {
           sortEngine.sort(sortBy);
         }
+
+        reportExploreMetrics('sorting_changed', { from: 'metrics-reducer', sortBy });
       })
     );
   }

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -1,6 +1,9 @@
 import { type AdHocVariableFilter } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 
+import { type LabelBreakdownSortingOption as BreakdownSortByOption } from 'Breakdown/SortByScene';
+import { type SortingOption as MetricsReducerSortByOption } from 'WingmanDataTrail/ListControls/MetricsSorter/MetricsSorter';
+
 import { type BreakdownLayoutType } from './Breakdown/types';
 import { type ActionViewType } from './MetricScene';
 
@@ -109,8 +112,15 @@ export type Interactions = {
     )
   };
   sorting_changed: {
-      // type of sorting
-      sortBy: string
+    // By clicking on the sort by variable in the metrics reducer
+    from: 'metrics-reducer',
+    // The sort by option selected
+    sortBy: MetricsReducerSortByOption
+  } | {
+    // By clicking on the sort by component in the label breakdown
+    from: 'label-breakdown',
+    // The sort by option selected
+    sortBy: BreakdownSortByOption
   };
   wasm_not_supported: {},
   missing_otel_labels_by_truncating_job_and_instance: {

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -1,3 +1,5 @@
+import { type LabelBreakdownSortingOption } from 'Breakdown/SortByScene';
+
 import { OTEL_EXPERIENCE_ENABLED_KEY, TRAIL_BREAKDOWN_SORT_KEY, TRAIL_BREAKDOWN_VIEW_KEY } from '../shared';
 
 export function getVewByPreference() {
@@ -8,16 +10,19 @@ export function setVewByPreference(value?: string) {
   return localStorage.setItem(TRAIL_BREAKDOWN_VIEW_KEY, value ?? 'grid');
 }
 
-export function getSortByPreference(target: string, defaultSortBy: string) {
+export function getSortByPreference(
+  target: string,
+  defaultSortBy: LabelBreakdownSortingOption
+): { sortBy: LabelBreakdownSortingOption; direction?: string } {
   const preference = localStorage.getItem(`${TRAIL_BREAKDOWN_SORT_KEY}.${target}.by`) ?? '';
   const parts = preference.split('.');
   if (!parts[0] || !parts[1]) {
     return { sortBy: defaultSortBy };
   }
-  return { sortBy: parts[0], direction: parts[1] };
+  return { sortBy: parts[0] as LabelBreakdownSortingOption, direction: parts[1] };
 }
 
-export function setSortByPreference(target: string, sortBy: string) {
+export function setSortByPreference(target: string, sortBy: LabelBreakdownSortingOption) {
   // Prevent storing empty values
   if (sortBy) {
     localStorage.setItem(`${TRAIL_BREAKDOWN_SORT_KEY}.${target}.by`, `${sortBy}`);


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** This PR supports #304.

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

The goal of this PR is to extend event tracking for `sortBy`, to capture sorting changes in the Metrics Reducer. Previously, we were tracking `sortBy` in the context of the breakdown scene, when selecting a label name (not "All"):

<img width="1354" alt="demo sort by in breakdown" src="https://github.com/user-attachments/assets/f496d53a-f237-45dd-8fd8-5d7b2b3ec630" />

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

This PR adapts the `'sorting_changed'` interaction to deal with sorting changes in both the label breakdown scene and the metrics reducer. By using a [discriminated union](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#discriminated-unions) in `src/interactions.ts`, we can support both Sort By controls (each with their own options) with great type safety (`sortBy` values match the options in each scene).
