### PR TITLE
fix(SeriesSort): Prevent the "Initialize outlier detector first" error

### DIFF
--- a/src/Breakdown/ByFrameRepeater.tsx
+++ b/src/Breakdown/ByFrameRepeater.tsx
@@ -16,11 +16,10 @@ import { Alert, Button } from '@grafana/ui';
 import React from 'react';
 
 import { BreakdownSearchReset } from './BreakdownSearchScene';
-import { type LabelBreakdownSortingOption } from './SortByScene';
 import { findSceneObjectsByType } from './utils';
 import { getLabelValueFromDataFrame } from '../services/levels';
 import { fuzzySearch } from '../services/search';
-import { sortSeries } from '../services/sorting';
+import { sortSeries, type SortSeriesByOption } from '../services/sorting';
 
 interface ByFrameRepeaterState extends SceneObjectState {
   body: SceneLayout;
@@ -33,7 +32,7 @@ type FrameIterateCallback = (frames: DataFrame[], seriesIndex: number) => void;
 
 export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
   private unfilteredChildren: SceneFlexItem[] = [];
-  private sortBy: LabelBreakdownSortingOption;
+  private sortBy: SortSeriesByOption;
   private sortedSeries: DataFrame[] = [];
   private getFilter: () => string;
 
@@ -41,7 +40,7 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     sortBy,
     getFilter,
     ...state
-  }: ByFrameRepeaterState & { sortBy: LabelBreakdownSortingOption; getFilter: () => string }) {
+  }: ByFrameRepeaterState & { sortBy: SortSeriesByOption; getFilter: () => string }) {
     super(state);
 
     this.sortBy = sortBy;
@@ -75,7 +74,7 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     });
   }
 
