### PR TITLE
feat(App): Add onboarding screen when no Prometheus data sources

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import { type AppRootProps, type GrafanaTheme2 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 import React from 'react';
 
@@ -9,12 +10,14 @@ import { ErrorView } from './ErrorView';
 import { Onboarding } from './Onboarding';
 import { AppRoutes } from './Routes';
 import { useCatchExceptions } from './useCatchExceptions';
-import { useListPrometheusDataSources } from './useListPrometheusDataSources';
 import { useReportAppInitialized } from './useReportAppInitialized';
 import { MetricsContext, useTrail } from './useTrail';
+import { isPrometheusDataSource } from '../utils/utils.datasource';
 import { PluginPropsContext } from '../utils/utils.plugin';
 
 initFaro();
+
+const prometheusDatasources = Object.values(config.datasources).filter(isPrometheusDataSource);
 
 export default function App(props: Readonly<AppRootProps>) {
   const styles = useStyles2(getStyles);
@@ -22,8 +25,6 @@ export default function App(props: Readonly<AppRootProps>) {
   const { trail, goToUrlForTrail } = useTrail();
 
   useReportAppInitialized();
-
-  const { datasources } = useListPrometheusDataSources();
 
   if (error) {
     return (
@@ -33,7 +34,7 @@ export default function App(props: Readonly<AppRootProps>) {
     );
   }
 
-  if (!datasources.length) {
+  if (!prometheusDatasources.length) {
     return <Onboarding />;
   }
 

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,56 +1,29 @@
 import { css } from '@emotion/css';
 import { type AppRootProps, type GrafanaTheme2 } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
-import React, { createContext, useEffect, useState } from 'react';
+import React from 'react';
 
-import { type DataTrail } from 'DataTrail';
 import { initFaro } from 'tracking/faro/faro';
-import { getUrlForTrail, newMetricsTrail } from 'utils';
 
 import { ErrorView } from './ErrorView';
+import { Onboarding } from './Onboarding';
 import { AppRoutes } from './Routes';
 import { useCatchExceptions } from './useCatchExceptions';
+import { useListPrometheusDataSources } from './useListPrometheusDataSources';
 import { useReportAppInitialized } from './useReportAppInitialized';
+import { MetricsContext, useTrail } from './useTrail';
 import { PluginPropsContext } from '../utils/utils.plugin';
-import { navigationEvents } from '../WingmanDataTrail/SideBar/sections/BookmarksList';
 
 initFaro();
 
-interface MetricsAppContext {
-  trail: DataTrail;
-  goToUrlForTrail: (trail: DataTrail) => void;
-}
-
-export const MetricsContext = createContext<MetricsAppContext>({
-  trail: newMetricsTrail(),
-  goToUrlForTrail: () => {},
-});
-
-function App(props: Readonly<AppRootProps>) {
-  const [error] = useCatchExceptions();
-  const [trail, setTrail] = useState<DataTrail>(newMetricsTrail());
+export default function App(props: Readonly<AppRootProps>) {
   const styles = useStyles2(getStyles);
+  const [error] = useCatchExceptions();
+  const { trail, goToUrlForTrail } = useTrail();
 
   useReportAppInitialized();
 
-  const goToUrlForTrail = (trail: DataTrail) => {
-    locationService.push(getUrlForTrail(trail));
-    setTrail(trail);
-  };
-
-  // Subscribe to navigation events from BookmarksList
-  useEffect(() => {
-    const handleNavigation = (trail: DataTrail) => {
-      goToUrlForTrail(trail);
-    };
-
-    // Subscribe to navigation events
-    const unsubscribe = navigationEvents.subscribe(handleNavigation);
-
-    // Clean up subscription
-    return () => unsubscribe();
-  }, []);
+  const { datasources } = useListPrometheusDataSources();
 
   if (error) {
     return (
@@ -58,6 +31,10 @@ function App(props: Readonly<AppRootProps>) {
         <ErrorView error={error} />
       </div>
     );
+  }
+
+  if (!datasources.length) {
+    return <Onboarding />;
   }
 
   return (
@@ -70,8 +47,6 @@ function App(props: Readonly<AppRootProps>) {
     </div>
   );
 }
-
-export default App;
 
 function getStyles(theme: GrafanaTheme2) {
   return {

--- a/src/App/Onboarding.tsx
+++ b/src/App/Onboarding.tsx
@@ -1,0 +1,99 @@
+import { css } from '@emotion/css';
+import { locationUtil, type GrafanaTheme2 } from '@grafana/data';
+import { useStyles2, useTheme2 } from '@grafana/ui';
+import React from 'react';
+import SVG from 'react-inlinesvg';
+
+export function Onboarding() {
+  const styles = useStyles2(getStyles);
+  const theme = useTheme2();
+  return (
+    <div className={styles.wrap}>
+      <div className={styles.graphicContainer}>
+        <SVG
+          src={
+            // eslint-disable-next-line sonarjs/no-all-duplicated-branches
+            theme.isDark
+              ? `/public/plugins/grafana-metricsdrilldown-app/img/logo.svg`
+              : `/public/plugins/grafana-metricsdrilldown-app/img/logo.svg`
+          }
+        />
+      </div>
+      <div className={styles.text}>
+        <h3 className={styles.title}>Welcome to Grafana Metrics Drilldown</h3>
+
+        <p>
+          We noticed there is no Prometheus datasource configured.
+          <br />
+          Add a{' '}
+          <a className={'external-link'} href={locationUtil.assureBaseUrl(`/connections/datasources/new`)}>
+            Prometheus datasource
+          </a>{' '}
+          to view metrics.
+        </p>
+
+        <br />
+
+        <p>
+          Click{' '}
+          <a
+            href={'https://grafana.com/docs/grafana/latest/explore/simplified-exploration/metrics/'}
+            target={'_blank'}
+            className={'external-link'}
+            rel="noreferrer"
+          >
+            here
+          </a>{' '}
+          to learn more...
+        </p>
+      </div>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    graphicContainer: css({
+      [theme.breakpoints.up('md')]: {
+        alignSelf: 'flex-end',
+        height: 'auto',
+        padding: theme.spacing(1),
+        width: '300px',
+      },
+      [theme.breakpoints.up('lg')]: {
+        alignSelf: 'flex-end',
+        height: 'auto',
+        padding: theme.spacing(1),
+        width: '400px',
+      },
+      display: 'flex',
+      height: '250px',
+      justifyContent: 'center',
+      margin: '0 auto',
+      padding: theme.spacing(1),
+      width: '200px',
+    }),
+
+    text: css({
+      alignItems: 'center',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+    }),
+    title: css({
+      marginBottom: '1.5rem',
+    }),
+    wrap: css({
+      [theme.breakpoints.up('md')]: {
+        flexDirection: 'row',
+        margin: '4rem auto auto auto',
+      },
+      alignItems: 'center',
+      display: 'flex',
+      flexDirection: 'column',
+      margin: '0 auto auto auto',
+      padding: '2rem',
+      textAlign: 'center',
+    }),
+  };
+};

--- a/src/App/Routes.tsx
+++ b/src/App/Routes.tsx
@@ -2,7 +2,7 @@ import React, { lazy, useContext } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
 import { ROUTES } from '../constants';
-import { MetricsContext } from './App';
+import { MetricsContext } from './useTrail';
 
 const Wingman = lazy(() => import('../pages/TrailWingman'));
 

--- a/src/App/useListPrometheusDataSources.ts
+++ b/src/App/useListPrometheusDataSources.ts
@@ -1,8 +1,0 @@
-import { config } from '@grafana/runtime';
-
-import { isPrometheusDataSource } from 'utils/utils.datasource';
-
-export function useListPrometheusDataSources() {
-  const datasources = Object.values(config.datasources).filter(isPrometheusDataSource);
-  return { datasources };
-}

--- a/src/App/useListPrometheusDataSources.ts
+++ b/src/App/useListPrometheusDataSources.ts
@@ -1,0 +1,8 @@
+import { config } from '@grafana/runtime';
+
+import { isPrometheusDataSource } from 'utils/utils.datasource';
+
+export function useListPrometheusDataSources() {
+  const datasources = Object.values(config.datasources).filter(isPrometheusDataSource);
+  return { datasources };
+}

--- a/src/App/useTrail.tsx
+++ b/src/App/useTrail.tsx
@@ -1,0 +1,41 @@
+import { locationService } from '@grafana/runtime';
+import { createContext, useEffect, useState } from 'react';
+
+import { type DataTrail } from 'DataTrail';
+import { getUrlForTrail, newMetricsTrail } from 'utils';
+
+import { navigationEvents } from '../WingmanDataTrail/SideBar/sections/BookmarksList';
+
+interface MetricsAppContext {
+  trail: DataTrail;
+  goToUrlForTrail: (trail: DataTrail) => void;
+}
+
+export const MetricsContext = createContext<MetricsAppContext>({
+  trail: newMetricsTrail(),
+  goToUrlForTrail: () => {},
+});
+
+export function useTrail() {
+  const [trail, setTrail] = useState<DataTrail>(newMetricsTrail());
+
+  const goToUrlForTrail = (trail: DataTrail) => {
+    locationService.push(getUrlForTrail(trail));
+    setTrail(trail);
+  };
+
+  // Subscribe to navigation events from BookmarksList
+  useEffect(() => {
+    const handleNavigation = (trail: DataTrail) => {
+      goToUrlForTrail(trail);
+    };
+
+    // Subscribe to navigation events
+    const unsubscribe = navigationEvents.subscribe(handleNavigation);
+
+    // Clean up subscription
+    return () => unsubscribe();
+  }, []);
+
+  return { trail, goToUrlForTrail };
+}


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** resolves https://github.com/grafana/metrics-drilldown/issues/473

This PR adds a simple onboarding screen when no Prometheus data source has been found on the instance:
<img width="1709" alt="image" src="https://github.com/user-attachments/assets/b2552b69-1062-4fb2-a33b-b1b1681a70d3" />

### 📖 Summary of the changes

In order to display the onboarding screen or not, this PR gets the list of data sources from Grafana runtime's configuration. See diff tab for specific comments.

### 🧪 How to test?

- Checkout this branch in local
- Comment/remove all the YAML files in `./provisioning/datasources` to ensure no Prometheus data sources will be configured
- Delete any volume used by the `grafana-gmd` Docker container
- In a terminal, execute `npm run server`
- Go to http://localhost:3001/a/grafana-metricsdrilldown-app
- You should see the onboarding screen
