### PR TITLE
fix: exclude dubious errors from error boundary

### DIFF
--- a/src/App/useCatchExceptions.test.ts
+++ b/src/App/useCatchExceptions.test.ts
@@ -1,0 +1,108 @@
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+
+import { useCatchExceptions } from './useCatchExceptions';
+import { logger } from '../tracking/logger/logger';
+
+// Mock the logger
+jest.mock('../tracking/logger/logger', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+describe('useCatchExceptions', () => {
+  const mockLogger = logger as jest.Mocked<typeof logger>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should filter out chrome extension errors and log them', () => {
+    const { result } = renderHook(() => useCatchExceptions());
+
+    // Simulate a chrome extension error
+    const chromeExtensionError = new ErrorEvent('error', {
+      message: 'Failed to execute appendChild on Node',
+      filename: 'chrome-extension://some-extension-id/something.html',
+      lineno: 13,
+      colno: 35,
+      error: new Error('TypeError: Failed to execute appendChild on Node'),
+    });
+
+    // Trigger the error event
+    act(() => {
+      window.dispatchEvent(chromeExtensionError);
+    });
+
+    // The error should be logged but not set as an application error
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Chrome extension error: Failed to execute appendChild on Node',
+      }),
+      expect.objectContaining({
+        filename: 'chrome-extension://some-extension-id/something.html',
+        lineno: '13',
+        colno: '35',
+      })
+    );
+
+    // The error state should remain undefined
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it('should filter out null error events with messages and log them', () => {
+    const { result } = renderHook(() => useCatchExceptions());
+
+    // Simulate a ResizeObserver error
+    const resizeObserverError = new ErrorEvent('error', {
+      message: 'ResizeObserver loop completed with undelivered notifications.',
+      filename: 'https://example.com/app.js',
+      lineno: 42,
+      colno: 10,
+      error: null,
+    });
+
+    // Trigger the error event
+    act(() => {
+      window.dispatchEvent(resizeObserverError);
+    });
+
+    // The error should be logged but not set as an application error
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Non-critical error: ResizeObserver loop completed with undelivered notifications.',
+      }),
+      expect.objectContaining({
+        filename: 'https://example.com/app.js',
+        lineno: '42',
+        colno: '10',
+      })
+    );
+
+    // The error state should remain undefined
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it('should catch legitimate application errors', () => {
+    const { result } = renderHook(() => useCatchExceptions());
+
+    // Simulate a legitimate application error (not from chrome extension and not null error)
+    const appError = new ErrorEvent('error', {
+      message: 'Cannot read property of undefined',
+      filename: 'https://example.com/app.js',
+      lineno: 100,
+      colno: 5,
+      error: new Error('TypeError: Cannot read property of undefined'),
+    });
+
+    // Trigger the error event
+    act(() => {
+      window.dispatchEvent(appError);
+    });
+
+    // The error should be set as an application error
+    expect(result.current[0]).toBeInstanceOf(Error);
+    expect(result.current[0]?.message).toBe('TypeError: Cannot read property of undefined');
+  });
+});

--- a/src/App/useCatchExceptions.test.ts
+++ b/src/App/useCatchExceptions.test.ts
@@ -18,11 +18,11 @@ describe('useCatchExceptions', () => {
     jest.clearAllMocks();
   });
 
