### PR TITLE
fix: retry until assertion passes

### DIFF
--- a/e2e/tests/metrics-reducer-view.spec.ts
+++ b/e2e/tests/metrics-reducer-view.spec.ts
@@ -51,10 +51,13 @@ test.describe('Metrics reducer view', () => {
         await metricsReducerView.changeSortOption(sortOption);
 
         // Wait for the usage count to load
-        const firstPanel = metricsReducerView.getByTestId('with-usage-data-preview-panel').first();
-        const usageElement = firstPanel.locator(`[data-testid="${usageType}-usage"]`);
-        const usageCount = parseInt((await usageElement.textContent()) || '0', 10);
-        expect(usageCount).toBeGreaterThan(0);
+        // eslint-disable-next-line sonarjs/no-nested-functions
+        await expect(async () => {
+          const firstPanel = await metricsReducerView.getByTestId('with-usage-data-preview-panel').first();
+          const usageElement = firstPanel.locator(`[data-testid="${usageType}-usage"]`);
+          const usageCount = parseInt((await usageElement.textContent()) || '0', 10);
+          expect(usageCount).toBeGreaterThan(0);
+        }).toPass();
 
         // Verify metrics are sorted by alerting usage count
         const usageCounts: Record<string, number> = {};


### PR DESCRIPTION
### ✨ Description

A change [here](https://github.com/grafana/metrics-drilldown/pull/376/files#diff-889ff398a9844294fd45acd689975a41466b984ef8b124b1cae2013f159126f7) caused an e2e test to be flaky.

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

This PR restores the `expect(...).toPass()` wrapper around the usage count assertion. This tells Playwright to keep trying the assertion until is passes, which avoids erroneous failures caused by loading behavior. For context on the `expect(...).toPass()` pattern, see https://playwright.dev/docs/test-assertions#expecttopass.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

All CI should pass.