### PR TITLE
fix(MetricVizPanel): Fix matcher parsing

### DIFF
--- a/src/WingmanDataTrail/MetricVizPanel/MetricVizPanel.tsx
+++ b/src/WingmanDataTrail/MetricVizPanel/MetricVizPanel.tsx
@@ -21,6 +21,7 @@ import { SelectAction } from './actions/SelectAction';
 import { buildHeatmapPanel } from './panels/buildHeatmapPanel';
 import { buildStatusHistoryPanel } from './panels/buildStatusHistoryPanel';
 import { buildTimeseriesPanel } from './panels/buildTimeseriesPanel';
+import { parseMatcher } from './parseMatcher';
 
 interface MetricVizPanelProps {
   metricName: string;
@@ -196,14 +197,7 @@ export class MetricVizPanel extends SceneObjectBase<MetricVizPanelState> {
     prometheusFunction?: PrometheusFn;
     queryOptions?: Partial<SceneDataQuery>;
   }): SceneQueryRunner {
-    const filters = matchers.map((matcher) => {
-      const [key, value] = matcher.split('=');
-      return {
-        key,
-        value: value.replace(/['"]/g, ''),
-        operator: '=',
-      };
-    });
+    const filters = matchers.map(parseMatcher);
     const { isRateQuery, groupings } = MetricVizPanel.determineQueryProperties(metricName, isHistogram);
     const expr = buildPrometheusQuery({
       metric: metricName,

--- a/src/WingmanDataTrail/MetricVizPanel/__tests__/parseMatchers.test.ts
+++ b/src/WingmanDataTrail/MetricVizPanel/__tests__/parseMatchers.test.ts
@@ -1,0 +1,18 @@
+import { parseMatcher } from '../parseMatcher';
+
+describe('parseMatcher(matcher)', () => {
+  test.each([
+    ['alertname=ErrorRatioBreach', { key: 'alertname', operator: '=', value: 'ErrorRatioBreach' }],
+    ['alertname!=ErrorRatioBreach', { key: 'alertname', operator: '!=', value: 'ErrorRatioBreach' }],
+    ['alertname=~ErrorRatioBreach', { key: 'alertname', operator: '=~', value: 'ErrorRatioBreach' }],
+    ['alertname=~Error.+', { key: 'alertname', operator: '=~', value: 'Error.+' }],
+    ['alertname=~.+Error', { key: 'alertname', operator: '=~', value: '.+Error' }],
+    ['alertname!~ErrorRatioBreach', { key: 'alertname', operator: '!~', value: 'ErrorRatioBreach' }],
+    ['alertname!~Error.+', { key: 'alertname', operator: '!~', value: 'Error.+' }],
+    ['alertname!~.+Error', { key: 'alertname', operator: '!~', value: '.+Error' }],
+    ['p99<42', { key: 'p99', operator: '<', value: '42' }],
+    ['p99>42', { key: 'p99', operator: '>', value: '42' }],
+  ])('%s', (matcher, expectedFilter) => {
+    expect(parseMatcher(matcher)).toStrictEqual(expectedFilter);
+  });
+});

--- a/src/WingmanDataTrail/MetricVizPanel/parseMatcher.ts
+++ b/src/WingmanDataTrail/MetricVizPanel/parseMatcher.ts
@@ -1,0 +1,15 @@
+type Filter = {
+  key: string;
+  operator: '=' | '!=' | '=~' | '!~' | '<' | '>';
+  value: string;
+};
+
+export function parseMatcher(matcher: string): Filter {
+  // eslint-disable-next-line sonarjs/slow-regex
+  const [, rawKey, rawOperator, rawValue] = matcher.match(/([a-z0-9]+)(>|<|!~|=~|!=|=)(.+)/i) || [, '', '', ''];
+  return {
+    key: rawKey.trim(),
+    value: rawValue.replace(/['" ]/g, ''),
+    operator: rawOperator.trim() as Filter['operator'],
+  };
+}


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** fixes https://github.com/grafana/support-escalations/issues/16702

Prior to this PR, the logic to parse a matcher was not taking count of all the available operators. This PR fixes it.

### 📖 Summary of the changes

See diff tab for specific comments

### 🧪 How to test?

- The build with new unit tests should pass
