### PR TITLE
chore: bump version to 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.4
+
+See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.4>
+
 ## v1.0.3
 
 See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.3-corrected>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-metricsdrilldown-app",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "AGPL-3.0",
       "dependencies": {
         "@bsull/augurs": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Grafana",
   "license": "AGPL-3.0",
   "scripts": {


### PR DESCRIPTION
### ✨ Description

This PR bumps the version to 1.0.4 from 1.0.3. We'll use the 1.0.4 tag as the basis for a new release.

### 📖 Summary of the changes

Changelog and package.json + lockfile updated as per https://wiki.grafana-ops.net/w/index.php/Engineering/Grafana/Grafana_Explore/Metrics_Drilldown/Deployment_Handbook#Versioning.

### 🧪 How to test?

N/A
