### PR TITLE
ci: Add zizmor config

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+# This is also used as the default configuration for the Zizmor reusable
+# workflow.
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: any # trust GitHub
+        grafana/*: any # trust Grafana


### PR DESCRIPTION
### ✨ Description

**TODO:
- Double-check if the recommendation is the best way to proceed.**

**Related issue(s):** See Slack thread for context

Currently our Zizmor checks are failing on forks, [for example](https://github.com/grafana/metrics-drilldown/actions/runs/15042715919):
```bash
Script failed: We're unable to look up the version of the Zizmor workflow being called, so we can't fetch the `grafana` default configuration. Zizmor's own default will be used. Is the `is-token: write` permission set? If so, is this a run from a fork? Unfortunately we're unable to do this lookup for pull requests from forks currently.
```

This PR follows the recommendation in the linked thread.

### 📖 Summary of the changes

Just adding a zizmor config to this repository.

### 🧪 How to test?

- The zizmor checks on this repo and on forks should work.
