### PR TITLE
fix(links): add pipe delimiter for all extension point links

### DIFF
--- a/src/extensions/links.test.ts
+++ b/src/extensions/links.test.ts
@@ -1,4 +1,4 @@
-import { buildNavigateToMetricsParams, configureDrilldownLink, createPromURLObject, parseFiltersToLabelMatchers, parsePromQLQuery, UrlParameters, type MetricsDrilldownContext } from './links';
+import { buildNavigateToMetricsParams, configureDrilldownLink, createPromURLObject, parseFiltersToLabelMatchers, parsePromQLQuery, UrlParameters, type GrafanaAssistantMetricsDrilldownContext } from './links';
 
 describe('parsePromQLQuery - lezer parser tests', () => {
   test('should parse basic metric name', () => {
@@ -264,7 +264,7 @@ describe('configureDrilldownLink', () => {
 
 describe('buildNavigateToMetricsParams', () => {
   it('should build URL parameters with all fields populated', () => {
-    const context: MetricsDrilldownContext = {
+    const context: GrafanaAssistantMetricsDrilldownContext = {
       navigateToMetrics: true,
       datasource_uid: 'test-datasource-uid',
       metric: 'http_requests_total',
@@ -287,7 +287,7 @@ describe('buildNavigateToMetricsParams', () => {
   });
 
   it('should build URL parameters with only required fields', () => {
-    const context: MetricsDrilldownContext = {
+    const context: GrafanaAssistantMetricsDrilldownContext = {
       navigateToMetrics: true,
       datasource_uid: 'test-datasource-uid',
     };
@@ -306,7 +306,7 @@ describe('buildNavigateToMetricsParams', () => {
   });
 
   it('should handle undefined label_filters', () => {
-    const context: MetricsDrilldownContext = {
+    const context: GrafanaAssistantMetricsDrilldownContext = {
       navigateToMetrics: true,
       datasource_uid: 'test-datasource-uid',
       label_filters: undefined,

--- a/src/extensions/links.test.ts
+++ b/src/extensions/links.test.ts
@@ -238,7 +238,7 @@ describe('configureDrilldownLink', () => {
   });
 
   describe('error handling', () => {
-    test('should return fallback URL and log errors when parsing fails', () => {
+    test('should return fallback URL when parsing fails', () => {
       // Test with a context that has a malformed query that might cause parsePromQLQuery to throw
       const context = {
         pluginId: 'timeseries',

--- a/src/extensions/links.test.ts
+++ b/src/extensions/links.test.ts
@@ -1,4 +1,4 @@
-import { buildNavigateToMetricsParams, configureDrilldownLink, parsePromQLQuery, UrlParameters, type MetricsDrilldownContext } from './links';
+import { buildNavigateToMetricsParams, configureDrilldownLink, createPromURLObject, parseFiltersToLabelMatchers, parsePromQLQuery, UrlParameters, type MetricsDrilldownContext } from './links';
 
 describe('parsePromQLQuery - lezer parser tests', () => {
   test('should parse basic metric name', () => {
@@ -272,14 +272,18 @@ describe('buildNavigateToMetricsParams', () => {
       end: '2024-01-01T01:00:00Z',
       label_filters: ['status=200', 'method=GET', 'path=/api/test'],
     };
-
-    const result = buildNavigateToMetricsParams(context);
+    // parse the labels to the PromQL format
+    const parsedLabels = parseFiltersToLabelMatchers(context.label_filters);
+    // create the PromURLObject for building params
+    const promURLObject = createPromURLObject(context.datasource_uid, parsedLabels, context.metric, context.start, context.end);
+    // build the params for the navigateToMetrics
+    const result = buildNavigateToMetricsParams(promURLObject);
 
     expect(result.get(UrlParameters.Metric)).toBe('http_requests_total');
     expect(result.get(UrlParameters.TimeRangeFrom)).toBe('2024-01-01T00:00:00Z');
     expect(result.get(UrlParameters.TimeRangeTo)).toBe('2024-01-01T01:00:00Z');
     expect(result.get(UrlParameters.DatasourceId)).toBe('test-datasource-uid');
-    expect(result.getAll(UrlParameters.Filters)).toEqual(['status=200', 'method=GET', 'path=/api/test']);
+    expect(result.getAll(UrlParameters.Filters)).toEqual(['status|=|200', 'method|=|GET', 'path|=|/api/test']);
   });
 
   it('should build URL parameters with only required fields', () => {
@@ -287,8 +291,12 @@ describe('buildNavigateToMetricsParams', () => {
       navigateToMetrics: true,
       datasource_uid: 'test-datasource-uid',
     };
-
-    const result = buildNavigateToMetricsParams(context);
+    // parse the labels to the PromQL format
+    const parsedLabels = parseFiltersToLabelMatchers(context.label_filters);
+    // create the PromURLObject for building params
+    const promURLObject = createPromURLObject(context.datasource_uid, parsedLabels, context.metric, context.start, context.end);
+    // build the params for the navigateToMetrics
+    const result = buildNavigateToMetricsParams(promURLObject);
 
     expect(result.get(UrlParameters.Metric)).toBeNull();
     expect(result.get(UrlParameters.TimeRangeFrom)).toBeNull();
@@ -303,8 +311,12 @@ describe('buildNavigateToMetricsParams', () => {
       datasource_uid: 'test-datasource-uid',
       label_filters: undefined,
     };
-
-    const result = buildNavigateToMetricsParams(context);
+    // parse the labels to the PromQL format
+    const parsedLabels = parseFiltersToLabelMatchers(context.label_filters);
+    // create the PromURLObject for building params
+    const promURLObject = createPromURLObject(context.datasource_uid, parsedLabels, context.metric, context.start, context.end);
+    // build the params for the navigateToMetrics
+    const result = buildNavigateToMetricsParams(promURLObject);
 
     expect(result.get(UrlParameters.DatasourceId)).toBe('test-datasource-uid');
     expect(result.getAll(UrlParameters.Filters)).toEqual([]);

--- a/src/extensions/links.test.ts
+++ b/src/extensions/links.test.ts
@@ -215,8 +215,8 @@ describe('configureDrilldownLink', () => {
       expect(result?.path).toContain('from=2023-01-01T00%3A00%3A00Z');
       expect(result?.path).toContain('to=2023-01-01T01%3A00%3A00Z');
       expect(result?.path).toContain('var-ds=prom-uid');
-      expect(result?.path).toContain('var-filters=method%3DGET');
-      expect(result?.path).toContain('var-filters=status%3D200');
+      expect(result?.path).toContain('var-filters=method%7C%3D%7CGET');
+      expect(result?.path).toContain('var-filters=status%7C%3D%7C200');
     });
 
     test('should construct URL with special characters in labels', () => {
@@ -233,7 +233,7 @@ describe('configureDrilldownLink', () => {
       const result = configureDrilldownLink(context);
       
       expect(result).toBeDefined();
-      expect(result?.path).toContain('var-filters=path%3D%2Fapi%2Fv1%2Fusers%3Fid%3D123%26name%3Dtest');
+      expect(result?.path).toContain('var-filters=path%7C%3D%7C%2Fapi%2Fv1%2Fusers%3Fid%3D123%26name%3Dtest');
     });
   });
 

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -7,9 +7,10 @@ import {
 import { type DataQuery } from '@grafana/schema';
 import { parser } from '@prometheus-io/lezer-promql';
 
+import { parseMatcher } from 'WingmanDataTrail/MetricVizPanel/parseMatcher';
+
 import { PLUGIN_BASE_URL, ROUTES } from '../constants';
 import { logger } from '../tracking/logger/logger';
-import { parseMatcher } from 'WingmanDataTrail/MetricVizPanel/parseMatcher';
 
 const PRODUCT_NAME = 'Grafana Metrics Drilldown';
 const title = `Open in ${PRODUCT_NAME}`;
@@ -56,7 +57,7 @@ export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
         start, 
         end
       };
-      
+
       const params = navigateToMetrics ? buildNavigateToMetricsParams(promURLObject) : undefined;
 
       return {
@@ -103,13 +104,15 @@ export function configureDrilldownLink(context: object | undefined) {
         ? (context.timeRange as { from: string; to: string })
         : undefined;
 
-    const params = appendUrlParameters([
-      [UrlParameters.Metric, metric], // we can create a path without a metric
-      [UrlParameters.TimeRangeFrom, timeRange?.from],
-      [UrlParameters.TimeRangeTo, timeRange?.to],
-      [UrlParameters.DatasourceId, datasource.uid],
-      ...labels.map(filterToUrlParameter),
-    ]);
+    const promURLObject = {
+      datasource_uid: datasource.uid, 
+      label_filters: labels, 
+      metric, 
+      start: timeRange?.from, 
+      end: timeRange?.to
+    };
+
+    const params = buildNavigateToMetricsParams(promURLObject);
 
     const pathToMetricView = createAppUrl(ROUTES.Drilldown, params);
 
@@ -215,7 +218,7 @@ export type MetricsDrilldownContext = {
 };
 
 type PromURLObject = {
-  datasource_uid: string;
+  datasource_uid?: string;
   label_filters?: PromQLLabelMatcher[];
   metric?: string;
   start?: string;

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -46,7 +46,7 @@ export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
         return;
       }
       
-      const { navigateToMetrics, datasource_uid, label_filters, metric, start, end }= (context as MetricsDrilldownContext);
+      const { navigateToMetrics, datasource_uid, label_filters, metric, start, end } = (context as GrafanaAssistantMetricsDrilldownContext);
       // parse the labels to the PromQL format
       const parsedLabels = parseFiltersToLabelMatchers(label_filters);
       // create the PromURLObject for building params
@@ -202,7 +202,7 @@ function filterToUrlParameter(filter: PromQLLabelMatcher): [UrlParameterType, st
 }
 
 // Type for the metrics drilldown context from Grafana Assistant
-export type MetricsDrilldownContext = {
+export type GrafanaAssistantMetricsDrilldownContext = {
   navigateToMetrics: boolean;
   datasource_uid: string;
   label_filters?: string[];

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -16,6 +16,8 @@ const description = `Open current query in the ${PRODUCT_NAME} view`;
 const category = 'metrics-drilldown';
 const icon = 'gf-prometheus';
 
+export const ADHOC_URL_DELIMITER = '|';
+
 export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
   {
     title,
@@ -88,9 +90,7 @@ export function configureDrilldownLink(context: object | undefined) {
       [UrlParameters.TimeRangeFrom, timeRange?.from],
       [UrlParameters.TimeRangeTo, timeRange?.to],
       [UrlParameters.DatasourceId, datasource.uid],
-      ...labels.map(
-        (filter) => [UrlParameters.Filters, `${filter.label}${filter.op}${filter.value}`] as [UrlParameterType, string]
-      ),
+      ...labels.map(filterToUrlParameter),
     ]);
 
     const pathToMetricView = createAppUrl(ROUTES.Drilldown, params);
@@ -176,6 +176,11 @@ function processLabelMatcher(node: any, expr: string): { label: string; op: stri
     return { label: labelName, op, value };
   }
   return null;
+}
+
+// Helper function to convert filter to URL parameter tuple
+function filterToUrlParameter(filter: { label: string; op: string; value: string }): [UrlParameterType, string] {
+  return [UrlParameters.Filters, `${filter.label}${ADHOC_URL_DELIMITER}${filter.op}${ADHOC_URL_DELIMITER}${filter.value}`] as [UrlParameterType, string];
 }
 
 // Type for the metrics drilldown context from Grafana Assistant

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -61,7 +61,7 @@ export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
   },
 ];
 
-export function configureDrilldownLink(context: object | undefined) {
+export function configureDrilldownLink(context: object | undefined): { path: string } | undefined {
   if (typeof context === 'undefined') {
     return;
   }

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -18,6 +18,12 @@ const icon = 'gf-prometheus';
 
 export const ADHOC_URL_DELIMITER = '|';
 
+export type PromQLLabelMatcher = {
+  label: string;
+  op: string;
+  value: string;
+};
+
 export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
   {
     title,
@@ -109,7 +115,7 @@ export function configureDrilldownLink(context: object | undefined) {
 
 export interface ParsedPromQLQuery {
   metric: string;
-  labels: Array<{ label: string; op: string; value: string }>;
+  labels: PromQLLabelMatcher[];
   hasErrors: boolean;
   errors: string[];
 }
@@ -117,7 +123,7 @@ export interface ParsedPromQLQuery {
 export function parsePromQLQuery(expr: string): ParsedPromQLQuery {
   const tree = parser.parse(expr);
   let metric = '';
-  const labels: Array<{ label: string; op: string; value: string }> = [];
+  const labels: PromQLLabelMatcher[] = [];
   let hasErrors = false;
   const errors: string[] = [];
 
@@ -151,7 +157,7 @@ export function parsePromQLQuery(expr: string): ParsedPromQLQuery {
 }
 
 // Helper function to process label matcher nodes
-function processLabelMatcher(node: any, expr: string): { label: string; op: string; value: string } | null {
+function processLabelMatcher(node: any, expr: string): PromQLLabelMatcher | null {
   if (node.name !== 'UnquotedLabelMatcher') {
     return null;
   }
@@ -178,8 +184,11 @@ function processLabelMatcher(node: any, expr: string): { label: string; op: stri
   return null;
 }
 
-// Helper function to convert filter to URL parameter tuple
-function filterToUrlParameter(filter: { label: string; op: string; value: string }): [UrlParameterType, string] {
+/**
+ * Scenes adhoc variable filters requires a | delimiter 
+ * between the label, operator, and value (see AdHocFiltersVariableUrlSyncHandler.ts in Scenes)
+ */
+function filterToUrlParameter(filter: PromQLLabelMatcher): [UrlParameterType, string] {
   return [UrlParameters.Filters, `${filter.label}${ADHOC_URL_DELIMITER}${filter.op}${ADHOC_URL_DELIMITER}${filter.value}`] as [UrlParameterType, string];
 }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/metrics-drilldown/issues/523

### ✨ Description

Fix: Add `|` delimiter for label filters when creating a link from an extension point.

**Related issue(s):** 
https://github.com/grafana/metrics-drilldown/issues/523

<img width="399" height="314" alt="Screenshot 2025-07-10 at 6 30 19 PM" src="https://github.com/user-attachments/assets/2ca17ac1-b9af-421d-ac3a-873b2bd07978" />

<img width="940" height="288" alt="Screenshot 2025-07-10 at 6 24 32 PM" src="https://github.com/user-attachments/assets/69bc3fe1-835f-4ba3-96fe-61467273161c" />

<img width="781" height="421" alt="Screenshot 2025-07-15 at 4 24 54 PM" src="https://github.com/user-attachments/assets/b04593f6-0a2c-4593-8b66-6901c836d4fc" />

When adding labels, the url contains the labels in the `var-filters` param and uses a `|` delimiter between the name, op and value.

`var-filter=service_name|=|adservice`
url encoded delimiter: `var-filters=service_name%7C%3D%7Cadservice`

We need to add the `|` when building a link so that the explore link and dashboard links respect the label filters when navigating to metrics drilldown.

### 📖 Summary of the changes

Add a `|` delimiter to label filter elements when building a link in Explore and Dashboard link as well as the Grafana Assistant link.

### 🧪 How to test?

#### Explore link

<img width="449" height="234" alt="Screenshot 2025-07-10 at 6 27 47 PM" src="https://github.com/user-attachments/assets/708836e0-1b50-4c37-9e50-586f4fe2154f" />

1. Navigate to Explore and chose a metrics and labels
2. See the go queryless button.
3. Use it to navigate to Metrics drilldown.
4. See labels are respected

#### Dashboard link

<img width="778" height="294" alt="Screenshot 2025-07-10 at 6 29 05 PM" src="https://github.com/user-attachments/assets/f14b4082-9145-442a-9d95-69923c757e87" />

1. Open a dashboard with a Prometheus query used in a panel
2. Make sure the Dashboard is NOT in edit mode
3. Click the `...` menu and see metrics drilldown link
4. Use the link to navigate to metrics drilldown and see labels are respected.

#### Grafana Assistant

1. [Run Grafana Assistant following the directions here exactly.](https://github.com/grafana/grafana-assistant-app)
2. Navigate to Explore and pick a prometheus data source
3. Write a query with labels
4. Ask the assistant to navigate you to metrics drilldown using that query. 
5. See that the labels are respected.