### PR TITLE
chore: upgrade playwright to 1.53.1

### DIFF
--- a/e2e/docker/Dockerfile.playwright
+++ b/e2e/docker/Dockerfile.playwright
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/playwright:v1.53.0
+FROM mcr.microsoft.com/playwright:v1.53.1
 
 WORKDIR /app
 
 # required by the e2e test code
-RUN npm install "@playwright/test@^1.53.0" "dotenv@^16.3.1" "@grafana/plugin-e2e"
+RUN npm install "@playwright/test@^1.53.1" "dotenv@^16.3.1" "@grafana/plugin-e2e"
 
 ENV TZ=Europe/Madrid
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@grafana/eslint-config": "^8.0.0",
         "@grafana/plugin-e2e": "^1.19.9",
         "@grafana/tsconfig": "^2.0.0",
-        "@playwright/test": "^1.53.0",
+        "@playwright/test": "^1.53.1",
         "@stylistic/eslint-plugin-ts": "^2.13.0",
         "@swc/core": "^1.11.24",
         "@swc/helpers": "^0.5.17",
@@ -3353,13 +3353,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.0.tgz",
-      "integrity": "sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==",
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.1.tgz",
+      "integrity": "sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.53.0"
+        "playwright": "1.53.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13336,13 +13336,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.0.tgz",
-      "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.1.tgz",
+      "integrity": "sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.53.0"
+        "playwright-core": "1.53.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13355,9 +13355,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.0.tgz",
-      "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.1.tgz",
+      "integrity": "sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@grafana/eslint-config": "^8.0.0",
     "@grafana/plugin-e2e": "^1.19.9",
     "@grafana/tsconfig": "^2.0.0",
-    "@playwright/test": "^1.53.0",
+    "@playwright/test": "^1.53.1",
     "@stylistic/eslint-plugin-ts": "^2.13.0",
     "@swc/core": "^1.11.24",
     "@swc/helpers": "^0.5.17",

--- a/src/helpers/MetricDatasourceHelper.ts
+++ b/src/helpers/MetricDatasourceHelper.ts
@@ -94,7 +94,7 @@ export class MetricDatasourceHelper {
     const ds = await this.getDatasource();
     if (ds && Object.keys(this._classicHistograms).length === 0) {
       const classicHistogramsCall = ds.metricFindQuery('metrics(.*_bucket)');
-      const allMetricsCall = ds.metricFindQuery('metrics(.*)');
+      const allMetricsCall = ds.metricFindQuery('metrics(.+)');
 
       const [classicHistograms, allMetrics] = await Promise.all([classicHistogramsCall, allMetricsCall]);
 


### PR DESCRIPTION
### ✨ Description

This PR upgrades Playwright to 1.53.1. We need this to fix CI failures like [this](https://github.com/grafana/metrics-drilldown/actions/runs/15741128673/job/44370769250?pr=504).

### 📖 Summary of the changes

See diff tab.

### 🧪 How to test?

All CI should pass.
