### PR TITLE
chore: create rudderstack event for quick search

### DIFF
--- a/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx
+++ b/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx
@@ -23,6 +23,7 @@ import {
 import { VAR_METRICS_VARIABLE, type MetricsVariable } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
 
 import { EventQuickSearchChanged } from './EventQuickSearchChanged';
+import { reportExploreMetrics } from '../../../interactions';
 
 interface QuickSearchState extends SceneObjectState {
   value: string;
@@ -115,6 +116,11 @@ export class QuickSearch extends SceneObjectBase<QuickSearchState> {
 
   private notifyValueChange = debounce((value: string) => {
     this.publishEvent(new EventQuickSearchChanged({ searchText: value }), true);
+
+    // Track when a user types in the search bar (simplified)
+    if (value) {
+      reportExploreMetrics('quick_search_used', {});
+    }
   }, 250);
 
   private updateValue(value: string) {

--- a/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx
+++ b/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx
@@ -117,11 +117,11 @@ export class QuickSearch extends SceneObjectBase<QuickSearchState> {
   private notifyValueChange = debounce((value: string) => {
     this.publishEvent(new EventQuickSearchChanged({ searchText: value }), true);
 
-    // Track when a user types in the search bar (simplified)
+    // Report when a user completes typing (after 1 second)
     if (value) {
       reportExploreMetrics('quick_search_used', {});
     }
-  }, 250);
+  }, 1000);
 
   private updateValue(value: string) {
     this.setState({ value });

--- a/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx
+++ b/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx
@@ -116,12 +116,7 @@ export class QuickSearch extends SceneObjectBase<QuickSearchState> {
 
   private notifyValueChange = debounce((value: string) => {
     this.publishEvent(new EventQuickSearchChanged({ searchText: value }), true);
-
-    // Report when a user completes typing (after 1 second)
-    if (value) {
-      reportExploreMetrics('quick_search_used', {});
-    }
-  }, 1000);
+  }, 250);
 
   private updateValue(value: string) {
     this.setState({ value });

--- a/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx
+++ b/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx
@@ -23,8 +23,6 @@ import {
 import { VAR_METRICS_VARIABLE, type MetricsVariable } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
 
 import { EventQuickSearchChanged } from './EventQuickSearchChanged';
-import { reportExploreMetrics } from '../../../interactions';
-
 interface QuickSearchState extends SceneObjectState {
   value: string;
   counts: { current: number; total: number };

--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -15,6 +15,7 @@ import {
   type SceneObjectState,
 } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
+import { debounce } from 'lodash';
 import React from 'react';
 
 import { reportExploreMetrics } from 'interactions';
@@ -69,6 +70,13 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
       this.updateBodyBasedOnGroupBy((variable as LabelsVariable).state.value as string);
     },
   });
+
+  // Report when a user completes typing (after 1 second)
+  private readonly _debounceReportQuickSearchChange = debounce((searchText: string) => {
+    if (searchText) {
+      reportExploreMetrics('quick_search_used', {});
+    }
+  }, 1000);
 
   public constructor() {
     super({
@@ -186,6 +194,8 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
           filterEngine.applyFilters({ names: searchText ? [searchText] : [] });
           sortEngine.sort(sortByVariable.state.value as SortingOption);
         }
+
+        this._debounceReportQuickSearchChange(searchText);
       })
     );
 

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -112,8 +112,7 @@ export type Interactions = {
     )
   };
   // User types in the quick search bar
-  quick_search_used: {
-  };
+  quick_search_used: {};
   sorting_changed: {
     // By clicking on the sort by variable in the metrics reducer
     from: 'metrics-reducer',

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -111,6 +111,9 @@ export type Interactions = {
       | 'close'
     )
   };
+  // User types in the quick search bar
+  quick_search_used: {
+  };
   sorting_changed: {
     // By clicking on the sort by variable in the metrics reducer
     from: 'metrics-reducer',


### PR DESCRIPTION
### ✨ Description

create rudderstack event for quick search

event only fires after a user has stopped typing for 1 second to prevent firing the event multiple times for a single search

ref https://github.com/grafana/metrics-drilldown/issues/304

### 📖 Summary of the changes

1. added new event type `quick_search_used` to `Interactions` interface
2. report the event when user types into quick search bar 

### 🧪 How to test?

i added `console.logs` in the code locally and saw them appear when typing into the quick search bar. you can see that typing quickly (alert) and slowly (kube) fires the event one time each
![image](https://github.com/user-attachments/assets/c717acd7-663f-41e3-8241-c1b68d88bd36)


https://github.com/user-attachments/assets/e753e42c-3eaa-4dc9-874f-8964e00a7282

