### PR TITLE
chore: pinning plugin-ci-workflows actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   CI:
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@97b7a6757b389a0048ccbd5bed6a15eed593f1fd
     with:
       run-playwright: false
       run-playwright-docker: true

--- a/.github/workflows/playwright-published.yml
+++ b/.github/workflows/playwright-published.yml
@@ -57,7 +57,7 @@ jobs:
           echo "plugin-name=$name" >> $GITHUB_OUTPUT
 
       - name: Sign and package
-        uses: grafana/plugin-ci-workflows/actions/plugins/package@9bacf72016cc3cd1b0fdd0eacf10baccdaf4f87c
+        uses: grafana/plugin-ci-workflows/actions/plugins/package@97b7a6757b389a0048ccbd5bed6a15eed593f1fd
         with:
           output-folder: dist-artifacts
           universal: 'true'
@@ -73,7 +73,7 @@ jobs:
 
   playwright:
     needs: build
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@97b7a6757b389a0048ccbd5bed6a15eed593f1fd
     with:
       id: ${{ needs.build.outputs.plugin-name }}
       version: ${{ needs.build.outputs.plugin-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
         (github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'npm version')) ||
         (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
       )
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@9bacf72016cc3cd1b0fdd0eacf10baccdaf4f87c
     with:
       environment: ${{ inputs.environment || 'prod' }}
       attestation: true # this guarantees that the plugin was built from the source code provided in the release


### PR DESCRIPTION
Pin actions to current `main` commit

I have this PR: https://github.com/grafana/plugin-ci-workflows/pull/103

That will enable us to further minimize our docker config on this other PR:

https://github.com/grafana/metrics-drilldown/pull/451

But if i merge right now it could break our `Playwright Published` workflow. This prevents that from happening and allow us to update with confidence.