### PR TITLE
refactor(QuickSearch): Decouple QuickSearch from metric variables

### DIFF
--- a/src/RelatedMetricsScene/RelatedListControls.tsx
+++ b/src/RelatedMetricsScene/RelatedListControls.tsx
@@ -13,9 +13,8 @@ import { useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { LayoutSwitcher } from 'WingmanDataTrail/ListControls/LayoutSwitcher';
+import { MetricVariableCountsProvider } from 'WingmanDataTrail/ListControls/QuickSearch/CountsProvider/MetricVariableCountsProvider';
 import { QuickSearch } from 'WingmanDataTrail/ListControls/QuickSearch/QuickSearch';
-import { VAR_FILTERED_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
-import { VAR_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
 
 import { PrefixFilterDropdown } from './PrefixFilterDropdown';
 
@@ -43,10 +42,7 @@ export class RelatedListControls extends EmbeddedScene {
             body: new QuickSearch({
               urlSearchParamName: 'gmd-relatedSearchText',
               targetName: 'related metric',
-              variableNames: {
-                nonFiltered: VAR_METRICS_VARIABLE,
-                filtered: VAR_FILTERED_METRICS_VARIABLE,
-              },
+              countsProvider: new MetricVariableCountsProvider(),
               displayCounts: true,
             }),
           }),

--- a/src/WingmanDataTrail/ListControls/ListControls.tsx
+++ b/src/WingmanDataTrail/ListControls/ListControls.tsx
@@ -12,11 +12,9 @@ import {
 import { useStyles2 } from '@grafana/ui';
 import React from 'react';
 
-import { VAR_FILTERED_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
-import { VAR_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
-
 import { LayoutSwitcher } from './LayoutSwitcher';
 import { MetricsSorter } from './MetricsSorter/MetricsSorter';
+import { MetricVariableCountsProvider } from './QuickSearch/CountsProvider/MetricVariableCountsProvider';
 import { QuickSearch } from './QuickSearch/QuickSearch';
 
 interface ListControlsState extends SceneObjectState {
@@ -40,10 +38,7 @@ export class ListControls extends EmbeddedScene {
             body: new QuickSearch({
               urlSearchParamName: 'search_txt',
               targetName: 'metric',
-              variableNames: {
-                nonFiltered: VAR_METRICS_VARIABLE,
-                filtered: VAR_FILTERED_METRICS_VARIABLE,
-              },
+              countsProvider: new MetricVariableCountsProvider(),
             }),
           }),
           new SceneFlexItem({

--- a/src/WingmanDataTrail/ListControls/QuickSearch/CountsProvider/CountsProvider.ts
+++ b/src/WingmanDataTrail/ListControls/QuickSearch/CountsProvider/CountsProvider.ts
@@ -13,7 +13,6 @@ export class CountsProvider<T extends CountsProviderState = CountsProviderState>
   constructor(state: Partial<T>) {
     super({
       ...state,
-      key: state.key || 'CountsProvider',
       counts: { current: 0, total: 0 },
     } as T);
   }

--- a/src/WingmanDataTrail/ListControls/QuickSearch/CountsProvider/CountsProvider.ts
+++ b/src/WingmanDataTrail/ListControls/QuickSearch/CountsProvider/CountsProvider.ts
@@ -1,0 +1,24 @@
+import { SceneObjectBase, type SceneObjectState } from '@grafana/scenes';
+
+export type CountsData = {
+  current: number;
+  total: number;
+};
+
+export interface CountsProviderState extends SceneObjectState {
+  counts: CountsData;
+}
+
+export class CountsProvider<T extends CountsProviderState = CountsProviderState> extends SceneObjectBase<T> {
+  constructor(state: Partial<T>) {
+    super({
+      ...state,
+      key: state.key || 'CountsProvider',
+      counts: { current: 0, total: 0 },
+    } as T);
+  }
+
+  public useCounts(): CountsData {
+    return this.useState().counts;
+  }
+}

--- a/src/WingmanDataTrail/ListControls/QuickSearch/CountsProvider/MetricVariableCountsProvider.ts
+++ b/src/WingmanDataTrail/ListControls/QuickSearch/CountsProvider/MetricVariableCountsProvider.ts
@@ -1,0 +1,44 @@
+import { sceneGraph, type MultiValueVariable } from '@grafana/scenes';
+
+import { VAR_FILTERED_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
+import { areArraysEqual } from 'WingmanDataTrail/MetricsVariables/helpers/areArraysEqual';
+import { VAR_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
+
+import { CountsProvider, type CountsProviderState } from './CountsProvider';
+
+export class MetricVariableCountsProvider extends CountsProvider<CountsProviderState> {
+  constructor() {
+    super({ key: 'MetricVariableCountsProvider' });
+
+    this.addActivationHandler(() => {
+      const nonFilteredVariable = sceneGraph.lookupVariable(VAR_METRICS_VARIABLE, this) as MultiValueVariable;
+      const filteredVariable = sceneGraph.lookupVariable(VAR_FILTERED_METRICS_VARIABLE, this) as MultiValueVariable;
+
+      this._subs.add(
+        filteredVariable.subscribeToState((newState, prevState) => {
+          if (!newState.loading && !prevState.loading && !areArraysEqual(newState.options, prevState.options)) {
+            this.setState({
+              counts: {
+                current: newState.options.length,
+                total: nonFilteredVariable.state.options.length,
+              },
+            });
+          }
+        })
+      );
+
+      this._subs.add(
+        nonFilteredVariable.subscribeToState((newState, prevState) => {
+          if (!areArraysEqual(newState.options, prevState.options)) {
+            this.setState({
+              counts: {
+                current: filteredVariable.state.options.length,
+                total: newState.options.length,
+              },
+            });
+          }
+        })
+      );
+    });
+  }
+}

--- a/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx
+++ b/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx
@@ -1,11 +1,9 @@
 import { css } from '@emotion/css';
 import { type GrafanaTheme2 } from '@grafana/data';
 import {
-  sceneGraph,
   SceneObjectBase,
   SceneObjectUrlSyncConfig,
   VariableDependencyConfig,
-  type MultiValueVariable,
   type SceneObjectState,
   type SceneObjectUrlValues,
 } from '@grafana/scenes';
@@ -15,19 +13,16 @@ import React, { type KeyboardEvent } from 'react';
 
 import { reportExploreMetrics } from 'interactions';
 import { VAR_DATASOURCE } from 'shared';
-import { areArraysEqual } from 'WingmanDataTrail/MetricsVariables/helpers/areArraysEqual';
 
+import { type CountsProvider } from './CountsProvider/CountsProvider';
 import { EventQuickSearchChanged } from './EventQuickSearchChanged';
+
 interface QuickSearchState extends SceneObjectState {
   urlSearchParamName: string;
   targetName: string;
-  variableNames: {
-    nonFiltered: string;
-    filtered: string;
-  };
-  value: string;
-  counts: { current: number; total: number };
+  countsProvider: CountsProvider;
   displayCounts: boolean;
+  value: string;
 }
 
 export class QuickSearch extends SceneObjectBase<QuickSearchState> {
@@ -57,61 +52,22 @@ export class QuickSearch extends SceneObjectBase<QuickSearchState> {
   public constructor({
     urlSearchParamName,
     targetName,
-    variableNames,
+    countsProvider,
     displayCounts,
   }: {
     urlSearchParamName: QuickSearchState['urlSearchParamName'];
     targetName: QuickSearchState['targetName'];
-    variableNames: QuickSearchState['variableNames'];
+    countsProvider: QuickSearchState['countsProvider'];
     displayCounts?: QuickSearchState['displayCounts'];
   }) {
     super({
       key: 'quick-search',
       urlSearchParamName,
       targetName,
-      variableNames,
-      value: '',
-      counts: {
-        current: 0,
-        total: 0,
-      },
+      countsProvider,
       displayCounts: Boolean(displayCounts),
+      value: '',
     });
-
-    this.addActivationHandler(this.onActivate.bind(this));
-  }
-
-  private onActivate() {
-    const { variableNames } = this.state;
-
-    const filteredVariable = sceneGraph.lookupVariable(variableNames.filtered, this) as MultiValueVariable;
-    const nonFilteredVariable = sceneGraph.lookupVariable(variableNames.nonFiltered, this) as MultiValueVariable;
-
-    this._subs.add(
-      filteredVariable.subscribeToState((newState, prevState) => {
-        if (!newState.loading && !prevState.loading && !areArraysEqual(newState.options, prevState.options)) {
-          this.setState({
-            counts: {
-              current: newState.options.length,
-              total: nonFilteredVariable.state.options.length,
-            },
-          });
-        }
-      })
-    );
-
-    this._subs.add(
-      nonFilteredVariable.subscribeToState((newState, prevState) => {
-        if (!areArraysEqual(newState.options, prevState.options)) {
-          this.setState({
-            counts: {
-              current: filteredVariable.state.options.length,
-              total: newState.options.length,
-            },
-          });
-        }
-      })
-    );
   }
 
   public toggleCountsDisplay(displayCounts: boolean) {
@@ -149,8 +105,9 @@ export class QuickSearch extends SceneObjectBase<QuickSearchState> {
     }
   };
 
-  private getHumanFriendlyCountsMessage() {
-    const { targetName, counts, displayCounts } = this.state;
+  private useHumanFriendlyCountsMessage() {
+    const { targetName, countsProvider, displayCounts } = this.state;
+    const counts = countsProvider.useCounts();
 
     if (!displayCounts) {
       return {
@@ -177,8 +134,8 @@ export class QuickSearch extends SceneObjectBase<QuickSearchState> {
 
   static readonly Component = ({ model }: { model: QuickSearch }) => {
     const styles = useStyles2(getStyles);
-    const { targetName, value } = model.useState();
-    const { tagName, tooltipContent } = model.getHumanFriendlyCountsMessage();
+    const { targetName, value, countsProvider } = model.useState();
+    const { tagName, tooltipContent } = model.useHumanFriendlyCountsMessage();
 
     return (
       <Input
@@ -189,6 +146,7 @@ export class QuickSearch extends SceneObjectBase<QuickSearchState> {
         prefix={<i className="fa fa-search" />}
         suffix={
           <>
+            <countsProvider.Component model={countsProvider} />
             {tagName && (
               <Tooltip content={tooltipContent} placement="top">
                 <Tag className={styles.counts} name={tagName} colorIndex={9} />


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** made to simplify https://github.com/grafana/metrics-drilldown/pull/557 

A refactor to decouple the [QuickSearch component](https://github.com/grafana/metrics-drilldown/blob/main/src/WingmanDataTrail/ListControls/QuickSearch/QuickSearch.tsx) from the metric variables. Indeed, prior to this PR, the search counts displayed in the UI were directly retrieved from the `MetricsVariable` and the `FilteredMetricsVariable` Scene objects.

This PR will enable us to reuse the `QuickSearch` component in  the "Breakdown" tab of the `MetricScene` and to display the number of labels.

### 📖 Summary of the changes

We introduce the new `CountsProvider` class to be able to customize how counts are retrieved by `QuickSearch`.

See diff tab for specific comments.

### 🧪 How to test?

- The build should pass
