### PR TITLE
feat: preserve labels and time range for logs drilldown

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
       GF_PLUGINS_PREINSTALL_DISABLED: true
     volumes:
       - ./provisioning/dashboards/dashboardJson:/etc/dashboards
+      - ../logs-drilldown/dist:/var/lib/grafana/plugins/grafana-lokiexplore-app
     extra_hosts:
       # This allows us to connect to other services running on the host machine.
       - 'host.docker.internal:host-gateway'

--- a/src/RelatedLogs/OpenInLogsDrilldownButton.tsx
+++ b/src/RelatedLogs/OpenInLogsDrilldownButton.tsx
@@ -1,0 +1,57 @@
+import { config, usePluginLinks } from '@grafana/runtime';
+import { type SceneDataQuery, type SceneTimeRangeState } from '@grafana/scenes';
+import { LinkButton } from '@grafana/ui';
+import React, { useMemo } from 'react';
+
+import { reportExploreMetrics } from '../interactions';
+
+const extensionPointId = 'grafana-metricsdrilldown-app/open-in-logs-drilldown/v1';
+
+export interface LogsDrilldownLinkContext {
+  targets: SceneDataQuery[];
+  timeRange?: SceneTimeRangeState;
+}
+
+export function OpenInLogsDrilldownButton({ context }: Readonly<{ context: LogsDrilldownLinkContext }>) {
+  const memoizedContext = useMemo(() => context, [context]);
+  const { links, isLoading } = usePluginLinks({
+    extensionPointId,
+    limitPerPlugin: 1,
+    context: memoizedContext,
+  });
+  const logsDrilldownLink = useMemo(() => {
+    return links.find(({ pluginId }) => pluginId === 'grafana-lokiexplore-app');
+  }, [links]);
+
+  if (isLoading) {
+    return (
+      <LinkButton variant="secondary" size="sm" disabled>
+        Loading...
+      </LinkButton>
+    );
+  }
+
+  const logsDrilldownLinkExists = typeof logsDrilldownLink !== 'undefined';
+
+  return (
+    <LinkButton
+      href={
+        // We prefix with the appSubUrl for environments that don't host grafana at the root.
+        logsDrilldownLinkExists
+          ? `${config.appSubUrl}${logsDrilldownLink.path}`
+          : `${config.appSubUrl}/a/grafana-lokiexplore-app` // We fall back to the app's landing page if a link can't get generated using the supplied `context`
+      }
+      target="_blank"
+      tooltip={
+        logsDrilldownLinkExists
+          ? 'Use the Logs Drilldown app to explore these logs'
+          : 'Navigate to the Logs Drilldown app'
+      }
+      variant="secondary"
+      size="sm"
+      onClick={() => reportExploreMetrics('related_logs_action_clicked', { action: 'open_logs_drilldown' })}
+    >
+      {logsDrilldownLinkExists ? 'Open in Logs Drilldown' : 'Open Logs Drilldown'}
+    </LinkButton>
+  );
+}

--- a/src/RelatedLogs/OpenInLogsDrilldownButton.tsx
+++ b/src/RelatedLogs/OpenInLogsDrilldownButton.tsx
@@ -31,23 +31,27 @@ export function OpenInLogsDrilldownButton({ context }: Readonly<{ context: LogsD
     );
   }
 
-  if (typeof logsDrilldownLink === 'undefined') {
-    return null;
-  }
+  const logsDrilldownLinkExists = typeof logsDrilldownLink !== 'undefined';
 
   return (
     <LinkButton
       href={
         // We prefix with the appSubUrl for environments that don't host grafana at the root.
-        `${config.appSubUrl}${logsDrilldownLink.path}`
+        logsDrilldownLinkExists
+          ? `${config.appSubUrl}${logsDrilldownLink.path}`
+          : `${config.appSubUrl}/a/grafana-lokiexplore-app` // We fall back to the app's landing page if a link can't get generated using the supplied `context`
       }
       target="_blank"
-      tooltip={'Navigate to the Logs Drilldown app'}
+      tooltip={
+        logsDrilldownLinkExists
+          ? 'Use the Logs Drilldown app to explore these logs'
+          : 'Navigate to the Logs Drilldown app'
+      }
       variant="secondary"
       size="sm"
       onClick={() => reportExploreMetrics('related_logs_action_clicked', { action: 'open_logs_drilldown' })}
     >
-      Open in Logs Drilldown
+      {logsDrilldownLinkExists ? 'Open in Logs Drilldown' : 'Open Logs Drilldown'}
     </LinkButton>
   );
 }

--- a/src/RelatedLogs/OpenInLogsDrilldownButton.tsx
+++ b/src/RelatedLogs/OpenInLogsDrilldownButton.tsx
@@ -31,27 +31,23 @@ export function OpenInLogsDrilldownButton({ context }: Readonly<{ context: LogsD
     );
   }
 
-  const logsDrilldownLinkExists = typeof logsDrilldownLink !== 'undefined';
+  if (typeof logsDrilldownLink === 'undefined') {
+    return null;
+  }
 
   return (
     <LinkButton
       href={
         // We prefix with the appSubUrl for environments that don't host grafana at the root.
-        logsDrilldownLinkExists
-          ? `${config.appSubUrl}${logsDrilldownLink.path}`
-          : `${config.appSubUrl}/a/grafana-lokiexplore-app` // We fall back to the app's landing page if a link can't get generated using the supplied `context`
+        `${config.appSubUrl}${logsDrilldownLink.path}`
       }
       target="_blank"
-      tooltip={
-        logsDrilldownLinkExists
-          ? 'Use the Logs Drilldown app to explore these logs'
-          : 'Navigate to the Logs Drilldown app'
-      }
+      tooltip={'Navigate to the Logs Drilldown app'}
       variant="secondary"
       size="sm"
       onClick={() => reportExploreMetrics('related_logs_action_clicked', { action: 'open_logs_drilldown' })}
     >
-      {logsDrilldownLinkExists ? 'Open in Logs Drilldown' : 'Open Logs Drilldown'}
+      Open in Logs Drilldown
     </LinkButton>
   );
 }

