### PR TITLE
chore(EndToEnd): Upgrade Playwright to v1.53.0

### DIFF
--- a/e2e/docker/Dockerfile.playwright
+++ b/e2e/docker/Dockerfile.playwright
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/playwright:v1.52.0
+FROM mcr.microsoft.com/playwright:v1.53.0
 
 WORKDIR /app
 
 # required by the e2e test code
-RUN npm install "@playwright/test@^1.52.0" "dotenv@^16.3.1" "@grafana/plugin-e2e"
+RUN npm install "@playwright/test@^1.53.0" "dotenv@^16.3.1" "@grafana/plugin-e2e"
 
 ENV TZ=Europe/Madrid
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@grafana/eslint-config": "^8.0.0",
         "@grafana/plugin-e2e": "^1.19.9",
         "@grafana/tsconfig": "^2.0.0",
-        "@playwright/test": "^1.52.0",
+        "@playwright/test": "^1.53.0",
         "@stylistic/eslint-plugin-ts": "^2.13.0",
         "@swc/core": "^1.11.24",
         "@swc/helpers": "^0.5.17",
@@ -3353,13 +3353,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
-      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.0.tgz",
+      "integrity": "sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.52.0"
+        "playwright": "1.53.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13336,13 +13336,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
-      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.0.tgz",
+      "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.52.0"
+        "playwright-core": "1.53.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13355,9 +13355,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
-      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.0.tgz",
+      "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@grafana/eslint-config": "^8.0.0",
     "@grafana/plugin-e2e": "^1.19.9",
     "@grafana/tsconfig": "^2.0.0",
-    "@playwright/test": "^1.52.0",
+    "@playwright/test": "^1.53.0",
     "@stylistic/eslint-plugin-ts": "^2.13.0",
     "@swc/core": "^1.11.24",
     "@swc/helpers": "^0.5.17",


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** [the build of the last commit to main has failed](https://github.com/grafana/metrics-drilldown/commit/1d2dbf4b4fcf36b239cf3231fd6c30af5d5f7efb)

### 📖 Summary of the changes

The changes in this PR are the result of executing `./scripts/upgrade-playwright.sh 1.52.0 1.53.0` locally (see our [E2E testing docs](https://github.com/grafana/metrics-drilldown/blob/main/docs/end-to-end-testing.md#the-build-of-my-pr-has-failed-because-playwright-was-just-updated-how-to-fix-it)).

### 🧪 How to test?

- The build should pass
