### PR TITLE
fix: use consistent line style in timeseries panels

### DIFF
--- a/src/WingmanDataTrail/MetricVizPanel/panels/buildTimeseriesPanel.ts
+++ b/src/WingmanDataTrail/MetricVizPanel/panels/buildTimeseriesPanel.ts
@@ -15,6 +15,7 @@ export function buildTimeseriesPanel({ panelTitle, queryRunner, color, headerAct
       .setData(queryRunner)
       .setColor({ mode: 'fixed', fixedColor: color })
       .setCustomFieldConfig('fillOpacity', 9)
+      .setCustomFieldConfig('pointSize', 1)
       // we clone to prevent Scenes warnings "SceneObject already has a parent set that is different from the new parent. You cannot share the same SceneObject instance in multiple scenes or in multiple different places of the same scene graph. Use SceneObject.clone() to duplicate a SceneObject or store a state key reference and use sceneGraph.findObject to locate it."
       .setHeaderActions(headerActions.map((action) => action.clone()))
       .setOption('legend', { showLegend: !hideLegend })


### PR DESCRIPTION
### ✨ Description

This PR intends to fix the CI issues that appeared in https://github.com/grafana/metrics-drilldown/pull/511.

### 📖 Summary of the changes

Explicitly set the `pointSize` to `1` to avoid points from appearing unexpectedly.

### 🧪 How to test?

1. On `main`, run `GRAFANA_IMAGE=grafana-dev GRAFANA_VERSION=12.1.0-249858 npm run e2e:server` and `npm run dev`
2. Look at `http://localhost:3001/a/grafana-metricsdrilldown-app/drilldown?nativeHistogramMetric=&layout=grid&filters-rule=&filters-prefix=go&filters-suffix=&from=2025-05-26T11:00:00.000Z&to=2025-05-26T12:05:00.000Z&timezone=utc&var-filters=&var-labelsWingman=%28none%29&search_txt=&var-metrics-reducer-sort-by=default&var-ds=gdev-prometheus&var-other_metric_filters=filters-prefix,prefix%7C%3D%7C` and notice that the time series panels have points during the static data time range used for our e2e tests.

<img width="1361" alt="demo points issue" src="https://github.com/user-attachments/assets/a28d3fe4-f3aa-4f2b-85e8-0ded50dff978" />

3. Switch to the `fix/point-size` branch. Notice that the points are gone, and only lines remain.

<img width="1361" alt="demo lines with no points" src="https://github.com/user-attachments/assets/16d50d18-1d15-4e74-87a6-2811cb89d3f1" />

