### PR TITLE
fix(*): Fix y-axis sync logic

### DIFF
--- a/src/Breakdown/MetricLabelsList/behaviors/syncYAxis.ts
+++ b/src/Breakdown/MetricLabelsList/behaviors/syncYAxis.ts
@@ -31,7 +31,12 @@ export function syncYAxis() {
         }
       }
 
-      if (newMax !== max && newMin !== min && newMax !== newMin) {
+      if (
+        newMax !== newMin &&
+        newMax !== Number.NEGATIVE_INFINITY &&
+        newMin !== Number.POSITIVE_INFINITY &&
+        (newMax !== max || newMin !== min)
+      ) {
         [max, min] = [newMax, newMin];
         updateTimeseriesAxis(vizPanelsParent, max, min);
       }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** follow-up of https://github.com/grafana/metrics-drilldown/pull/488

The logic to prevent updating the y axis of timeseries panel has a bug. This PR fixes it.

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The build should pass
