### PR TITLE
feat(ExtensionPoint): Add link for Grafana assistant to build URL

### DIFF
--- a/src/extensions/links.test.ts
+++ b/src/extensions/links.test.ts
@@ -1,4 +1,4 @@
-import { parsePromQueryRegex } from './links';
+import { buildNavigateToMetricsParams, parsePromQueryRegex, UrlParameters, type MetricsDrilldownContext } from './links';
 
 describe('parsePromQueryRegex', () => {
   test('should parse basic metric name', () => {
@@ -77,5 +77,54 @@ describe('parsePromQueryRegex', () => {
     const result = parsePromQueryRegex('invalid{query');
     expect(result.metric).toBe('invalid');
     expect(result.labelFilters).toEqual([]);
+  });
+});
+
+describe('buildNavigateToMetricsParams', () => {
+  it('should build URL parameters with all fields populated', () => {
+    const context: MetricsDrilldownContext = {
+      navigateToMetrics: true,
+      datasource_uid: 'test-datasource-uid',
+      metric: 'http_requests_total',
+      start: '2024-01-01T00:00:00Z',
+      end: '2024-01-01T01:00:00Z',
+      label_filters: ['status=200', 'method=GET', 'path=/api/test'],
+    };
+
+    const result = buildNavigateToMetricsParams(context);
+
+    expect(result.get(UrlParameters.Metric)).toBe('http_requests_total');
+    expect(result.get(UrlParameters.TimeRangeFrom)).toBe('2024-01-01T00:00:00Z');
+    expect(result.get(UrlParameters.TimeRangeTo)).toBe('2024-01-01T01:00:00Z');
+    expect(result.get(UrlParameters.DatasourceId)).toBe('test-datasource-uid');
+    expect(result.getAll(UrlParameters.Filters)).toEqual(['status=200', 'method=GET', 'path=/api/test']);
+  });
+
+  it('should build URL parameters with only required fields', () => {
+    const context: MetricsDrilldownContext = {
+      navigateToMetrics: true,
+      datasource_uid: 'test-datasource-uid',
+    };
+
+    const result = buildNavigateToMetricsParams(context);
+
+    expect(result.get(UrlParameters.Metric)).toBeNull();
+    expect(result.get(UrlParameters.TimeRangeFrom)).toBeNull();
+    expect(result.get(UrlParameters.TimeRangeTo)).toBeNull();
+    expect(result.get(UrlParameters.DatasourceId)).toBe('test-datasource-uid');
+    expect(result.getAll(UrlParameters.Filters)).toEqual([]);
+  });
+
+  it('should handle undefined label_filters', () => {
+    const context: MetricsDrilldownContext = {
+      navigateToMetrics: true,
+      datasource_uid: 'test-datasource-uid',
+      label_filters: undefined,
+    };
+
+    const result = buildNavigateToMetricsParams(context);
+
+    expect(result.get(UrlParameters.DatasourceId)).toBe('test-datasource-uid');
+    expect(result.getAll(UrlParameters.Filters)).toEqual([]);
   });
 });

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -72,7 +72,55 @@ export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
       };
     },
   },
+  {
+    targets: ['grafana-metricsdrilldown-app/grafana-assistant-app/navigateToDrilldown/v0-alpha'],
+    title: 'Navigate to metrics drilldown',
+    description: 'Build a url path to the metrics drilldown',
+    path: createAppUrl(ROUTES.Drilldown),
+    configure: (context) => {
+      if (typeof context === 'undefined') {
+        return;
+      }
+
+      const navigateToMetrics = (context as MetricsDrilldownContext).navigateToMetrics;
+      if (navigateToMetrics) {
+        const { metric, start, end, datasource_uid, label_filters } = context as MetricsDrilldownContext;
+
+        const filters = label_filters ?? [];
+        // Use the structured context data to build parameters
+        const params = appendUrlParameters([
+          [UrlParameters.Metric, metric],
+          [UrlParameters.TimeRangeFrom, start],
+          [UrlParameters.TimeRangeTo, end],
+          [UrlParameters.DatasourceId, datasource_uid],
+          ...filters.map(
+            (filter) => [UrlParameters.Filters, filter] as [UrlParameterType, string]
+          ),
+        ]);
+
+        const pathToMetricView = createAppUrl(ROUTES.Drilldown, params);
+
+        return {
+          path: pathToMetricView,
+        };
+      }
+
+      return {
+        path: createAppUrl(ROUTES.Drilldown),
+      };
+    },
+  },
 ];
