### PR TITLE
chore: bump version v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.7
+
+See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.7>
+
 ## v1.0.6
 
 See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.6>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-metricsdrilldown-app",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "AGPL-3.0",
       "dependencies": {
         "@bsull/augurs": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "Grafana",
   "license": "AGPL-3.0",
   "scripts": {


### PR DESCRIPTION
### Description

This PR bumps the version to 1.0.7 as per the process described in the Metrics Drilldown [Deployment Handbook](https://wiki.grafana-ops.net/w/index.php?title=Engineering/Grafana/Grafana_Explore/Metrics_Drilldown/Deployment_Handbook#Recipe_for_engineers).

