### PR TITLE
Breakdown: Fix sorting with empty series fields

### DIFF
--- a/src/services/sorting.test.ts
+++ b/src/services/sorting.test.ts
@@ -41,6 +41,7 @@ const frameC = toDataFrame({
     },
   ],
 });
+const frameEmpty = toDataFrame({ fields: [] });
 
 describe('sortSeries', () => {
   test('Sorts series by standard deviation, descending', () => {
@@ -70,5 +71,10 @@ describe('sortSeries', () => {
 
     const result = sortSeries(series, 'alphabetical', 'desc');
     expect(result).toEqual(sortedSeries);
+  });
+  test('Does not throw on empty series', () => {
+    const series = [frameEmpty];
+
+    expect(() => sortSeries(series, 'alphabetical', 'asc')).not.toThrow();
   });
 });

--- a/src/services/sorting.ts
+++ b/src/services/sorting.ts
@@ -61,17 +61,20 @@ export const sortSeries = memoize(
     return seriesCalcs.map(({ dataFrame }) => dataFrame);
   },
   (series: DataFrame[], sortBy: string, direction = 'asc') => {
-    const firstTimestamp = series.length > 0 ? series[0].fields[0].values[0] : 0;
-    const lastTimestamp =
-      series.length > 0
-        ? series[series.length - 1].fields[0].values[series[series.length - 1].fields[0].values.length - 1]
-        : 0;
+    const firstTimestamp = seriesIsNotEmpty(series) ? series[0].fields[0].values[0] : 0;
+    const lastTimestamp = seriesIsNotEmpty(series)
+      ? series[series.length - 1].fields[0].values[series[series.length - 1].fields[0].values.length - 1]
+      : 0;
     const firstValue = series.length > 0 ? getLabelValueFromDataFrame(series[0]) : '';
     const lastValue = series.length > 0 ? getLabelValueFromDataFrame(series[series.length - 1]) : '';
     const key = `${firstValue}_${lastValue}_${firstTimestamp}_${lastTimestamp}_${series.length}_${sortBy}_${direction}`;
     return key;
   }
 );
+
+function seriesIsNotEmpty(series: DataFrame[]) {
+  return series.length > 0 && series[0].fields.length > 0 && series[0].fields[0].values.length > 0;
+}
 
 const initOutlierDetector = (series: DataFrame[]) => {
   if (!wasmSupported()) {


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** This PR fixes https://github.com/grafana/metrics-drilldown/issues/455.

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

The goal is to fix an error related to an unhandled case (empty series) when sorting label values in the Metric scene's Breakdown tab.

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

1. I wrote an "empty series" test that failed before the fix.
2. A sorting function was updated to handle empty series.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

- [x] All CI should pass
