### PR TITLE
refactor(LayoutSwitcher): Support custom options and URL search parameter name

### DIFF
--- a/src/Breakdown/MetricLabelsList/MetricLabelsList.tsx
+++ b/src/Breakdown/MetricLabelsList/MetricLabelsList.tsx
@@ -43,7 +43,7 @@ export class MetricLabelsList extends SceneObjectBase<MetricLabelsListState> {
       metric,
       // TODO: we add the layout switcher here for now to keep the changes in the LabelBreakdownScene component minimal
       // but we should refactor further and move it to LabelBreakdownScene
-      layoutSwitcher: new LayoutSwitcher(),
+      layoutSwitcher: new LayoutSwitcher({}),
       body: new SceneByVariableRepeater({
         variableName: VAR_GROUP_BY,
         initialPageSize: 60,

--- a/src/RelatedMetricsScene/RelatedListControls.tsx
+++ b/src/RelatedMetricsScene/RelatedListControls.tsx
@@ -52,7 +52,7 @@ export class RelatedListControls extends EmbeddedScene {
           }),
           new SceneFlexItem({
             width: 'auto',
-            body: new LayoutSwitcher(),
+            body: new LayoutSwitcher({}),
           }),
         ],
       }),

--- a/src/WingmanDataTrail/ListControls/LayoutSwitcher.tsx
+++ b/src/WingmanDataTrail/ListControls/LayoutSwitcher.tsx
@@ -11,59 +11,72 @@ import React from 'react';
 export enum LayoutType {
   GRID = 'grid',
   ROWS = 'rows',
+  SINGLE = 'single',
 }
 
 export interface LayoutSwitcherState extends SceneObjectState {
+  urlSearchParamName: string;
   layout: LayoutType;
-  onChange?: (layout: LayoutType) => void;
+  options: Array<{ label: string; value: LayoutType }>;
 }
 
 export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> {
-  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['layout'] });
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, {
+    keys: [this.state.urlSearchParamName],
+  });
 
-  static readonly OPTIONS = [
+  static readonly DEFAULT_OPTIONS = [
     { label: 'Grid', value: LayoutType.GRID },
     { label: 'Rows', value: LayoutType.ROWS },
   ];
 
   static readonly DEFAULT_LAYOUT = LayoutType.GRID;
 
-  constructor() {
+  constructor({
+    urlSearchParamName,
+    options,
+  }: {
+    urlSearchParamName?: LayoutSwitcherState['urlSearchParamName'];
+    options?: LayoutSwitcherState['options'];
+  }) {
     super({
       key: 'layout-switcher',
+      urlSearchParamName: urlSearchParamName || 'layout',
+      options: options || LayoutSwitcher.DEFAULT_OPTIONS,
       layout: LayoutSwitcher.DEFAULT_LAYOUT,
     });
   }
 
   getUrlState() {
     return {
-      layout: this.state.layout,
+      [this.state.urlSearchParamName]: this.state.layout,
     };
   }
 
   updateFromUrl(values: SceneObjectUrlValues) {
     const stateUpdate: Partial<LayoutSwitcherState> = {};
+    const newLayout = values[this.state.urlSearchParamName] as LayoutType;
 
-    if (typeof values.layout === 'string' && values.layout !== this.state.layout) {
-      stateUpdate.layout = Object.values(LayoutType).includes(values.layout as LayoutType)
-        ? (values.layout as LayoutType)
+    if (newLayout !== this.state.layout) {
+      stateUpdate.layout = this.state.options.find((o) => o.value === newLayout)
+        ? newLayout
         : LayoutSwitcher.DEFAULT_LAYOUT;
     }
 
     this.setState(stateUpdate);
   }
 
-  onChange = (layout: LayoutType) => {
+  private onChange = (layout: LayoutType) => {
     this.setState({ layout });
   };
 
   static readonly Component = ({ model }: SceneComponentProps<LayoutSwitcher>) => {
-    const { layout } = model.useState();
+    const { options, layout } = model.useState();
 
     return (
       <RadioButtonGroup
         aria-label="Layout switcher"
-        options={LayoutSwitcher.OPTIONS}
+        options={options}
         value={layout}
         onChange={model.onChange}
         fullWidth={false}

--- a/src/WingmanDataTrail/ListControls/ListControls.tsx
+++ b/src/WingmanDataTrail/ListControls/ListControls.tsx
@@ -52,7 +52,7 @@ export class ListControls extends EmbeddedScene {
           }),
           new SceneFlexItem({
             width: 'auto',
-            body: new LayoutSwitcher(),
+            body: new LayoutSwitcher({}),
           }),
         ],
       }),


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** relates to https://github.com/grafana/metrics-drilldown/pull/557/files

A refactor to allow the [LayoutSwitcher component](https://github.com/grafana/metrics-drilldown/blob/main/src/WingmanDataTrail/ListControls/LayoutSwitcher.tsx) to accept custom options and URL search parameter name.

### 📖 Summary of the changes

Seee diff tab

### 🧪 How to test?

- The build should pass
