### PR TITLE
chore: Tracking updates

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
     ...baseConfig.moduleNameMapper,
     '\\.svg$': '<rootDir>/src/mocks/svgMock.js',
     '^.+/logger/logger$': '<rootDir>/src/mocks/loggerMock.ts',
+    '^.+/interactions$': '<rootDir>/src/mocks/interactionsMock.ts',
   },
   transform: {
     '^.+\\.(t|j)sx?$': [

--- a/src/Breakdown/LabelBreakdownScene.tsx
+++ b/src/Breakdown/LabelBreakdownScene.tsx
@@ -229,6 +229,9 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     if (event.target !== 'labels') {
       return;
     }
+
+    reportExploreMetrics('sorting_changed', { from: 'label-breakdown', sortBy: event.sortBy });
+
     if (this.state.body instanceof LayoutSwitcher) {
       this.state.body.state.breakdownLayouts.forEach((layout) => {
         if (layout instanceof ByFrameRepeater) {
@@ -236,7 +239,6 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
         }
       });
     }
-    reportExploreMetrics('sorting_changed', { from: 'label-breakdown', sortBy: event.sortBy });
   };
 
   private onReferencedVariableValueChanged() {

--- a/src/MetricScene.tsx
+++ b/src/MetricScene.tsx
@@ -23,7 +23,7 @@ import { getAutoQueriesForMetric } from './autoQuery/getAutoQueriesForMetric';
 import { type AutoQueryDef, type AutoQueryInfo } from './autoQuery/types';
 import { buildLabelBreakdownActionScene } from './Breakdown/LabelBreakdownScene';
 import { UI_TEXT } from './constants/ui';
-import { reportExploreMetrics, type Interactions } from './interactions';
+import { reportExploreMetrics } from './interactions';
 import {
   MAIN_PANEL_MAX_HEIGHT,
   MAIN_PANEL_MIN_HEIGHT,
@@ -274,13 +274,13 @@ export class MetricActionBar extends SceneObjectBase<MetricActionBarState> {
                 counter={counter}
                 active={actionView === tab.value}
                 onChangeTab={() => {
-                  const actionViewChangedPayload: Interactions['metric_action_view_changed'] = { view: tab.value };
+                  reportExploreMetrics('metric_action_view_changed', {
+                    view: tab.value,
+                    related_logs_count: metricScene.relatedLogsOrchestrator.checkConditionsMetForRelatedLogs()
+                      ? counter
+                      : undefined,
+                  });
 
-                  if (metricScene.relatedLogsOrchestrator.checkConditionsMetForRelatedLogs()) {
-                    actionViewChangedPayload.related_logs_count = counter;
-                  }
-
-                  reportExploreMetrics('metric_action_view_changed', actionViewChangedPayload);
                   metricScene.setActionView(tab.value);
                 }}
               />

--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -215,12 +215,11 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
     this._subs.add(
       this.subscribeToEvent(EventSortByChanged, (event) => {
         const { sortBy } = event.payload;
+        reportExploreMetrics('sorting_changed', { from: 'metrics-reducer', sortBy });
 
         for (const [, { sortEngine }] of this.state.enginesMap) {
           sortEngine.sort(sortBy);
         }
-
-        reportExploreMetrics('sorting_changed', { from: 'metrics-reducer', sortBy });
       })
     );
   }

--- a/src/WingmanDataTrail/SideBar/SideBar.tsx
+++ b/src/WingmanDataTrail/SideBar/SideBar.tsx
@@ -235,17 +235,15 @@ export class SideBar extends SceneObjectBase<SideBarState> {
       section: sectionKey,
     });
 
+    if (sectionKey === 'filters-prefix') {
+      reportExploreMetrics('sidebar_prefix_filter_section_clicked', {});
+    } else if (sectionKey === 'filters-suffix') {
+      reportExploreMetrics('sidebar_suffix_filter_section_clicked', {});
+    }
+
     this.setState({
       visibleSection: sections.find((section) => section.state.key === sectionKey) ?? null,
     });
-
-    if (sectionKey === 'filters-prefix') {
-      reportExploreMetrics('sidebar_prefix_filter_section_clicked', {});
-    }
-
-    if (sectionKey === 'filters-suffix') {
-      reportExploreMetrics('sidebar_suffix_filter_section_clicked', {});
-    }
   }
 
   public static readonly Component = ({ model }: SceneComponentProps<SideBar>) => {

--- a/src/WingmanDataTrail/SideBar/sections/BookmarksList.tsx
+++ b/src/WingmanDataTrail/SideBar/sections/BookmarksList.tsx
@@ -74,8 +74,8 @@ export class BookmarksList extends SceneObjectBase<BookmarksListState> {
     };
 
     const onDelete = (index: number) => {
-      getTrailStore().removeBookmark(index);
       reportExploreMetrics('bookmark_changed', { action: 'deleted' });
+      getTrailStore().removeBookmark(index);
       setLastDelete(Date.now()); // trigger re-render
     };
 

--- a/src/WingmanDataTrail/SideBar/sections/LabelsBrowser/LabelsBrowser.tsx
+++ b/src/WingmanDataTrail/SideBar/sections/LabelsBrowser/LabelsBrowser.tsx
@@ -67,8 +67,8 @@ export class LabelsBrowser extends SceneObjectBase<LabelsBrowserState> {
   }
 
   private onClickLabel = (label: string) => {
-    this.selectLabel(label);
     reportExploreMetrics('sidebar_group_by_label_filter_applied', { label });
+    this.selectLabel(label);
   };
 
   private onClickClearSelection = () => {

--- a/src/WingmanDataTrail/SideBar/sections/MetricsFilterSection/MetricsFilterSection.tsx
+++ b/src/WingmanDataTrail/SideBar/sections/MetricsFilterSection/MetricsFilterSection.tsx
@@ -212,9 +212,7 @@ export class MetricsFilterSection extends SceneObjectBase<MetricsFilterSectionSt
       reportExploreMetrics('sidebar_prefix_filter_applied', {
         filter_count: selectedGroups.length,
       });
-    }
-
-    if (this.state.type === 'suffixes') {
+    } else if (this.state.type === 'suffixes') {
       reportExploreMetrics('sidebar_suffix_filter_applied', {
         filter_count: selectedGroups.length,
       });

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -1,11 +1,13 @@
 import { type AdHocVariableFilter } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 
 import { type LabelBreakdownSortingOption as BreakdownSortByOption } from 'Breakdown/SortByScene';
 import { type SortingOption as MetricsReducerSortByOption } from 'WingmanDataTrail/ListControls/MetricsSorter/MetricsSorter';
 
 import { type BreakdownLayoutType } from './Breakdown/types';
+import { PLUGIN_ID } from './constants';
 import { type ActionViewType } from './MetricScene';
+import { GIT_COMMIT } from './version';
 
 // prettier-ignore
 export type Interactions = {
@@ -161,15 +163,23 @@ export type Interactions = {
   },
   // User applies a label filter from the sidebar
   sidebar_group_by_label_filter_applied: {
-    // The label that was applied (optional)
-    label?: string;
+    label: string;
   }
 };
 
-const PREFIX = 'grafana_explore_metrics_';
+const META_PROPERTIES: Record<string, any> = {
+  // same naming as Faro (see src/shared/infrastructure/tracking/faro/faro.ts)
+  appRelease: config.apps[PLUGIN_ID].version,
+  appVersion: GIT_COMMIT,
+};
+
+const INTERACTION_NAME_PREFIX = 'grafana_explore_metrics_';
 
 export function reportExploreMetrics<E extends keyof Interactions, P extends Interactions[E]>(event: E, payload: P) {
-  reportInteraction(`${PREFIX}${event}`, payload);
+  reportInteraction(`${INTERACTION_NAME_PREFIX}${event}`, {
+    ...payload,
+    meta: META_PROPERTIES,
+  });
 }
 
 /**

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -9,17 +9,14 @@ import { PLUGIN_ID } from './constants';
 import { type ActionViewType } from './MetricScene';
 import { GIT_COMMIT } from './version';
 
-// prettier-ignore
-export type Interactions = {
+type Interactions = {
   // User selected a label to view its breakdown.
   label_selected: {
     label: string;
-    cause: (
-      // By clicking the "select" button on that label's breakdown panel
-      | 'breakdown_panel'
+    cause: // By clicking the "select" button on that label's breakdown panel
+    | 'breakdown_panel'
       // By clicking on the label selector at the top of the breakdown
-      | 'selector'
-    );
+      | 'selector';
     otel_resource_attribute?: boolean;
   };
   // User changed a label filter
@@ -33,144 +30,121 @@ export type Interactions = {
   breakdown_layout_changed: { layout: BreakdownLayoutType };
   // A metric exploration has started due to one of the following causes
   exploration_started: {
-    cause: (
-      | 'bookmark_clicked'
-    );
+    cause: 'bookmark_clicked';
   };
   // A user has changed a bookmark
   bookmark_changed: {
-    action: (
-      // Toggled on or off from the bookmark icon
-      | 'toggled_on'
+    action: // Toggled on or off from the bookmark icon
+    | 'toggled_on'
       | 'toggled_off'
       // Deleted from the sidebar bookmarks list
-      | 'deleted'
-    );
+      | 'deleted';
   };
   // User changes metric explore settings
   settings_changed: { stickyMainGraph?: boolean };
   // User clicks on tab to change the action view
   metric_action_view_changed: {
-    view: ActionViewType
+    view: ActionViewType;
 
     // The number of related logs
-    related_logs_count?: number
+    related_logs_count?: number;
   };
   // User clicks on one of the action buttons associated with a selected metric
   selected_metric_action_clicked: {
-    action: (
-      // Opens the metric queries in Explore
-      | 'open_in_explore'
+    action: // Opens the metric queries in Explore
+    | 'open_in_explore'
       // Clicks on the share URL button
       | 'share_url'
       // Deselects the current selected metrics by clicking the "Select new metric" button
       | 'unselect'
       // When in embedded mode, clicked to open the exploration from the embedded view
-      | 'open_from_embedded'
-    );
+      | 'open_from_embedded';
   };
   // User clicks on one of the action buttons associated with related logs
   related_logs_action_clicked: {
-    action: (
-      // Opens Logs Drilldown
-      | 'open_logs_drilldown'
+    action: // Opens Logs Drilldown
+    | 'open_logs_drilldown'
       // Logs data source changed
-      | 'logs_data_source_changed'
-    );
+      | 'logs_data_source_changed';
   };
   // User selects a metric
   metric_selected: {
-    from: (
-      // By clicking "Select" on a metric panel when on the no-metric-selected metrics list view
-      | 'metric_list'
+    from: // By clicking "Select" on a metric panel when on the no-metric-selected metrics list view
+    | 'metric_list'
       // By clicking "Select" on a metric panel when on the related metrics tab
-      | 'related_metrics'
-    );
+      | 'related_metrics';
     // The number of search terms activated when the selection was made
     searchTermCount: number | null;
   };
   // User opens/closes the prefix filter dropdown
   prefix_filter_clicked: {
-    from: (
-      // By clicking "Select" on a metric panel when on the no-metric-selected metrics list view
-      | 'metric_list'
+    from: // By clicking "Select" on a metric panel when on the no-metric-selected metrics list view
+    | 'metric_list'
       // By clicking "Select" on a metric panel when on the related metrics tab
-      | 'related_metrics'
-    )
-    action: (
-      // Opens the dropdown
-      | 'open'
+      | 'related_metrics';
+    action: // Opens the dropdown
+    | 'open'
       // Closes the dropdown
-      | 'close'
-    )
+      | 'close';
   };
   // User types in the quick search bar
   quick_search_used: {};
-  sorting_changed: {
-    // By clicking on the sort by variable in the metrics reducer
-    from: 'metrics-reducer',
-    // The sort by option selected
-    sortBy: MetricsReducerSortByOption
-  } | {
-    // By clicking on the sort by component in the label breakdown
-    from: 'label-breakdown',
-    // The sort by option selected
-    sortBy: BreakdownSortByOption
-  };
-  wasm_not_supported: {},
+  sorting_changed:
+    | {
+        // By clicking on the sort by variable in the metrics reducer
+        from: 'metrics-reducer';
+        // The sort by option selected
+        sortBy: MetricsReducerSortByOption;
+      }
+    | {
+        // By clicking on the sort by component in the label breakdown
+        from: 'label-breakdown';
+        // The sort by option selected
+        sortBy: BreakdownSortByOption;
+      };
+  wasm_not_supported: {};
   missing_otel_labels_by_truncating_job_and_instance: {
     metric?: string;
-  },
-  deployment_environment_migrated: {},
-  otel_experience_used: {},
+  };
+  deployment_environment_migrated: {};
+  otel_experience_used: {};
   otel_experience_toggled: {
-    value: ('on'| 'off')
-  },
-  native_histogram_examples_closed: {},
+    value: 'on' | 'off';
+  };
+  native_histogram_examples_closed: {};
   native_histogram_example_clicked: {
     metric: string;
-  },
+  };
   // User toggles the Wingman sidebar
   metrics_sidebar_toggled: {
-    action: (
-      // Opens the sidebar section
-      | 'opened'
+    action: // Opens the sidebar section
+    | 'opened'
       // Closes the sidebar section
-      | 'closed'
-    ),
-    section?: string
-  },
+      | 'closed';
+    section?: string;
+  };
   // User clicks into the prefix filter section of the sidebar
-  sidebar_prefix_filter_section_clicked: {},
+  sidebar_prefix_filter_section_clicked: {};
   // User applies any prefix filter from the sidebar
   sidebar_prefix_filter_applied: {
     // Number of prefix filters applied (optional)
     filter_count?: number;
-  },
+  };
   // User clicks into the suffix filter section of the sidebar
-  sidebar_suffix_filter_section_clicked: {},
+  sidebar_suffix_filter_section_clicked: {};
   // User applies any suffix filter from the sidebar
   sidebar_suffix_filter_applied: {
     // Number of suffix filters applied (optional)
     filter_count?: number;
-  },
+  };
   // User selects a rules filter from the Wingman sidebar
   sidebar_rules_filter_selected: {
-    filter_type: (
-      | 'non_rules_metrics'
-      | 'recording_rules'
-    )
-  },
+    filter_type: 'non_rules_metrics' | 'recording_rules';
+  };
   // User applies a label filter from the sidebar
   sidebar_group_by_label_filter_applied: {
     label: string;
-  }
-};
-
-const META_PROPERTIES: Record<string, any> = {
-  // same naming as Faro (see src/tracking/faro/faro.ts)
-  appRelease: config.apps[PLUGIN_ID].version,
-  appVersion: GIT_COMMIT,
+  };
 };
 
 const INTERACTION_NAME_PREFIX = 'grafana_explore_metrics_';
@@ -178,7 +152,11 @@ const INTERACTION_NAME_PREFIX = 'grafana_explore_metrics_';
 export function reportExploreMetrics<E extends keyof Interactions, P extends Interactions[E]>(event: E, payload: P) {
   reportInteraction(`${INTERACTION_NAME_PREFIX}${event}`, {
     ...payload,
-    meta: META_PROPERTIES,
+    meta: {
+      // same naming as Faro (see src/tracking/faro/faro.ts)
+      appRelease: config.apps[PLUGIN_ID].version,
+      appVersion: GIT_COMMIT,
+    },
   });
 }
 

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -168,7 +168,7 @@ export type Interactions = {
 };
 
 const META_PROPERTIES: Record<string, any> = {
-  // same naming as Faro (see src/shared/infrastructure/tracking/faro/faro.ts)
+  // same naming as Faro (see src/tracking/faro/faro.ts)
   appRelease: config.apps[PLUGIN_ID].version,
   appVersion: GIT_COMMIT,
 };

--- a/src/mocks/interactionsMock.ts
+++ b/src/mocks/interactionsMock.ts
@@ -1,0 +1,4 @@
+import { jest } from '@jest/globals';
+
+export const reportExploreMetrics = jest.fn();
+export const reportChangeInLabelFilters = jest.fn();


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR adds some metadata to the tracking events: the app version number and GIT commit, so we can understand better the tracking event we receive.

Additionally, wherever it's needed, it moves the calls to `reportExploreMetrics` to the top of the function body they're part of. We do this to ensure we always capture the user intent, even if the rest of the function body creates a runtime exception.

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The build should pass