-  public sort = (sortBy: LabelBreakdownSortingOption) => {
+  public sort = (sortBy: SortSeriesByOption) => {
     const data = sceneGraph.getData(this);
     this.sortBy = sortBy;
     if (data.state.data) {

--- a/src/Breakdown/LabelBreakdownScene.tsx
+++ b/src/Breakdown/LabelBreakdownScene.tsx
@@ -1,4 +1,3 @@
-import init from '@bsull/augurs/outlier';
 import { css } from '@emotion/css';
 import { FieldType, type DataFrame, type GrafanaTheme2, type PanelData, type SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
@@ -25,23 +24,19 @@ import { Button, Field, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 import { isNumber, max, min, throttle } from 'lodash';
 import React from 'react';
 
-import { logger } from 'tracking/logger/logger';
 import { METRICS_VIZ_PANEL_HEIGHT } from 'WingmanDataTrail/MetricVizPanel/MetricVizPanel';
 
 import { getAutoQueriesForMetric } from '../autoQuery/getAutoQueriesForMetric';
 import { type AutoQueryDef } from '../autoQuery/types';
 import { BreakdownLabelSelector } from '../BreakdownLabelSelector';
 import { reportExploreMetrics } from '../interactions';
-import { MetricScene } from '../MetricScene';
 import { AddToFiltersGraphAction } from './AddToFiltersGraphAction';
 import { BreakdownSearchReset, BreakdownSearchScene } from './BreakdownSearchScene';
 import { ByFrameRepeater } from './ByFrameRepeater';
 import { LayoutSwitcher } from './LayoutSwitcher';
 import { SortByScene, SortCriteriaChanged } from './SortByScene';
-import { type BreakdownLayoutChangeCallback } from './types';
-import { getLabelOptions } from './utils';
-import { BreakdownAxisChangeEvent, yAxisSyncBehavior } from './yAxisSyncBehavior';
 import { PanelMenu } from '../Menu/PanelMenu';
+import { MetricScene } from '../MetricScene';
 import { getSortByPreference } from '../services/store';
 import { ALL_VARIABLE_VALUE } from '../services/variables';
 import { MDP_METRIC_PREVIEW, RefreshMetricsEvent, trailDS, VAR_FILTERS, VAR_GROUP_BY } from '../shared';
@@ -49,6 +44,9 @@ import { StatusWrapper } from '../StatusWrapper';
 import { getColorByIndex, getTrailFor } from '../utils';
 import { isQueryVariable } from '../utils/utils.variables';
 import { MetricLabelsList } from './MetricLabelsList/MetricLabelsList';
+import { type BreakdownLayoutChangeCallback } from './types';
+import { getLabelOptions } from './utils';
+import { BreakdownAxisChangeEvent, yAxisSyncBehavior } from './yAxisSyncBehavior';
 
 export interface LabelBreakdownSceneState extends SceneObjectState {
   body?: LayoutSwitcher | MetricLabelsList;
@@ -81,9 +79,6 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
   private _query?: AutoQueryDef;
 
   private _onActivate() {
-    // eslint-disable-next-line no-console
-    init().then(() => logger.debug('Grafana ML initialized'));
-
     const variable = this.getVariable();
 
     if (config.featureToggles.enableScopesInMetricsExplore) {

--- a/src/Breakdown/SortByScene.tsx
+++ b/src/Breakdown/SortByScene.tsx
@@ -4,24 +4,24 @@ import { SceneObjectBase, type SceneComponentProps, type SceneObjectState } from
 import { Combobox, Field, IconButton, useStyles2, type ComboboxOption } from '@grafana/ui';
 import React from 'react';
 
+import { type SortSeriesByOption } from 'services/sorting';
+
 import { getSortByPreference, setSortByPreference } from '../services/store';
 
 export interface SortBySceneState extends SceneObjectState {
   target: 'fields' | 'labels';
-  sortBy: LabelBreakdownSortingOption;
+  sortBy: SortSeriesByOption;
 }
 
 export class SortCriteriaChanged extends BusEventBase {
-  constructor(public target: 'fields' | 'labels', public sortBy: LabelBreakdownSortingOption) {
+  constructor(public target: 'fields' | 'labels', public sortBy: SortSeriesByOption) {
     super();
   }
 
   public static readonly type = 'sort-criteria-changed';
 }
 
-export type LabelBreakdownSortingOption = 'outliers' | 'alphabetical' | 'alphabetical-reversed';
-
-const sortingOptions: Array<ComboboxOption<LabelBreakdownSortingOption>> = [
+const sortingOptions: Array<ComboboxOption<SortSeriesByOption>> = [
   {
     value: 'outliers',
     label: 'Outlying series',
@@ -48,7 +48,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
     });
   }
 
-  public onCriteriaChange = (criteria: ComboboxOption<LabelBreakdownSortingOption> | null) => {
+  public onCriteriaChange = (criteria: ComboboxOption<SortSeriesByOption> | null) => {
     if (!criteria?.value) {
       return;
     }

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -1,8 +1,8 @@
 import { type AdHocVariableFilter } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
 
-import { type LabelBreakdownSortingOption as BreakdownSortByOption } from 'Breakdown/SortByScene';
 import { type ActionViewType } from 'MetricActionBar';
+import { type SortSeriesByOption } from 'services/sorting';
 import { type SortingOption as MetricsReducerSortByOption } from 'WingmanDataTrail/ListControls/MetricsSorter/MetricsSorter';
 
 import { type BreakdownLayoutType } from './Breakdown/types';
@@ -100,7 +100,7 @@ type Interactions = {
         // By clicking on the sort by component in the label breakdown
         from: 'label-breakdown';
         // The sort by option selected
-        sortBy: BreakdownSortByOption;
+        sortBy: SortSeriesByOption;
       };
   wasm_not_supported: {};
   native_histogram_examples_closed: {};

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -10,8 +10,13 @@ const LazyApp = lazy(async () => {
   const { default: initOutlier } = await import('@bsull/augurs/outlier');
 
   if (wasmSupported()) {
-    await initOutlier();
-    logger.info('WASM supported');
+    try {
+      await initOutlier();
+    } catch (e) {
+      logger.error(e as Error, { message: 'Error while initializing outlier detection' });
+    }
+  } else {
+    logger.warn('WASM not supported, outlier detection will not work');
   }
 
   return import('./App/App');

--- a/src/services/sorting.test.ts
+++ b/src/services/sorting.test.ts
@@ -10,7 +10,7 @@ const frameA = toDataFrame({
       type: FieldType.number,
       values: [0, 1, 0],
       labels: {
-        test: 'C',
+        test: 'labelA',
       },
     },
   ],
@@ -23,7 +23,7 @@ const frameB = toDataFrame({
       type: FieldType.number,
       values: [1, 1, 1],
       labels: {
-        test: 'A',
+        test: 'labelB',
       },
     },
   ],
@@ -36,45 +36,35 @@ const frameC = toDataFrame({
       type: FieldType.number,
       values: [100, 9999, 100],
       labels: {
-        test: 'B',
+        test: 'labelC',
       },
     },
   ],
 });
 const frameEmpty = toDataFrame({ fields: [] });
 
-describe('sortSeries', () => {
-  test('Sorts series by standard deviation, descending', () => {
-    const series = [frameA, frameB, frameC];
-    const sortedSeries = [frameC, frameA, frameB];
-
-    const result = sortSeries(series, ReducerID.stdDev, 'desc');
-    expect(result).toEqual(sortedSeries);
-  });
+describe('sortSeries(series, sortBy)', () => {
   test('Sorts series by standard deviation, ascending', () => {
-    const series = [frameA, frameB, frameC];
-    const sortedSeries = [frameB, frameA, frameC];
-
-    const result = sortSeries(series, ReducerID.stdDev, 'asc');
-    expect(result).toEqual(sortedSeries);
+    const result = sortSeries([frameA, frameB, frameC], ReducerID.stdDev, 'asc');
+    expect(result).toEqual([frameB, frameA, frameC]);
   });
+
+  test('Sorts series by standard deviation, descending', () => {
+    const result = sortSeries([frameA, frameB, frameC], ReducerID.stdDev, 'desc');
+    expect(result).toEqual([frameC, frameA, frameB]);
+  });
+
   test('Sorts series alphabetically, ascending', () => {
-    const series = [frameA, frameB, frameC];
-    const sortedSeries = [frameB, frameC, frameA];
-
-    const result = sortSeries(series, 'alphabetical', 'asc');
-    expect(result).toEqual(sortedSeries);
+    const result = sortSeries([frameA, frameB, frameC], 'alphabetical');
+    expect(result).toEqual([frameA, frameB, frameC]);
   });
+
   test('Sorts series alphabetically, descending', () => {
-    const series = [frameA, frameB, frameC];
-    const sortedSeries = [frameB, frameC, frameA];
-
-    const result = sortSeries(series, 'alphabetical', 'desc');
-    expect(result).toEqual(sortedSeries);
+    const result = sortSeries([frameA, frameB, frameC], 'alphabetical-reversed');
+    expect(result).toEqual([frameC, frameB, frameA]);
   });
-  test('Does not throw on empty series', () => {
-    const series = [frameEmpty];
 
-    expect(() => sortSeries(series, 'alphabetical', 'asc')).not.toThrow();
+  test('Does not throw on empty series', () => {
+    expect(() => sortSeries([frameEmpty], 'alphabetical')).not.toThrow();
   });
 });

--- a/src/services/sorting.ts
+++ b/src/services/sorting.ts
@@ -10,66 +10,130 @@ import {
 import { memoize } from 'lodash';
 
 import { logger } from 'tracking/logger/logger';
+import { localeCompare } from 'WingmanDataTrail/helpers/localCompare';
 
 import { reportExploreMetrics } from '../interactions';
 import { getLabelValueFromDataFrame } from './levels';
 
+export type SortSeriesByOption = 'alphabetical' | 'alphabetical-reversed' | 'outliers' | ReducerID.stdDev;
+export type SortSeriesDirection = 'asc' | 'desc';
+
+// Alphabetical sort
+const sortAlphabetical = (series: DataFrame[], direction: SortSeriesDirection = 'asc') => {
+  const sortedSeries = [...series];
+
+  const compareFn: (a: string, b: string) => number =
+    direction === 'asc' ? (a, b) => localeCompare(a, b) : (a, b) => localeCompare(b, a);
+
+  return sortedSeries.sort((a, b) => {
+    const labelA = getLabelValueFromDataFrame(a);
+    if (!labelA) {
+      return 0;
+    }
+
+    const labelB = getLabelValueFromDataFrame(b);
+    if (!labelB) {
+      return 0;
+    }
+
+    return compareFn(labelA, labelB);
+  });
+};
+
+// Field reducer sort
+const sortByFieldReducer = (series: DataFrame[], sortBy: string, direction: SortSeriesDirection = 'asc') => {
+  const fieldReducer = fieldReducers.get(sortBy);
+
+  const seriesCalcs = series.map((dataFrame) => {
+    const value =
+      fieldReducer.reduce?.(dataFrame.fields[1], true, true) ?? doStandardCalcs(dataFrame.fields[1], true, true);
+
+    return {
+      value: value[sortBy] ?? 0,
+      dataFrame: dataFrame,
+    };
+  });
+
+  seriesCalcs.sort(direction === 'asc' ? (a, b) => a.value - b.value : (a, b) => b.value - a.value);
+
+  return seriesCalcs.map(({ dataFrame }) => dataFrame);
+};
+
+// Outlier sort
+const sortByOutliers = (series: DataFrame[], direction: 'asc' | 'desc' = 'asc') => {
+  if (!wasmSupported()) {
+    throw new Error('WASM not supported');
+  }
+
+  const outliers = getOutliers(series);
+
+  const seriesCalcs = series.map((dataFrame, index) => ({
+    value: calculateOutlierValue(outliers, index),
+    dataFrame: dataFrame,
+  }));
+
+  seriesCalcs.sort(direction === 'asc' ? (a, b) => a.value - b.value : (a, b) => b.value - a.value);
+
+  return seriesCalcs.map(({ dataFrame }) => dataFrame);
+};
+
+const getOutliers = (series: DataFrame[]): OutlierOutput => {
+  // Combine all frames into one by joining on time.
+  const joined = outerJoinDataFrames({ frames: series });
+  if (!joined) {
+    throw new Error('Error while joining frames into a single one');
+  }
+
+  // Get number fields: these are our series.
+  const joinedSeries = joined.fields.filter((f) => f.type === FieldType.number);
+  const points = joinedSeries.map((series) => new Float64Array(series.values));
+
+  return OutlierDetector.dbscan({ sensitivity: 0.4 }).preprocess(points).detect();
+};
+
+const calculateOutlierValue = (outliers: OutlierOutput, index: number): number => {
+  if (outliers.seriesResults[index].isOutlier) {
+    return -outliers.seriesResults[index].outlierIntervals.length;
+  }
+  return 0;
+};
+
 export const sortSeries = memoize(
-  (series: DataFrame[], sortBy: string, direction = 'asc') => {
+  (series: DataFrame[], sortBy: SortSeriesByOption, direction: SortSeriesDirection = 'asc') => {
+    // Alphabetical sorting
     if (sortBy === 'alphabetical') {
-      return sortSeriesByName(series, 'asc');
+      return sortAlphabetical(series, 'asc');
     }
 
     if (sortBy === 'alphabetical-reversed') {
-      return sortSeriesByName(series, 'desc');
+      return sortAlphabetical(series, 'desc');
     }
 
+    // Outlier detection sorting
     if (sortBy === 'outliers') {
-      initOutlierDetector(series);
-    }
-
-    const reducer = (dataFrame: DataFrame) => {
       try {
-        if (sortBy === 'outliers') {
-          return calculateOutlierValue(series, dataFrame);
-        }
+        return sortByOutliers(series, direction);
       } catch (e) {
-        logger.error(e as Error, { message: 'ML sorting panicked, fallback to stdDev' });
+        logger.error(e as Error, { message: 'Error while sorting by outlying series, fallback to stdDev' });
         // ML sorting panicked, fallback to stdDev
-        sortBy = ReducerID.stdDev;
+        return sortByFieldReducer(series, ReducerID.stdDev, direction);
       }
-      const fieldReducer = fieldReducers.get(sortBy);
-      const value =
-        fieldReducer.reduce?.(dataFrame.fields[1], true, true) ?? doStandardCalcs(dataFrame.fields[1], true, true);
-      return value[sortBy] ?? 0;
-    };
-
-    const seriesCalcs = series.map((dataFrame) => ({
-      value: reducer(dataFrame),
-      dataFrame: dataFrame,
-    }));
-
-    seriesCalcs.sort((a, b) => {
-      if (a.value !== undefined && b.value !== undefined) {
-        return b.value - a.value;
-      }
-      return 0;
-    });
-
-    if (direction === 'asc') {
-      seriesCalcs.reverse();
     }
 
-    return seriesCalcs.map(({ dataFrame }) => dataFrame);
+    // Field reducer sorting (default case)
+    return sortByFieldReducer(series, sortBy, direction);
   },
-  (series: DataFrame[], sortBy: string, direction = 'asc') => {
+  (series: DataFrame[], sortBy: string, direction: SortSeriesDirection = 'asc') => {
     const firstTimestamp = seriesIsNotEmpty(series) ? series[0].fields[0].values[0] : 0;
     const lastTimestamp = seriesIsNotEmpty(series)
       ? series[series.length - 1].fields[0].values[series[series.length - 1].fields[0].values.length - 1]
       : 0;
+
     const firstValue = series.length > 0 ? getLabelValueFromDataFrame(series[0]) : '';
     const lastValue = series.length > 0 ? getLabelValueFromDataFrame(series[series.length - 1]) : '';
+
     const key = `${firstValue}_${lastValue}_${firstTimestamp}_${lastTimestamp}_${series.length}_${sortBy}_${direction}`;
+
     return key;
   }
 );
@@ -77,64 +141,6 @@ export const sortSeries = memoize(
 function seriesIsNotEmpty(series: DataFrame[]) {
   return series.length > 0 && series[0].fields.length > 0 && series[0].fields[0].values.length > 0;
 }
-
-const initOutlierDetector = (series: DataFrame[]) => {
-  if (!wasmSupported()) {
-    return;
-  }
-
-  // Combine all frames into one by joining on time.
-  const joined = outerJoinDataFrames({ frames: series });
-  if (!joined) {
-    return;
-  }
-
-  // Get number fields: these are our series.
-  const joinedSeries = joined.fields.filter((f) => f.type === FieldType.number);
-  const points = joinedSeries.map((series) => new Float64Array(series.values));
-
-  try {
-    const detector = OutlierDetector.dbscan({ sensitivity: 0.4 }).preprocess(points);
-    outliers = detector.detect();
-  } catch (e) {
-    logger.error(e as Error, { message: 'Error initializing outlier detector' });
-    outliers = undefined;
-  }
-};
-
-let outliers: OutlierOutput | undefined = undefined;
-
-export const calculateOutlierValue = (series: DataFrame[], data: DataFrame): number => {
-  if (!wasmSupported()) {
-    throw new Error('WASM not supported, fall back to stdDev');
-  }
-  if (!outliers) {
-    throw new Error('Initialize outlier detector first');
-  }
-
-  const index = series.indexOf(data);
-  if (outliers.seriesResults[index].isOutlier) {
-    return -outliers.seriesResults[index].outlierIntervals.length;
-  }
-
-  return 0;
-};
-
-export const sortSeriesByName = (series: DataFrame[], direction: string) => {
-  const sortedSeries = [...series];
-  sortedSeries.sort((a, b) => {
-    const valueA = getLabelValueFromDataFrame(a);
-    const valueB = getLabelValueFromDataFrame(b);
-    if (!valueA || !valueB) {
-      return 0;
-    }
-    return valueA?.localeCompare(valueB) ?? 0;
-  });
-  if (direction === 'desc') {
-    sortedSeries.reverse();
-  }
-  return sortedSeries;
-};
 
 export const wasmSupported = () => {
   const support = typeof WebAssembly === 'object';

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -1,6 +1,5 @@
-import { type LabelBreakdownSortingOption } from 'Breakdown/SortByScene';
-
 import { TRAIL_BREAKDOWN_SORT_KEY, TRAIL_BREAKDOWN_VIEW_KEY } from '../shared';
+import { type SortSeriesByOption } from './sorting';
 
 export function getVewByPreference() {
   return localStorage.getItem(TRAIL_BREAKDOWN_VIEW_KEY) ?? 'grid';
@@ -12,17 +11,17 @@ export function setVewByPreference(value?: string) {
 
 export function getSortByPreference(
   target: string,
-  defaultSortBy: LabelBreakdownSortingOption
-): { sortBy: LabelBreakdownSortingOption; direction?: string } {
+  defaultSortBy: SortSeriesByOption
+): { sortBy: SortSeriesByOption; direction?: string } {
   const preference = localStorage.getItem(`${TRAIL_BREAKDOWN_SORT_KEY}.${target}.by`) ?? '';
   const parts = preference.split('.');
   if (!parts[0] || !parts[1]) {
     return { sortBy: defaultSortBy };
   }
-  return { sortBy: parts[0] as LabelBreakdownSortingOption, direction: parts[1] };
+  return { sortBy: parts[0] as SortSeriesByOption, direction: parts[1] };
 }
 
-export function setSortByPreference(target: string, sortBy: LabelBreakdownSortingOption) {
+export function setSortByPreference(target: string, sortBy: SortSeriesByOption) {
   // Prevent storing empty values
   if (sortBy) {
     localStorage.setItem(`${TRAIL_BREAKDOWN_SORT_KEY}.${target}.by`, `${sortBy}`);


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** loosely relates to https://github.com/grafana/metrics-drilldown/issues/499

Note: this PR is part of many a series of refactoring PRs aimed at improving the performance of the MetricScene (see https://github.com/grafana/metrics-drilldown/issues/499), as well as making its code more maintainable.

The goals of this PR are:
1. Fixing the "Initialize outlier detector first" errors that [have been on the rise for at least a week](https://ops.grafana-ops.net/a/grafana-kowalski-app/apps/49/errors?frameIndex=0&from=now-7d&to=now&timezone=utc)
2. Refactor the series sorting code to separate concerns into independent functions, each dedicated to a sorting type (alphabetical, outliers, stdDev)

### 📖 Summary of the changes

See diff tab for specific comments

### 🧪 How to test?

- All the automated tests should pass