-  it('should filter out chrome extension errors and log them', () => {
+  it('should filter out browser extension errors and log them', () => {
     const { result } = renderHook(() => useCatchExceptions());
 
-    // Simulate a chrome extension error
-    const chromeExtensionError = new ErrorEvent('error', {
+    // Simulate a browser extension error
+    const browserExtensionError = new ErrorEvent('error', {
       message: 'Failed to execute appendChild on Node',
       filename: 'chrome-extension://some-extension-id/something.html',
       lineno: 13,
@@ -32,13 +32,13 @@ describe('useCatchExceptions', () => {
 
     // Trigger the error event
     act(() => {
-      window.dispatchEvent(chromeExtensionError);
+      window.dispatchEvent(browserExtensionError);
     });
 
     // The error should be logged but not set as an application error
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: 'Chrome extension error: Failed to execute appendChild on Node',
+        message: 'Browser extension error: Failed to execute appendChild on Node',
       }),
       expect.objectContaining({
         filename: 'chrome-extension://some-extension-id/something.html',
@@ -87,7 +87,7 @@ describe('useCatchExceptions', () => {
   it('should catch legitimate application errors', () => {
     const { result } = renderHook(() => useCatchExceptions());
 
-    // Simulate a legitimate application error (not from chrome extension and not null error)
+    // Simulate a legitimate application error (not from browser extension and not null error)
     const appError = new ErrorEvent('error', {
       message: 'Cannot read property of undefined',
       filename: 'https://example.com/app.js',

--- a/src/App/useCatchExceptions.ts
+++ b/src/App/useCatchExceptions.ts
@@ -17,17 +17,21 @@ function ensureErrorObject(error: any, defaultMessage: string): Error {
 
 /**
  * Determines if an error should be treated as an application-breaking error.
- * Filters out known non-critical errors like chrome extension errors and ResizeObserver warnings.
+ * Filters out known non-critical errors like browser extension errors and ResizeObserver warnings.
  */
 function shouldTreatAsApplicationError(errorEvent: ErrorEvent): boolean {
-  // Check if error is from a chrome extension
-  if (errorEvent.filename && errorEvent.filename.startsWith('chrome-extension://')) {
-    logger.error(new Error(`Chrome extension error: ${errorEvent.message}`), {
-      filename: errorEvent.filename,
-      lineno: errorEvent.lineno?.toString(),
-      colno: errorEvent.colno?.toString(),
-    });
-    return false;
+  // Check if error is from a browser extension
+  if (errorEvent.filename) {
+    const protocol = new URL(errorEvent.filename).protocol;
+
+    if (protocol.endsWith('extension:')) {
+      logger.error(new Error(`Browser extension error: ${errorEvent.message}`), {
+        filename: errorEvent.filename,
+        lineno: errorEvent.lineno?.toString(),
+        colno: errorEvent.colno?.toString(),
+      });
+      return false;
+    }
   }
 
   // Check for null error with message (like ResizeObserver warnings)

--- a/src/App/useCatchExceptions.ts
+++ b/src/App/useCatchExceptions.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+import { logger } from '../tracking/logger/logger';
+
 function ensureErrorObject(error: any, defaultMessage: string): Error {
   if (error instanceof Error) {
     return error;
@@ -13,6 +15,34 @@ function ensureErrorObject(error: any, defaultMessage: string): Error {
   return new Error(defaultMessage);
 }
 
+/**
+ * Determines if an error should be treated as an application-breaking error.
+ * Filters out known non-critical errors like chrome extension errors and ResizeObserver warnings.
+ */
+function shouldTreatAsApplicationError(errorEvent: ErrorEvent): boolean {
+  // Check if error is from a chrome extension
+  if (errorEvent.filename && errorEvent.filename.startsWith('chrome-extension://')) {
+    logger.error(new Error(`Chrome extension error: ${errorEvent.message}`), {
+      filename: errorEvent.filename,
+      lineno: errorEvent.lineno?.toString(),
+      colno: errorEvent.colno?.toString(),
+    });
+    return false;
+  }
+
+  // Check for null error with message (like ResizeObserver warnings)
+  if (errorEvent.error === null && errorEvent.message) {
+    logger.error(new Error(`Non-critical error: ${errorEvent.message}`), {
+      filename: errorEvent.filename,
+      lineno: errorEvent.lineno?.toString(),
+      colno: errorEvent.colno?.toString(),
+    });
+    return false;
+  }
+
+  return true;
+}
+
 export function useCatchExceptions(): [Error | undefined, React.Dispatch<React.SetStateAction<Error | undefined>>] {
   const [error, setError] = useState<Error>();
 
@@ -20,6 +50,10 @@ export function useCatchExceptions(): [Error | undefined, React.Dispatch<React.S
   // so we have to set global handlers to catch these (e.g. error thrown from some click handlers)
   useEffect(() => {
     const onError = (errorEvent: ErrorEvent) => {
+      if (!shouldTreatAsApplicationError(errorEvent)) {
+        return;
+      }
+
       setError(ensureErrorObject(errorEvent.error, 'Uncaught exception!'));
     };
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** Fixes #526

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

Before this PR, `errorEvent`s with falsey `error` properties (including errors originating from problematic browser extensions) were causing experience-breaking application errors.

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

This PR adjusts error handling, such that:
- Errors originating from browser extensions are logged and manually tracked with Faro (using `logger.error`) but don't make it to the error boundary.
- `errorEvent`s without an `error` property are logged and manually tracked with Faro (using `logger.error`) but don't make it to the error boundary. We are making an assumption that if an `errorEvent` doesn't have an `error` property, then it shouldn't be a Metrics Drilldown application error. We can revisit this assumption as needed.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

All CI should pass, which implies that the tests added in this PR are passing.

If anyone's interested, I can work on some instructions for testing this locally with falsey errors.
