### PR TITLE
chore: track group by label usage

### DIFF
--- a/src/WingmanDataTrail/SideBar/sections/LabelsBrowser/LabelsBrowser.tsx
+++ b/src/WingmanDataTrail/SideBar/sections/LabelsBrowser/LabelsBrowser.tsx
@@ -7,6 +7,7 @@ import React, { useMemo, useState } from 'react';
 import { NULL_GROUP_BY_VALUE } from 'WingmanDataTrail/Labels/LabelsDataSource';
 import { type LabelsVariable } from 'WingmanDataTrail/Labels/LabelsVariable';
 
+import { reportExploreMetrics } from '../../../../interactions';
 import { EventSectionValueChanged } from '../EventSectionValueChanged';
 import { SectionTitle } from '../SectionTitle';
 import { type SideBarSectionState } from '../types';
@@ -67,6 +68,7 @@ export class LabelsBrowser extends SceneObjectBase<LabelsBrowserState> {
 
   private onClickLabel = (label: string) => {
     this.selectLabel(label);
+    reportExploreMetrics('sidebar_group_by_label_filter_applied', { label });
   };
 
   private onClickClearSelection = () => {

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -165,6 +165,11 @@ export type Interactions = {
       | 'non_rules_metrics'
       | 'recording_rules'
     )
+  },
+  // User applies a label filter from the sidebar
+  sidebar_group_by_label_filter_applied: {
+    // The label that was applied (optional)
+    label?: string;
   }
 };
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** This PR supports #304.

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

The goal of this PR is to add event tracking for "group by label" filtering in the Metrics Reducer sidebar.

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

See diff.
