### PR TITLE
fix(MetricScene): Prevent high cardinality labels to make the UI unresponsive in the "Breakdown" tab

### DIFF
--- a/src/Breakdown/MetricLabelsList/behaviors/publishTimeseriesData.ts
+++ b/src/Breakdown/MetricLabelsList/behaviors/publishTimeseriesData.ts
@@ -9,8 +9,8 @@ import { EventTimeseriesDataReceived } from '../events/EventTimeseriesDataReceiv
  */
 export function publishTimeseriesData() {
   return (vizPanel: VizPanel) => {
-    (vizPanel.state.$data as SceneDataProvider).subscribeToState((newState) => {
-      if (newState.data?.state === LoadingState.Done) {
+    (vizPanel.state.$data as SceneDataProvider).subscribeToState((newState, prevState) => {
+      if (newState.data?.state === LoadingState.Done && newState.data?.series !== prevState.data?.series) {
         vizPanel.publishEvent(new EventTimeseriesDataReceived({ series: newState.data.series }), true);
       }
     });

--- a/src/Breakdown/MetricLabelsList/transformations/addRefId.ts
+++ b/src/Breakdown/MetricLabelsList/transformations/addRefId.ts
@@ -1,6 +1,12 @@
 import { type DataFrame } from '@grafana/data';
-import { merge } from 'lodash';
 import { map, type Observable } from 'rxjs';
 
 export const addRefId = () => (source: Observable<DataFrame[]>) =>
-  source.pipe(map((data: DataFrame[]) => data?.map((d, i) => merge(d, { refId: `${d.refId}-${i}` }))));
+  source.pipe(
+    map((data: DataFrame[]) =>
+      data?.map((d, i) => {
+        d.refId = `${d.refId}-${i}`;
+        return d;
+      })
+    )
+  );

--- a/src/Breakdown/MetricLabelsList/transformations/sliceSeries.ts
+++ b/src/Breakdown/MetricLabelsList/transformations/sliceSeries.ts
@@ -1,0 +1,17 @@
+import { type DataFrame } from '@grafana/data';
+import { map, type Observable } from 'rxjs';
+
+export const SERIES_COUNT_STATS_NAME = 'seriesCount';
+
+export const sliceSeries = (start: number, end: number) => () => (source: Observable<DataFrame[]>) =>
+  source.pipe(
+    map((data: DataFrame[]) =>
+      // eslint-disable-next-line sonarjs/no-nested-functions
+      data?.slice(start, end).map((d) => {
+        d.meta = { ...d.meta };
+        d.meta.stats ||= [];
+        d.meta.stats.unshift({ displayName: SERIES_COUNT_STATS_NAME, value: data.length });
+        return d;
+      })
+    )
+  );


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR limits the number of series being rendered in the "Breakdown" tab to prevent the UI to be unresponsive:

<img width="432" alt="image" src="https://github.com/user-attachments/assets/64983373-e345-4248-ad4e-8d3c2355ae36" />

### 📖 Summary of the changes

This PR;
1. introduces a new `sliceSeries` data transformation in `LabelVizPanel`,
2. adds the cardinality in the panel title,
3. and adds a panel description when the number of series has been capped.

See diff tab for specific comments.

### 🧪 How to test?

- The build should pass

Manually, by checking with a "heavy" data source (one from ops, DM for details if needed)
