### PR TITLE
Bug: fetchLabelValues old params were 1 and new with Timerange are 2

### DIFF
--- a/src/helpers/MetricDatasourceHelper.ts
+++ b/src/helpers/MetricDatasourceHelper.ts
@@ -205,7 +205,7 @@ export class MetricDatasourceHelper {
     // This works because the `fetchLabelValues` method happens to have changed in a way that
     // can be used as a heuristic to check if the runtime datasource uses the G12-style
     // language provider methods introduced in https://github.com/grafana/grafana/pull/101889.
-    return ds.languageProvider.fetchLabelValues.length > 2;
+    return ds.languageProvider.fetchLabelValues.length > 1;
   }
 }
 


### PR DESCRIPTION
**UPDATE** ❇️❇️❇️❇️❇️❇️❇️❇️❇️❇️❇️❇️❇️❇️

The most up to date signature is 3 parameters

[A limit param was added recently](https://github.com/grafana/grafana/pull/101705/files#r2074252669).

Old versions still require a check > 1. As long as we check for > 1 we still cover the issue of Timerange being the first parameter.

❇️❇️❇️❇️❇️❇️❇️❇️❇️❇️❇️❇️❇️❇️❇️❇️❇️❇️

**What is this?** Bug fix with changed signature

**What code was changed**

`fetchLabelValues` old signature had one parameter.

The new signature has two.

So, we should check for >1 when we need to add the timerange parameter.

**How to test?**

Group by labels should not break like this

<img width="588" alt="Screenshot 2025-05-05 at 1 31 26 PM" src="https://github.com/user-attachments/assets/22589b0a-c702-4011-8cdf-6b186cbc6531" />
