### PR TITLE
docs: Update doc link in readme

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -8,7 +8,7 @@ Requires Grafana 11.6.0 or newer.
 
 ## Getting Started
 
-See the [docs](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/metrics/#standalone-experience) for more info using Grafana Metrics Drilldown.
+See the [docs](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/metrics/) for more info using Grafana Metrics Drilldown.
 
 ## Documentation
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/metrics-drilldown/issues/286

This PR updates a doc link in the readme to point to the new docs.