--- a/src/RelatedLogs/RelatedLogsOrchestrator.ts
+++ b/src/RelatedLogs/RelatedLogsOrchestrator.ts
@@ -1,5 +1,5 @@
 import { LoadingState } from '@grafana/data';
-import { SceneQueryRunner } from '@grafana/scenes';
+import { SceneQueryRunner, type QueryRunnerState } from '@grafana/scenes';
 
 import { type MetricsLogsConnector } from '../Integrations/logs/base';
 import { createLabelsCrossReferenceConnector } from '../Integrations/logs/labelsCrossReference';
@@ -165,7 +165,7 @@ export class RelatedLogsOrchestrator {
 
           // Check if we found logs in this datasource
           if (state.data?.series) {
-            const rowCount = state.data.series.reduce((sum: number, frame) => sum + frame.length, 0);
+            const rowCount = this.countLogsLines(state);
             if (rowCount > 0) {
               // This datasource has logs
               datasourcesWithLogs.push(datasource);
@@ -192,5 +192,12 @@ export class RelatedLogsOrchestrator {
    */
   public checkConditionsMetForRelatedLogs(): boolean {
     return this._logsConnectors.some((connector) => connector.checkConditionsMetForRelatedLogs());
+  }
+
+  /**
+   * Given the state of a query runner running a Loki query, count the number of log lines.
+   */
+  public countLogsLines(state: QueryRunnerState): number {
+    return state.data?.series.reduce((sum: number, frame) => sum + frame.length, 0) ?? 0;
   }
 }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -63,6 +63,9 @@
     "extensionPoints": [
       {
         "id": "grafana-exploremetrics-app/investigation/v1"
+      },
+      {
+        "id": "grafana-metricsdrilldown-app/open-in-logs-drilldown/v1"
       }
     ]
   }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** This PR closes #524.

By leveraging the Grafana Logs Drilldown app's ability to generate links to certain Logs Drilldown views, we can improve the transition from Grafana Metrics Drilldown app's Related Logs scene to Grafana Logs Drilldown.

Before this PR, users could **Open Logs Drilldown** from the Related Logs tab, but this would only take them to the Logs Drilldown homepage, requiring them to re-apply label filters and time range settings before continuing their Drilldown journey.

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

- Adds a new [Extension Point](https://grafana.com/developers/plugin-tools/how-to-guides/ui-extensions/create-an-extension-point) to Metrics Drilldown to allow Logs Drilldown to create links to views with the correct label filters and time range (see companion PR, https://github.com/grafana/logs-drilldown/pull/1389)
- Updates the Related Logs scene to leverage the Logs Drilldown links when related logs are found

### Next steps

https://github.com/grafana/metrics-drilldown/issues/537 captures the need for e2e tests for the Related Logs feature. Creating e2e tests for Related Logs is challenging due to the TSDB resources involved (captured by https://github.com/grafana/metrics-drilldown/issues/536).

### Demo

https://github.com/user-attachments/assets/41d2c533-1cb6-48b0-8750-75819c4978bf

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

The setup involved in testing this PR is a bit tedious - sorry! We can improve this in the future. I created https://github.com/grafana/metrics-drilldown/issues/536 to capture this need.

#### Logs Drilldown setup

1. If you haven't already, clone the https://github.com/grafana/logs-drilldown project
2. If you've cloned the project previously, check that the directory name matches the repo name (`logs-drilldown`) and that it's a sibling of the `metrics-drilldown` project in your filesystem
3. Check out the latest `main`, which contains the [requisite Extension Point updates](https://github.com/grafana/logs-drilldown/pull/1389)
4. Build the project (e.g. with `yarn build`)

#### Metrics Drilldown setup

(Adapted from https://github.com/grafana/grafana/pull/98775)

I recommend using https://github.com/NWRichmond/demo-prometheus-loki-shared-labels to test this PR. If you'd like to test with other Prometheus & Loki resources, awesome!

1. Check out https://github.com/NWRichmond/demo-prometheus-loki-shared-labels and follow the Getting Started to spin up Prometheus and Loki resources on ports `9098` and `3108`, respectively
5. Create new Prometheus and Loki data sources that point to these services. The easiest way to do that is to create a `provisioning/datasources/labels-cross-reference.yaml` file containing:

```yaml
apiVersion: 1

datasources:
  - name: prometheus-labels-x-ref
    uid: prometheus-labels-x-ref
    type: prometheus
    access: proxy
    url: http://host.docker.internal:9098
    basicAuth: false
    withCredentials: false
    jsonData:
      manageAlerts: true
      prometheusType: Prometheus
      prometheusVersion: '3.2.1'
      cacheLevel: 'Low'
  - name: loki-labels-x-ref
    uid: loki-labels-x-ref
    type: loki
    access: proxy
    url: http://host.docker.internal:3108
    jsonData:
      manageAlerts: true
```

6. In Metrics Drilldown, select the new Prometheus data source (`prometheus-labels-x-ref`)
7. Select a metric and apply some labels to the filter. Some labels are shared (such as `region=us-west-2,environment=dev`) while others are not (`instance=demo-app:80`). We expect logs to only appear when the filters contain shared labels.
