### PR TITLE
chore: prepare for removal of deprecated method

### DIFF
--- a/src/helpers/MetricDatasourceHelper.ts
+++ b/src/helpers/MetricDatasourceHelper.ts
@@ -213,11 +213,14 @@ export class MetricDatasourceHelper {
    * It will be removed when we upgrade the Grafana dependency to 12.0.0.
    * For more details, see https://github.com/grafana/metrics-drilldown/issues/370.
    */
-  public static datasourceUsesTimeRangeInLanguageProviderMethods(ds: PrometheusDatasource): boolean {
+  public static dsUsesTimeRangeInLegacyLanguageProviderMethods(ds: PrometheusDatasource): boolean {
     // This works because the `fetchLabelValues` method happens to have changed in a way that
     // can be used as a heuristic to check if the runtime datasource uses the G12-style
     // language provider methods introduced in https://github.com/grafana/grafana/pull/101889.
-    return ds.languageProvider.fetchLabelValues.length > 1; // eslint-disable-line sonarjs/deprecation
+    return (
+      // eslint-disable-next-line sonarjs/deprecation
+      typeof ds.languageProvider.fetchLabelValues === 'function' && ds.languageProvider.fetchLabelValues.length > 1
+    );
   }
 
   /**
@@ -254,7 +257,7 @@ export class MetricDatasourceHelper {
       return ds.languageProvider.queryLabelKeys(timeRange, matcher);
     }
 
-    if (MetricDatasourceHelper.datasourceUsesTimeRangeInLanguageProviderMethods(ds)) {
+    if (MetricDatasourceHelper.dsUsesTimeRangeInLegacyLanguageProviderMethods(ds)) {
       // eslint-disable-next-line sonarjs/deprecation
       return ds.languageProvider.fetchLabelsWithMatch(timeRange, matcher).then((labels) => Object.keys(labels));
     }
@@ -304,7 +307,7 @@ export class MetricDatasourceHelper {
       ? ds.languageProvider.fetchSeriesValuesWithMatch // eslint-disable-line sonarjs/deprecation
       : ds.languageProvider.fetchLabelValues; // eslint-disable-line sonarjs/deprecation
 
-    if (MetricDatasourceHelper.datasourceUsesTimeRangeInLanguageProviderMethods(ds)) {
+    if (MetricDatasourceHelper.dsUsesTimeRangeInLegacyLanguageProviderMethods(ds)) {
       return fetchLabelValuesWithOptionalMatcher(timeRange, labelName, matcher);
     }
 


### PR DESCRIPTION
### ✨ Description

This PR adds an additional layer of safety in preparation for the eventual removal of deprecated `languageProvider` methods from the `@grafana/prometheus` package.

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

Although we shouldn't hit a case where the `dsUsesTimeRangeInLegacyLanguageProviderMethods` method is called for a version of `@grafana/prometheus` that doesn't have these functions (it should call the `queryLabelKeys`/`queryLabelValues` methods instead), this PR adds an additional check to the existence of the `languageProvider.fetchLabelValues` method before checking the number of parameters it has.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

All CI should pass.
