### PR TITLE
re-name prometheus to prometheus-gmd

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,8 +22,8 @@ services:
       - 'host.docker.internal:host-gateway'
 
   # We use this for displaying the metrics in our app
-  prometheus:
-    container_name: 'prometheus'
+  prometheus-gmd:
+    container_name: 'prometheus-gmd'
     build:
       dockerfile: ./e2e/docker/Dockerfile.prometheus-static-data
       context: .

--- a/e2e/provisioning/prometheus/prometheus.yml
+++ b/e2e/provisioning/prometheus/prometheus.yml
@@ -13,4 +13,4 @@ scrape_configs:
 
   - job_name: 'prometheus'
     static_configs:
-      - targets: ['prometheus:9090']
+      - targets: ['prometheus-gmd:9090']


### PR DESCRIPTION
Seems like other containers use `prometheus` name for the service so lets be a bit more specific on our use case


## How to test it out

```sh
npm run dev
# on another tab
npm run server
# on another tab
npm run e2e:ci
```