### PR TITLE
refactor(MetricsList): Ability to pass a variable name to the constructor

### DIFF
--- a/src/WingmanDataTrail/GroupBy/MetricsGroupByRow.tsx
+++ b/src/WingmanDataTrail/GroupBy/MetricsGroupByRow.tsx
@@ -22,7 +22,7 @@ import { getColorByIndex, getTrailFor } from 'utils';
 import { NULL_GROUP_BY_VALUE } from 'WingmanDataTrail/Labels/LabelsDataSource';
 import { VAR_WINGMAN_GROUP_BY, type LabelsVariable } from 'WingmanDataTrail/Labels/LabelsVariable';
 import { LayoutSwitcher, LayoutType, type LayoutSwitcherState } from 'WingmanDataTrail/ListControls/LayoutSwitcher';
-import { GRID_TEMPLATE_COLUMNS, GRID_TEMPLATE_ROWS } from 'WingmanDataTrail/MetricsList/SimpleMetricsList';
+import { GRID_TEMPLATE_COLUMNS, GRID_TEMPLATE_ROWS } from 'WingmanDataTrail/MetricsList/MetricsList';
 import { SelectAction } from 'WingmanDataTrail/MetricVizPanel/actions/SelectAction';
 import {
   METRICS_VIZ_PANEL_HEIGHT_WITH_USAGE_DATA_PREVIEW,

--- a/src/WingmanDataTrail/MetricsList/MetricsList.tsx
+++ b/src/WingmanDataTrail/MetricsList/MetricsList.tsx
@@ -7,6 +7,7 @@ import {
   sceneGraph,
   SceneObjectBase,
   SceneReactObject,
+  type MultiValueVariable,
   type SceneComponentProps,
   type SceneObjectState,
 } from '@grafana/scenes';
@@ -20,37 +21,32 @@ import { VAR_FILTERS } from 'shared';
 import { getColorByIndex, getTrailFor } from 'utils';
 import { isAdHocFiltersVariable } from 'utils/utils.variables';
 import { LayoutSwitcher, LayoutType, type LayoutSwitcherState } from 'WingmanDataTrail/ListControls/LayoutSwitcher';
-import {
-  VAR_FILTERED_METRICS_VARIABLE,
-  type FilteredMetricsVariable,
-} from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
-import {
-  METRICS_VIZ_PANEL_HEIGHT_WITH_USAGE_DATA_PREVIEW,
-  MetricVizPanel,
-} from 'WingmanDataTrail/MetricVizPanel/MetricVizPanel';
+import { METRICS_VIZ_PANEL_HEIGHT, MetricVizPanel } from 'WingmanDataTrail/MetricVizPanel/MetricVizPanel';
 import { SceneByVariableRepeater } from 'WingmanDataTrail/SceneByVariableRepeater/SceneByVariableRepeater';
 import { ShowMoreButton } from 'WingmanDataTrail/ShowMoreButton';
 
 export const GRID_TEMPLATE_COLUMNS = 'repeat(auto-fit, minmax(400px, 1fr))';
 export const GRID_TEMPLATE_ROWS = '1fr';
 
-interface SimpleMetricsListState extends SceneObjectState {
+interface MetricsListState extends SceneObjectState {
+  variableName: string;
   body: SceneByVariableRepeater;
 }
 
-export class SimpleMetricsList extends SceneObjectBase<SimpleMetricsListState> {
-  constructor() {
+export class MetricsList extends SceneObjectBase<MetricsListState> {
+  constructor({ variableName }: { variableName: MetricsListState['variableName'] }) {
     super({
-      key: 'simple-metrics-list',
+      key: 'metrics-list',
+      variableName,
       body: new SceneByVariableRepeater({
-        variableName: VAR_FILTERED_METRICS_VARIABLE,
+        variableName,
         initialPageSize: 120,
         pageSizeIncrement: 9,
         body: new SceneCSSGridLayout({
           children: [],
           isLazy: true,
           templateColumns: GRID_TEMPLATE_COLUMNS,
-          autoRows: METRICS_VIZ_PANEL_HEIGHT_WITH_USAGE_DATA_PREVIEW,
+          autoRows: METRICS_VIZ_PANEL_HEIGHT,
           $behaviors: [
             new behaviors.CursorSync({
               key: 'metricCrosshairSync',
@@ -124,11 +120,11 @@ export class SimpleMetricsList extends SceneObjectBase<SimpleMetricsListState> {
     this._subs.add(layoutSwitcher.subscribeToState(onChangeState));
   }
 
-  public static readonly Component = ({ model }: SceneComponentProps<SimpleMetricsList>) => {
-    const { body } = model.useState();
+  public static readonly Component = ({ model }: SceneComponentProps<MetricsList>) => {
+    const { variableName, body } = model.useState();
     const styles = useStyles2(getStyles);
 
-    const variable = sceneGraph.lookupVariable(VAR_FILTERED_METRICS_VARIABLE, model) as FilteredMetricsVariable;
+    const variable = sceneGraph.lookupVariable(variableName, model) as MultiValueVariable;
     const { loading, error } = variable.useState();
 
     const batchSizes = body.useSizes();

--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -36,11 +36,11 @@ import {
 } from './ListControls/MetricsSorter/MetricsSorter';
 import { EventQuickSearchChanged } from './ListControls/QuickSearch/EventQuickSearchChanged';
 import { QuickSearch } from './ListControls/QuickSearch/QuickSearch';
-import { GRID_TEMPLATE_COLUMNS, SimpleMetricsList } from './MetricsList/SimpleMetricsList';
+import { GRID_TEMPLATE_COLUMNS, MetricsList } from './MetricsList/MetricsList';
 import { EventMetricsVariableActivated } from './MetricsVariables/EventMetricsVariableActivated';
 import { EventMetricsVariableDeactivated } from './MetricsVariables/EventMetricsVariableDeactivated';
 import { EventMetricsVariableLoaded } from './MetricsVariables/EventMetricsVariableLoaded';
-import { FilteredMetricsVariable } from './MetricsVariables/FilteredMetricsVariable';
+import { FilteredMetricsVariable, VAR_FILTERED_METRICS_VARIABLE } from './MetricsVariables/FilteredMetricsVariable';
 import { MetricsVariable } from './MetricsVariables/MetricsVariable';
 import { MetricsVariableFilterEngine, type MetricFilters } from './MetricsVariables/MetricsVariableFilterEngine';
 import { MetricsVariableSortEngine } from './MetricsVariables/MetricsVariableSortEngine';
@@ -77,7 +77,7 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
       }),
       listControls: new ListControls({}),
       sidebar: new SideBar({}),
-      body: new SimpleMetricsList() as unknown as SceneObjectBase,
+      body: new MetricsList({ variableName: VAR_FILTERED_METRICS_VARIABLE }) as unknown as SceneObjectBase,
       drawer: new SceneDrawer({}),
       enginesMap: new Map(),
     });
@@ -104,7 +104,7 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
     this.setState({
       body: hasGroupByValue
         ? (new MetricsGroupByList({ labelName: groupByValue }) as unknown as SceneObjectBase)
-        : (new SimpleMetricsList() as unknown as SceneObjectBase),
+        : (new MetricsList({ variableName: VAR_FILTERED_METRICS_VARIABLE }) as unknown as SceneObjectBase),
     });
   }
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** previous refactorings → https://github.com/grafana/metrics-drilldown/pull/477, https://github.com/grafana/metrics-drilldown/pull/479

Another refactor to ease the integration into Asserts (there are more to come).

### 📖 Summary of the changes

By adding the option to pass a variable name to the `MetricsList` component, we will be able to reuse it easily for diplaying the related metrics in `MetricScene`.

### 🧪 How to test?

- The build should pass
