### PR TITLE
refactor(QuickSearch): Improve QuickSearch

### DIFF
--- a/src/WingmanDataTrail/ListControls/ListControls.tsx
+++ b/src/WingmanDataTrail/ListControls/ListControls.tsx
@@ -12,6 +12,9 @@ import {
 import { useStyles2 } from '@grafana/ui';
 import React from 'react';
 
+import { VAR_FILTERED_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
+import { VAR_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
+
 import { LayoutSwitcher } from './LayoutSwitcher';
 import { MetricsSorter } from './MetricsSorter/MetricsSorter';
 import { QuickSearch } from './QuickSearch/QuickSearch';
@@ -34,7 +37,13 @@ export class ListControls extends EmbeddedScene {
         maxHeight: '32px',
         children: [
           new SceneFlexItem({
-            body: new QuickSearch(),
+            body: new QuickSearch({
+              targetName: 'metric',
+              variableNames: {
+                nonFiltered: VAR_METRICS_VARIABLE,
+                filtered: VAR_FILTERED_METRICS_VARIABLE,
+              },
+            }),
           }),
           new SceneFlexItem({
             width: 'auto',

--- a/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx
+++ b/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx
@@ -15,50 +15,27 @@ import React, { type KeyboardEvent } from 'react';
 
 import { reportExploreMetrics } from 'interactions';
 import { VAR_DATASOURCE } from 'shared';
-import { NULL_GROUP_BY_VALUE } from 'WingmanDataTrail/Labels/LabelsDataSource';
-import { VAR_WINGMAN_GROUP_BY } from 'WingmanDataTrail/Labels/LabelsVariable';
-import {
-  VAR_FILTERED_METRICS_VARIABLE,
-  type FilteredMetricsVariable,
-} from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
-import { VAR_METRICS_VARIABLE, type MetricsVariable } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
+import { areArraysEqual } from 'WingmanDataTrail/MetricsVariables/helpers/areArraysEqual';
 
 import { EventQuickSearchChanged } from './EventQuickSearchChanged';
 interface QuickSearchState extends SceneObjectState {
+  targetName: string;
+  variableNames: {
+    nonFiltered: string;
+    filtered: string;
+  };
   value: string;
   counts: { current: number; total: number };
-  disableRatioDisplay: boolean;
+  displayCounts: boolean;
 }
 
 export class QuickSearch extends SceneObjectBase<QuickSearchState> {
   public static readonly URL_SEARCH_PARAM_NAME = 'search_txt';
 
   protected _variableDependency = new VariableDependencyConfig(this, {
-    variableNames: [VAR_DATASOURCE, VAR_METRICS_VARIABLE, VAR_FILTERED_METRICS_VARIABLE, VAR_WINGMAN_GROUP_BY],
-    onAnyVariableChanged: (variable) => {
-      if ([VAR_METRICS_VARIABLE, VAR_FILTERED_METRICS_VARIABLE].includes(variable.state.name)) {
-        const { counts } = this.state;
-        const key = variable.state.name === VAR_METRICS_VARIABLE ? 'total' : 'current';
-        const newCount = (sceneGraph.lookupVariable(variable.state.name, this) as MultiValueVariable).state.options
-          .length;
-
-        if (newCount !== counts[key]) {
-          this.setState({ counts: { ...counts, [key]: newCount } });
-        }
-        return;
-      }
-
-      if (variable.state.name === VAR_WINGMAN_GROUP_BY) {
-        const value = (variable as MultiValueVariable).state.value;
-        this.setState({ disableRatioDisplay: Boolean(value && value !== NULL_GROUP_BY_VALUE) });
-        return;
-      }
-
-      this.setState({ disableRatioDisplay: false });
-
-      if (variable.state.name === VAR_DATASOURCE) {
-        this.setState({ value: '' });
-      }
+    variableNames: [VAR_DATASOURCE],
+    onReferencedVariableValueChanged: () => {
+      this.setState({ value: '' });
     },
   });
 
@@ -78,39 +55,63 @@ export class QuickSearch extends SceneObjectBase<QuickSearchState> {
     }
   }
 
-  public constructor() {
+  public constructor({
+    targetName,
+    variableNames,
+  }: {
+    targetName: QuickSearchState['targetName'];
+    variableNames: QuickSearchState['variableNames'];
+  }) {
     super({
       key: 'quick-search',
+      targetName,
+      variableNames,
       value: '',
       counts: {
         current: 0,
         total: 0,
       },
-      disableRatioDisplay: false,
+      displayCounts: false,
     });
 
     this.addActivationHandler(this.onActivate.bind(this));
   }
 
   private onActivate() {
-    this.setState({
-      counts: {
-        current: (sceneGraph.lookupVariable(VAR_FILTERED_METRICS_VARIABLE, this) as FilteredMetricsVariable).state
-          .options.length,
-        total: (sceneGraph.lookupVariable(VAR_METRICS_VARIABLE, this) as MetricsVariable).state.options.length,
-      },
-    });
+    const { variableNames } = this.state;
 
-    this.updateDisableRatioDisplay();
+    const filteredVariable = sceneGraph.lookupVariable(variableNames.filtered, this) as MultiValueVariable;
+    const nonFilteredVariable = sceneGraph.lookupVariable(variableNames.nonFiltered, this) as MultiValueVariable;
+
+    this._subs.add(
+      filteredVariable.subscribeToState((newState, prevState) => {
+        if (!newState.loading && !prevState.loading && !areArraysEqual(newState.options, prevState.options)) {
+          this.setState({
+            counts: {
+              current: newState.options.length,
+              total: nonFilteredVariable.state.options.length,
+            },
+          });
+        }
+      })
+    );
+
+    this._subs.add(
+      nonFilteredVariable.subscribeToState((newState, prevState) => {
+        if (!areArraysEqual(newState.options, prevState.options)) {
+          this.setState({
+            counts: {
+              current: filteredVariable.state.options.length,
+              total: newState.options.length,
+            },
+          });
+        }
+      })
+    );
   }
 
-  private updateDisableRatioDisplay() {
-    const groupByVariable = sceneGraph.lookupVariable(VAR_WINGMAN_GROUP_BY, this) as MultiValueVariable;
-    const groupByValue = groupByVariable.state.value;
-
-    this.setState({
-      disableRatioDisplay: Boolean(groupByValue && groupByValue !== NULL_GROUP_BY_VALUE),
-    });
+  public toggleCountsDisplay(displayCounts: boolean) {
+    this.setState({ displayCounts });
   }
 
   private notifyValueChange = debounce((value: string) => {
@@ -133,7 +134,7 @@ export class QuickSearch extends SceneObjectBase<QuickSearchState> {
     this.updateValue(e.currentTarget.value);
   };
 
-  public clear = () => {
+  private clear = () => {
     this.updateValue('');
   };
 
@@ -145,14 +146,19 @@ export class QuickSearch extends SceneObjectBase<QuickSearchState> {
   };
 
   private getHumanFriendlyCountsMessage() {
-    const { counts, disableRatioDisplay } = this.state;
+    const { targetName, counts, displayCounts } = this.state;
 
-    if (disableRatioDisplay || counts.current === counts.total) {
-      // we keep current because it's the count of the active variable (e.g. MetricsWithLabelValueVariable) after selecting a "Group by" value
-      // (total is always the count of options of MetricsVariable)
+    if (!displayCounts) {
+      return {
+        tagName: '',
+        tooltipContent: '',
+      };
+    }
+
+    if (counts.current === counts.total) {
       return {
         tagName: `${counts.current}`,
-        tooltipContent: counts.current !== 1 ? `${counts.current} metrics in total` : '1 metric in total',
+        tooltipContent: counts.current !== 1 ? `${counts.current} ${targetName}s in total` : `1 ${targetName} in total`,
       };
     }
 
@@ -160,15 +166,14 @@ export class QuickSearch extends SceneObjectBase<QuickSearchState> {
       tagName: `${counts.current}/${counts.total}`,
       tooltipContent:
         counts.current !== 1
-          ? `${counts.current} out of ${counts.total} metrics in total`
-          : `1 out of ${counts.total} metrics in total`,
+          ? `${counts.current} out of ${counts.total} ${targetName}s in total`
+          : `1 out of ${counts.total} ${targetName}s in total`,
     };
   }
 
   static readonly Component = ({ model }: { model: QuickSearch }) => {
     const styles = useStyles2(getStyles);
-    const { value } = model.useState();
-
+    const { targetName, value } = model.useState();
     const { tagName, tooltipContent } = model.getHumanFriendlyCountsMessage();
 
     return (
@@ -176,13 +181,15 @@ export class QuickSearch extends SceneObjectBase<QuickSearchState> {
         value={value}
         onChange={model.onChange}
         onKeyDown={model.onKeyDown}
-        placeholder="Quick search metrics..."
+        placeholder={`Quick search ${targetName}s`}
         prefix={<i className="fa fa-search" />}
         suffix={
           <>
-            <Tooltip content={tooltipContent} placement="top">
-              <Tag className={styles.counts} name={tagName} colorIndex={9} />
-            </Tooltip>
+            {tagName && (
+              <Tooltip content={tooltipContent} placement="top">
+                <Tag className={styles.counts} name={tagName} colorIndex={9} />
+              </Tooltip>
+            )}
             <IconButton
               name="times"
               variant="secondary"

--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -66,7 +66,7 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
   protected _variableDependency = new VariableDependencyConfig(this, {
     variableNames: [VAR_WINGMAN_GROUP_BY],
     onReferencedVariableValueChanged: (variable) => {
-      this.updateBodyBasedOnGroupBy((variable as LabelsVariable).state.value as string);
+      this.updateBasedOnGroupBy((variable as LabelsVariable).state.value as string);
     },
   });
 
@@ -88,11 +88,24 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
   }
 
   private onActivate() {
-    this.updateBodyBasedOnGroupBy(
-      (sceneGraph.lookupVariable(VAR_WINGMAN_GROUP_BY, this) as LabelsVariable).state.value as string
-    );
+    const groupByValue = (sceneGraph.lookupVariable(VAR_WINGMAN_GROUP_BY, this) as LabelsVariable).state
+      .value as string;
+
+    this.updateBasedOnGroupBy(groupByValue);
 
     this.subscribeToEvents();
+  }
+
+  private updateBasedOnGroupBy(groupByValue: string) {
+    const hasGroupByValue = Boolean(groupByValue && groupByValue !== NULL_GROUP_BY_VALUE);
+
+    sceneGraph.findByKeyAndType(this, 'quick-search', QuickSearch).toggleCountsDisplay(!hasGroupByValue);
+
+    this.setState({
+      body: hasGroupByValue
+        ? (new MetricsGroupByList({ labelName: groupByValue }) as unknown as SceneObjectBase)
+        : (new SimpleMetricsList() as unknown as SceneObjectBase),
+    });
   }
 
   private subscribeToEvents() {
@@ -212,15 +225,6 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
         }
       })
     );
-  }
-
-  private updateBodyBasedOnGroupBy(groupByValue: string) {
-    this.setState({
-      body:
-        !groupByValue || groupByValue === NULL_GROUP_BY_VALUE
-          ? (new SimpleMetricsList() as unknown as SceneObjectBase)
-          : (new MetricsGroupByList({ labelName: groupByValue }) as unknown as SceneObjectBase),
-    });
   }
 
   private openDrawer(metricName: string) {


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/metrics-drilldown/pull/477

Another refactor to ease the integration into Asserts (there are more to come).

### 📖 Summary of the changes

This refactor makes the `QuickSearch` component easier to reuse by enabling the configuration of the target variables (the variables that are filtered). See diff tab for specific comments.

### 🧪 How to test?

- The build should pass
