### PR TITLE
ci: add Grafana instance with Scopes enabled

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,16 @@ services:
       # This allows us to connect to other services running on the host machine.
       - 'host.docker.internal:host-gateway'
 
+  grafana-scopes-gmd:
+    container_name: 'grafana-scopes-gmd'
+    extends:
+      service: grafana-gmd
+    ports: !override
+      - '${GRAFANA_SCOPES_PORT:-3002}:3000'
+    environment:
+      GF_SERVER_ROOT_URL: 'http://localhost:${GRAFANA_SCOPES_PORT:-3002}'
+      GF_FEATURE_TOGGLES_ENABLE: exploreMetricsUseExternalAppPlugin,grafanaAPIServer,grafanaAPIServerWithExperimentalAPIs,scopeFilters,promQLScope,enableScopesInMetricsExplore
+
   prometheus-gmd:
     container_name: 'prometheus-gmd'
     build:


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** This PR closes #553 and aims to make e2e testing practical in https://github.com/grafana/metrics-drilldown/pull/446

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

This PR adds a new `grafana-scopes-gmd` service running on port `3002`. This Grafana server has feature toggles enabled that should make it possible to test Scopes x Metrics Drilldown functionality, such as in https://github.com/grafana/metrics-drilldown/pull/446.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

`npm run server` now also creates a `grafana-scopes-gmd` container on port `3002`:

<img width="973" height="385" alt="containers with grafana-scopes-gmd" src="https://github.com/user-attachments/assets/436a08ba-3e80-4c47-9ae3-507156c94a4b" />