+
+// Type for the metrics drilldown context from Grafana Assistant
+type MetricsDrilldownContext = {
+  navigateToMetrics: boolean;
+  datasource_uid: string;
+  label_filters?: string[];
+  metric?: string;
+  start?: string;
+  end?: string;
+};
 
 export function createAppUrl(route: string, urlParams?: URLSearchParams): string {
   const urlParamsAsString = urlParams ? `?${urlParams.toString()}` : '';

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -83,30 +83,10 @@ export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
       }
 
       const navigateToMetrics = (context as MetricsDrilldownContext).navigateToMetrics;
-      if (navigateToMetrics) {
-        const { metric, start, end, datasource_uid, label_filters } = context as MetricsDrilldownContext;
-
-        const filters = label_filters ?? [];
-        // Use the structured context data to build parameters
-        const params = appendUrlParameters([
-          [UrlParameters.Metric, metric],
-          [UrlParameters.TimeRangeFrom, start],
-          [UrlParameters.TimeRangeTo, end],
-          [UrlParameters.DatasourceId, datasource_uid],
-          ...filters.map(
-            (filter) => [UrlParameters.Filters, filter] as [UrlParameterType, string]
-          ),
-        ]);
-
-        const pathToMetricView = createAppUrl(ROUTES.Drilldown, params);
-
-        return {
-          path: pathToMetricView,
-        };
-      }
+      const params = navigateToMetrics ? buildNavigateToMetricsParams(context as MetricsDrilldownContext) : undefined;
 
       return {
-        path: createAppUrl(ROUTES.Drilldown),
+        path: createAppUrl(ROUTES.Drilldown, params),
       };
     },
   },
@@ -121,6 +101,22 @@ type MetricsDrilldownContext = {
   start?: string;
   end?: string;
 };
+
+function buildNavigateToMetricsParams(context: MetricsDrilldownContext): URLSearchParams {
+  const { metric, start, end, datasource_uid, label_filters } = context;
+
+  const filters = label_filters ?? [];
+  // Use the structured context data to build parameters
+  return appendUrlParameters([
+    [UrlParameters.Metric, metric],
+    [UrlParameters.TimeRangeFrom, start],
+    [UrlParameters.TimeRangeTo, end],
+    [UrlParameters.DatasourceId, datasource_uid],
+    ...filters.map(
+      (filter) => [UrlParameters.Filters, filter] as [UrlParameterType, string]
+    ),
+  ]);
+}
 
 export function createAppUrl(route: string, urlParams?: URLSearchParams): string {
   const urlParamsAsString = urlParams ? `?${urlParams.toString()}` : '';

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -93,7 +93,7 @@ export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
 ];
 
 // Type for the metrics drilldown context from Grafana Assistant
-type MetricsDrilldownContext = {
+export type MetricsDrilldownContext = {
   navigateToMetrics: boolean;
   datasource_uid: string;
   label_filters?: string[];
@@ -102,7 +102,7 @@ type MetricsDrilldownContext = {
   end?: string;
 };
 
-function buildNavigateToMetricsParams(context: MetricsDrilldownContext): URLSearchParams {
+export function buildNavigateToMetricsParams(context: MetricsDrilldownContext): URLSearchParams {
   const { metric, start, end, datasource_uid, label_filters } = context;
 
   const filters = label_filters ?? [];

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -58,6 +58,11 @@
         "targets": ["grafana/dashboard/panel/menu", "grafana/explore/toolbar/action"],
         "title": "Open in Grafana Metrics Drilldown",
         "description": "Open current query in the Grafana Metrics Drilldown view"
+      },
+      {
+        "targets": ["grafana-metricsdrilldown-app/grafana-assistant-app/navigateToDrilldown/v0-alpha"],
+        "title": "Navigate to metrics drilldown",
+        "description": "Build a url path to the metrics drilldown"
       }
     ],
     "extensionPoints": [


### PR DESCRIPTION
### ✨ Description

The Grafana Assistant is currently building the link to metrics drilldown manually in their code. This work adds a link from the metrics drilldown app to expose code to build the URL from our repo. 

This means that we are responsible for the correct building of the url.

https://github.com/user-attachments/assets/fbedf97c-de25-410e-98b5-8e38bafd7752

**Related issue(s):** https://github.com/grafana/metrics-drilldown/issues/501

### 📖 Summary of the changes

Add an extension point link to build a URL for Grafana Assistant.

### 🧪 How to test?

1. [Run Grafana Assistant locally](https://github.com/grafana/grafana-assistant-app) 
  - Follow the steps exactly in the repo, please ask me if you get stuck 
2. Build metrics drilldown
3. Run Grafana locally from the instructions in the grafana assistant repository instructions (IMPORTANT)
4. Open the assistant.
5. Navigate to explore and write yourself a query with labels.
6. Copy this query.
7. Ask the assistant to navigate to metrics drilldown using this query.
8. See that the labels and metric are in the url and the metrics drilldown app reflects this in the metrics scene.





