### PR TITLE
bug: Labels require a delimiter when building links

### DIFF
--- a/src/extensions/links.test.ts
+++ b/src/extensions/links.test.ts
@@ -1,4 +1,4 @@
-import { parsePromQueryRegex } from './links';
+import { ADHOC_URL_DELIMITER, parsePromQueryRegex } from './links';
 
 describe('parsePromQueryRegex', () => {
   test('should parse basic metric name', () => {
@@ -77,5 +77,30 @@ describe('parsePromQueryRegex', () => {
     const result = parsePromQueryRegex('invalid{query');
     expect(result.metric).toBe('invalid');
     expect(result.labelFilters).toEqual([]);
+  });
+});
+
+describe('URL Parameter Label Filter Formatting', () => {
+  test('should format filter parameters with delimiter', () => {
+    const mockLabelFilter = { label: 'method', op: '=', value: 'GET' };
+    const formattedFilter = `${mockLabelFilter.label}${ADHOC_URL_DELIMITER}${mockLabelFilter.op}${ADHOC_URL_DELIMITER}${mockLabelFilter.value}`;
+    
+    expect(formattedFilter).toBe(`method${ADHOC_URL_DELIMITER}=${ADHOC_URL_DELIMITER}GET`);
+  });
+
+  test('should handle multiple filters with delimiter', () => {
+    const mockLabelFilters = [
+      { label: 'method', op: '=', value: 'GET' },
+      { label: 'status', op: '!=', value: '404' },
+      { label: 'path', op: '=~', value: '/api/.*' }
+    ];
+    
+    const formattedFilters = mockLabelFilters.map(f => `${f.label}${ADHOC_URL_DELIMITER}${f.op}${ADHOC_URL_DELIMITER}${f.value}`);
+    
+    expect(formattedFilters).toEqual([
+      `method${ADHOC_URL_DELIMITER}=${ADHOC_URL_DELIMITER}GET`,
+      `status${ADHOC_URL_DELIMITER}!=${ADHOC_URL_DELIMITER}404`,
+      `path${ADHOC_URL_DELIMITER}=~${ADHOC_URL_DELIMITER}/api/.*`
+    ]);
   });
 });

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -15,6 +15,8 @@ const description = `Open current query in the ${PRODUCT_NAME} view`;
 const category = 'metrics-drilldown';
 const icon = 'gf-prometheus';
 
+export const ADHOC_URL_DELIMITER = '|'; 
+
 export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
   {
     targets: [PluginExtensionPoints.DashboardPanelMenu, PluginExtensionPoints.ExploreToolbarAction],
@@ -61,7 +63,7 @@ export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
         [UrlParameters.TimeRangeTo, timeRange?.to],
         [UrlParameters.DatasourceId, datasource.uid],
         ...query.labelFilters.map(
-          (f) => [UrlParameters.Filters, `${f.label}${f.op}${f.value}`] as [UrlParameterType, string]
+          (f) => [UrlParameters.Filters, `${f.label}${ADHOC_URL_DELIMITER}${f.op}${ADHOC_URL_DELIMITER}${f.value}`] as [UrlParameterType, string]
         ),
       ]);
 


### PR DESCRIPTION
Fixes https://github.com/grafana/metrics-drilldown/issues/523

### ✨ Description

**Related issue(s):** 
https://github.com/grafana/metrics-drilldown/issues/523

<img width="399" height="314" alt="Screenshot 2025-07-10 at 6 30 19 PM" src="https://github.com/user-attachments/assets/2ca17ac1-b9af-421d-ac3a-873b2bd07978" />

<img width="940" height="288" alt="Screenshot 2025-07-10 at 6 24 32 PM" src="https://github.com/user-attachments/assets/69bc3fe1-835f-4ba3-96fe-61467273161c" />

When adding labels, the url contains the labels in the `var-filters` param and uses a `|` delimiter between the name, op and value.

`var-filter=service_name|=|adservice`
escaped: `var-filters=service_name%7C%3D%7Cadservice`

We need to add the `|` when building a link so that the explore link and dashboard links respect the label filters when navigating to metrics drilldown.

### 📖 Summary of the changes

Add a `|` delimiter to label filter elements when building a link.

### 🧪 How to test?

#### Explore link

<img width="449" height="234" alt="Screenshot 2025-07-10 at 6 27 47 PM" src="https://github.com/user-attachments/assets/708836e0-1b50-4c37-9e50-586f4fe2154f" />

1. Navigate to Explore and chose a metrics and labels
2. See the go queryless button.
3. Use it to navigate to Metrics drilldown.
4. See labels are respected

#### Dashboard link

<img width="778" height="294" alt="Screenshot 2025-07-10 at 6 29 05 PM" src="https://github.com/user-attachments/assets/f14b4082-9145-442a-9d95-69923c757e87" />

1. Open a dashboard with a Prometheus query used in a panel
2. Make sure the Dashboard is NOT in edit mode
3. Click the `...` menu and see metrics drilldown link
4. Use the link to navigate to metrics drilldown and see labels are respected.