### PR TITLE
ci: Unblock build by skipping Grafana dev image in E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
         description: Skip the grafana dev image e2e test
         required: false
         type: boolean
-        default: false
+        default: true # TEMP until the Docker Hub issue is fixed (2025-07-09)
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
         description: Skip the grafana dev image e2e test
         required: false
         type: boolean
-        default: true # TEMP until the Docker Hub issue is fixed (2025-07-09)
+        default: false
   pull_request:
     branches:
       - main
@@ -22,7 +22,9 @@ jobs:
     with:
       run-playwright: false
       run-playwright-docker: true
-      run-playwright-with-skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image || false }}
+      # TEMP until the Docker Hub issue is fixed (2025-07-09)
+      run-playwright-with-skip-grafana-dev-image: true
+      # run-playwright-with-skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image || false }}
       upload-playwright-artifacts: true
       playwright-report-path: e2e/test-reports/
       playwright-docker-compose-file: docker-compose.yaml


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** see https://raintank-corp.slack.com/archives/C01C4K8DETW/p1751971692619869

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The `grafana-enterprise` E2E tests should be executed 
- The `grafana-dev` E2E tests should be skipped 
