### PR TITLE
fix: Selecting __name__ as a filter breaks queries

### DIFF
--- a/e2e/config/playwright.config.common.ts
+++ b/e2e/config/playwright.config.common.ts
@@ -66,12 +66,9 @@ export function config(config: CustomEnvConfig) {
       grafanaAPICredentials: getGrafanaUser(),
       /* Base URL to use in actions like `await page.goto('/')`. */
       baseURL: getGrafanaUrl(),
-      // Record trace only when retrying a test for the first time.
       screenshot: 'only-on-failure',
-      // Record video only when retrying a test for the first time.
-      video: 'on-first-retry',
-      /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-      trace: 'on-first-retry',
+      video: 'retain-on-failure',
+      trace: 'retain-on-failure',
     },
     /* Configure projects for major browsers */
     projects: [

--- a/e2e/tests/metrics-reducer-view.spec.ts
+++ b/e2e/tests/metrics-reducer-view.spec.ts
@@ -63,7 +63,7 @@ test.describe('Metrics reducer view', () => {
           await metricsReducerView.sidebar.selectGroupByLabel('db_name');
           await metricsReducerView.assertMetricsGroupByList();
 
-          await metricsReducerView.selectMetricsGroup('db_name', 'grafana');
+          metricsReducerView.selectMetricsGroup('db_name', 'grafana');
           await metricsReducerView.assertAdHocFilter('db_name', '=', 'grafana');
 
           await metricsReducerView.sidebar.assertActiveButton('Group by labels', false);
@@ -85,7 +85,7 @@ test.describe('Metrics reducer view', () => {
           await metricsReducerView.sidebar.selectGroupByLabel('db_name');
           await metricsReducerView.assertMetricsGroupByList();
 
-          await metricsReducerView.selectMetricsGroup('db_name', 'grafana');
+          metricsReducerView.selectMetricsGroup('db_name', 'grafana');
           await metricsReducerView.assertAdHocFilter('db_name', '=', 'grafana');
           await metricsReducerView.clearAdHocFilter('db_name');
 

--- a/e2e/tests/metrics-reducer-view.spec.ts
+++ b/e2e/tests/metrics-reducer-view.spec.ts
@@ -11,6 +11,14 @@ test.describe('Metrics reducer view', () => {
     await metricsReducerView.assertCoreUI();
   });
 
+  test('AdHoc Filters', async ({ metricsReducerView, selectors }) => {
+    await metricsReducerView.goto();
+    await metricsReducerView.getByRole('combobox', { name: 'Filter by label values' }).click();
+    const option = selectors.components.Select.option;
+    await expect(metricsReducerView.getByGrafanaSelector(option)).not.toHaveText(['__name__']);
+    await expect(metricsReducerView.getByRole('option', { name: '__name__' })).not.toBeVisible();
+  });
+
   test.describe('Sidebar', () => {
     test.describe('Prefix and suffix filters logic behavior', () => {
       test('Within a filter group, selections use OR logic (prefix.one OR prefix.two)', async ({

--- a/e2e/tests/metrics-reducer-view.spec.ts
+++ b/e2e/tests/metrics-reducer-view.spec.ts
@@ -12,12 +12,28 @@ test.describe('Metrics reducer view', () => {
   });
 
   test.describe('AdHoc Filters', async () => {
-    test('__name__ should be filtered out of the options', async ({ metricsReducerView, selectors }) => {
+    test('__name__ filter is not interpolated into the query', async ({ metricsReducerView, selectors, page }) => {
       await metricsReducerView.goto();
       await metricsReducerView.getByRole('combobox', { name: 'Filter by label values' }).click();
-      const option = selectors.components.Select.option;
-      await expect(metricsReducerView.getByGrafanaSelector(option)).not.toHaveText(['__name__']);
-      await expect(metricsReducerView.getByRole('option', { name: '__name__' })).not.toBeVisible();
+      await metricsReducerView.getByRole('option', { name: '__name__' }).click();
+      await page.keyboard.type('=');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('grafana_database_conn_idle');
+      await page.keyboard.press('Enter');
+      await metricsReducerView.getByGrafanaSelector(selectors.components.RefreshPicker.runButtonV2).click();
+
+      await metricsReducerView.getByTestId('select-action-a_utf8_http_requests_total').click();
+
+      await metricsReducerView
+        .getByRole('button', { name: UI_TEXT.METRIC_SELECT_SCENE.SELECT_NEW_METRIC_TOOLTIP })
+        .click();
+
+      await metricsReducerView.assertCoreUI();
+      await expect(
+        metricsReducerView
+          .getByTestId('data-testid Panel header a_utf8_http_requests_total')
+          .getByTestId('data-testid Panel status error')
+      ).not.toBeVisible();
     });
   });
 

--- a/e2e/tests/metrics-reducer-view.spec.ts
+++ b/e2e/tests/metrics-reducer-view.spec.ts
@@ -11,12 +11,14 @@ test.describe('Metrics reducer view', () => {
     await metricsReducerView.assertCoreUI();
   });
 
-  test('AdHoc Filters', async ({ metricsReducerView, selectors }) => {
-    await metricsReducerView.goto();
-    await metricsReducerView.getByRole('combobox', { name: 'Filter by label values' }).click();
-    const option = selectors.components.Select.option;
-    await expect(metricsReducerView.getByGrafanaSelector(option)).not.toHaveText(['__name__']);
-    await expect(metricsReducerView.getByRole('option', { name: '__name__' })).not.toBeVisible();
+  test.describe('AdHoc Filters', async () => {
+    test('__name__ should be filtered out of the options', async ({ metricsReducerView, selectors }) => {
+      await metricsReducerView.goto();
+      await metricsReducerView.getByRole('combobox', { name: 'Filter by label values' }).click();
+      const option = selectors.components.Select.option;
+      await expect(metricsReducerView.getByGrafanaSelector(option)).not.toHaveText(['__name__']);
+      await expect(metricsReducerView.getByRole('option', { name: '__name__' })).not.toBeVisible();
+    });
   });
 
   test.describe('Sidebar', () => {

--- a/src/autoQuery/buildPrometheusQuery.ts
+++ b/src/autoQuery/buildPrometheusQuery.ts
@@ -39,11 +39,13 @@ export function buildPrometheusQuery({
     defaultSelectors: [
       ...(isUtf8Metric ? [{ label: utf8Support(metric), operator: MatchingOperator.equal, value: '__REMOVE__' }] : []),
       ...(ignoreUsage ? [{ label: '__ignore_usage__', operator: MatchingOperator.equal, value: '' }] : []),
-      ...filters.map(({ key, value, operator }) => ({
-        label: utf8Support(key),
-        operator: operator as MatchingOperator,
-        value,
-      })),
+      ...filters
+        .filter((filter) => filter.key !== '__name__')
+        .map(({ key, value, operator }) => ({
+          label: utf8Support(key),
+          operator: operator as MatchingOperator,
+          value,
+        })),
     ],
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -181,7 +181,9 @@ export function limitAdhocProviders(
         opts.queries = [];
       }
 
-      let values = (await datasourceHelper.getTagKeys(opts)).slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
+      let values = (await datasourceHelper.getTagKeys(opts))
+        .filter((filter) => filter.text !== '__name__')
+        .slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
 
       // use replace: true to override the default lookup in adhoc filter variable
       return { replace: true, values };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -187,7 +187,7 @@ export function limitAdhocProviders(
       return { replace: true, values };
     },
     getTagValuesProvider: async (
-      variable: AdHocFiltersVariable,
+      _: AdHocFiltersVariable,
       filter: AdHocVariableFilter
     ): Promise<{
       replace?: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -181,9 +181,7 @@ export function limitAdhocProviders(
         opts.queries = [];
       }
 
-      let values = (await datasourceHelper.getTagKeys(opts))
-        .filter((filter) => filter.text !== '__name__')
-        .slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
+      let values = (await datasourceHelper.getTagKeys(opts)).slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
 
       // use replace: true to override the default lookup in adhoc filter variable
       return { replace: true, values };


### PR DESCRIPTION
### ✨ Description

Addresses: https://github.com/grafana/support-escalations/issues/14997
