### PR TITLE
feat(Extensions): Update Grafana assistant extension point to use full query to generate a URL

### DIFF
--- a/src/extensions/links.test.ts
+++ b/src/extensions/links.test.ts
@@ -1,4 +1,12 @@
-import { buildNavigateToMetricsParams, configureDrilldownLink, createPromURLObject, parseFiltersToLabelMatchers, parsePromQLQuery, UrlParameters, type GrafanaAssistantMetricsDrilldownContext } from './links';
+import {
+  buildNavigateToMetricsParams,
+  configureDrilldownLink,
+  createPromURLObject,
+  parseFiltersToLabelMatchers,
+  parsePromQLQuery,
+  UrlParameters,
+  type GrafanaAssistantMetricsDrilldownContext,
+} from './links';
 
 describe('parsePromQLQuery - lezer parser tests', () => {
   test('should parse basic metric name', () => {
@@ -167,7 +175,6 @@ describe('configureDrilldownLink', () => {
         pluginId: 'timeseries',
         targets: [
           {
-
             datasource: { type: 'prometheus', uid: 'prom-uid' },
           },
         ],
@@ -209,7 +216,7 @@ describe('configureDrilldownLink', () => {
       };
 
       const result = configureDrilldownLink(context);
-      
+
       expect(result).toBeDefined();
       expect(result?.path).toContain('/a/grafana-metricsdrilldown-app/drilldown');
       expect(result?.path).toContain('metric=http_requests_total');
@@ -232,7 +239,7 @@ describe('configureDrilldownLink', () => {
       };
 
       const result = configureDrilldownLink(context);
-      
+
       expect(result).toBeDefined();
       expect(result?.path).toContain('var-filters=path%7C%3D%7C%2Fapi%2Fv1%2Fusers%3Fid%3D123%26name%3Dtest');
     });
@@ -252,11 +259,11 @@ describe('configureDrilldownLink', () => {
       };
 
       const result = configureDrilldownLink(context);
-      
+
       // Should still return a result (either with parsed data or fallback)
       expect(result).toBeDefined();
       expect(result?.path).toContain('/a/grafana-metricsdrilldown-app/drilldown');
-      
+
       // Note: The actual parsePromQLQuery might handle this gracefully with hasErrors=true,
       // so we just test that the function doesn't crash and returns a valid path
     });
@@ -264,7 +271,7 @@ describe('configureDrilldownLink', () => {
 });
 
 describe('buildNavigateToMetricsParams', () => {
-  it('should build URL parameters with all fields populated', () => {
+  test('should build URL parameters with all fields populated', () => {
     const context: GrafanaAssistantMetricsDrilldownContext = {
       navigateToMetrics: true,
       datasource_uid: 'test-datasource-uid',
@@ -276,7 +283,13 @@ describe('buildNavigateToMetricsParams', () => {
     // parse the labels to the PromQL format
     const parsedLabels = parseFiltersToLabelMatchers(context.label_filters);
     // create the PromURLObject for building params
-    const promURLObject = createPromURLObject(context.datasource_uid, parsedLabels, context.metric, context.start, context.end);
+    const promURLObject = createPromURLObject(
+      context.datasource_uid,
+      parsedLabels,
+      context.metric,
+      context.start,
+      context.end
+    );
     // build the params for the navigateToMetrics
     const result = buildNavigateToMetricsParams(promURLObject);
 
@@ -287,7 +300,7 @@ describe('buildNavigateToMetricsParams', () => {
     expect(result.getAll(UrlParameters.Filters)).toEqual(['status|=|200', 'method|=|GET', 'path|=|/api/test']);
   });
 
-  it('should build URL parameters with only required fields', () => {
+  test('should build URL parameters with only required fields', () => {
     const context: GrafanaAssistantMetricsDrilldownContext = {
       navigateToMetrics: true,
       datasource_uid: 'test-datasource-uid',
@@ -295,7 +308,13 @@ describe('buildNavigateToMetricsParams', () => {
     // parse the labels to the PromQL format
     const parsedLabels = parseFiltersToLabelMatchers(context.label_filters);
     // create the PromURLObject for building params
-    const promURLObject = createPromURLObject(context.datasource_uid, parsedLabels, context.metric, context.start, context.end);
+    const promURLObject = createPromURLObject(
+      context.datasource_uid,
+      parsedLabels,
+      context.metric,
+      context.start,
+      context.end
+    );
     // build the params for the navigateToMetrics
     const result = buildNavigateToMetricsParams(promURLObject);
 
@@ -306,7 +325,7 @@ describe('buildNavigateToMetricsParams', () => {
     expect(result.getAll(UrlParameters.Filters)).toEqual([]);
   });
 
-  it('should handle undefined label_filters', () => {
+  test('should handle undefined label_filters', () => {
     const context: GrafanaAssistantMetricsDrilldownContext = {
       navigateToMetrics: true,
       datasource_uid: 'test-datasource-uid',
@@ -315,7 +334,13 @@ describe('buildNavigateToMetricsParams', () => {
     // parse the labels to the PromQL format
     const parsedLabels = parseFiltersToLabelMatchers(context.label_filters);
     // create the PromURLObject for building params
-    const promURLObject = createPromURLObject(context.datasource_uid, parsedLabels, context.metric, context.start, context.end);
+    const promURLObject = createPromURLObject(
+      context.datasource_uid,
+      parsedLabels,
+      context.metric,
+      context.start,
+      context.end
+    );
     // build the params for the navigateToMetrics
     const result = buildNavigateToMetricsParams(promURLObject);
 

--- a/src/extensions/links.test.ts
+++ b/src/extensions/links.test.ts
@@ -162,18 +162,19 @@ describe('configureDrilldownLink', () => {
       expect(result).toBeUndefined();
     });
     // do we want to show a link when the data source is prometheus? We can default to showing a link to the metrics reducer page..
-    test('should return undefined when query has no expression', () => {
+    test('should return drilldown path when query has no expression but has prometheus datasource', () => {
       const context = {
         pluginId: 'timeseries',
         targets: [
           {
-            expr: '',
+
             datasource: { type: 'prometheus', uid: 'prom-uid' },
           },
         ],
       };
       const result = configureDrilldownLink(context);
-      expect(result).toBeUndefined();
+      expect(result).toBeDefined();
+      expect(result?.path).toBe('/a/grafana-metricsdrilldown-app/drilldown');
     });
 
     test('should return undefined when datasource is not prometheus', () => {

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -36,7 +36,11 @@ export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
     category,
     icon,
     path: createAppUrl(ROUTES.Drilldown),
-    targets: [PluginExtensionPoints.DashboardPanelMenu, PluginExtensionPoints.ExploreToolbarAction, ASSISTANT_TARGET_V1],
+    targets: [
+      PluginExtensionPoints.DashboardPanelMenu,
+      PluginExtensionPoints.ExploreToolbarAction,
+      ASSISTANT_TARGET_V1,
+    ],
     configure: configureDrilldownLink,
   },
   {
@@ -48,8 +52,9 @@ export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
       if (typeof context === 'undefined') {
         return;
       }
-      
-      const { navigateToMetrics, datasource_uid, label_filters, metric, start, end } = (context as GrafanaAssistantMetricsDrilldownContext);
+
+      const { navigateToMetrics, datasource_uid, label_filters, metric, start, end } =
+        context as GrafanaAssistantMetricsDrilldownContext;
       // parse the labels to the PromQL format
       const parsedLabels = parseFiltersToLabelMatchers(label_filters);
       // create the PromURLObject for building params
@@ -73,7 +78,6 @@ export function configureDrilldownLink(context: object | undefined): { path: str
     return;
   }
 
-  // check that the datasource is prometheus
   const queries = (context as PluginExtensionPanelContext).targets.filter(isPromQuery);
 
   if (!queries.length) {
@@ -105,13 +109,7 @@ export function configureDrilldownLink(context: object | undefined): { path: str
         ? (context.timeRange as { from: string; to: string })
         : undefined;
 
-    const promURLObject = createPromURLObject(
-      datasource?.uid,
-      labels,
-      metric,
-      timeRange?.from,
-      timeRange?.to
-    );
+    const promURLObject = createPromURLObject(datasource?.uid, labels, metric, timeRange?.from, timeRange?.to);
 
     const params = buildNavigateToMetricsParams(promURLObject);
 
@@ -150,17 +148,17 @@ export function parsePromQLQuery(expr: string): ParsedPromQLQuery {
       if (node.type.isError || node.name === '⚠') {
         hasErrors = true;
         const errorText = expr.slice(node.from, node.to);
-        const errorMsg = errorText 
+        const errorMsg = errorText
           ? `Parse error at position ${node.from}-${node.to}: "${errorText}"`
           : `Parse error at position ${node.from}`;
         errors.push(errorMsg);
       }
-      
+
       // Get the first metric name from any VectorSelector > Identifier
       if (!metric && node.name === 'Identifier' && node.node.parent?.type.name === 'VectorSelector') {
         metric = expr.slice(node.from, node.to);
       }
-      
+
       // Extract label matchers using helper function
       const labelData = processLabelMatcher(node, expr);
       if (labelData) {
@@ -182,7 +180,7 @@ function processLabelMatcher(node: any, expr: string): PromQLLabelMatcher | null
   let labelName = '';
   let op = '';
   let value = '';
-  
+
   // Get children of UnquotedLabelMatcher
   for (let child = labelNode.firstChild; child; child = child.nextSibling) {
     if (child.type.name === 'LabelName') {
@@ -193,19 +191,23 @@ function processLabelMatcher(node: any, expr: string): PromQLLabelMatcher | null
       value = expr.slice(child.from + 1, child.to - 1); // Remove quotes
     }
   }
-  
-  if (labelName && op) { // Allow empty string values
+
+  if (labelName && op) {
+    // Allow empty string values
     return { label: labelName, op, value };
   }
   return null;
 }
 
 /**
- * Scenes adhoc variable filters requires a | delimiter 
+ * Scenes adhoc variable filters requires a | delimiter
  * between the label, operator, and value (see AdHocFiltersVariableUrlSyncHandler.ts in Scenes)
  */
 function filterToUrlParameter(filter: PromQLLabelMatcher): [UrlParameterType, string] {
-  return [UrlParameters.Filters, `${filter.label}${ADHOC_URL_DELIMITER}${filter.op}${ADHOC_URL_DELIMITER}${filter.value}`] as [UrlParameterType, string];
+  return [
+    UrlParameters.Filters,
+    `${filter.label}${ADHOC_URL_DELIMITER}${filter.op}${ADHOC_URL_DELIMITER}${filter.value}`,
+  ] as [UrlParameterType, string];
 }
 
 // Type for the metrics drilldown context from Grafana Assistant
@@ -246,7 +248,7 @@ export function buildNavigateToMetricsParams(promURLObject: PromURLObject): URLS
   const { metric, start, end, datasource_uid, label_filters } = promURLObject;
 
   const filters = label_filters ?? [];
-  
+
   // Use the structured context data to build parameters
   return appendUrlParameters([
     [UrlParameters.Metric, metric],
@@ -261,7 +263,7 @@ export function parseFiltersToLabelMatchers(label_filters?: string[]): PromQLLab
   if (!label_filters) {
     return [];
   }
-  
+
   return label_filters.map((filter) => {
     const matcher = parseMatcher(filter);
     return {

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -18,6 +18,9 @@ const description = `Open current query in the ${PRODUCT_NAME} view`;
 const category = 'metrics-drilldown';
 const icon = 'gf-prometheus';
 
+export const ASSISTANT_TARGET_V0 = 'grafana-metricsdrilldown-app/grafana-assistant-app/navigateToDrilldown/v0-alpha';
+export const ASSISTANT_TARGET_V1 = 'grafana-metricsdrilldown-app/grafana-assistant-app/navigateToDrilldown/v1';
+
 export const ADHOC_URL_DELIMITER = '|';
 
 export type PromQLLabelMatcher = {
@@ -33,11 +36,11 @@ export const linkConfigs: PluginExtensionAddedLinkConfig[] = [
     category,
     icon,
     path: createAppUrl(ROUTES.Drilldown),
-    targets: [PluginExtensionPoints.DashboardPanelMenu, PluginExtensionPoints.ExploreToolbarAction],
+    targets: [PluginExtensionPoints.DashboardPanelMenu, PluginExtensionPoints.ExploreToolbarAction, ASSISTANT_TARGET_V1],
     configure: configureDrilldownLink,
   },
   {
-    targets: ['grafana-metricsdrilldown-app/grafana-assistant-app/navigateToDrilldown/v0-alpha'],
+    targets: [ASSISTANT_TARGET_V0],
     title: 'Navigate to metrics drilldown',
     description: 'Build a url path to the metrics drilldown',
     path: createAppUrl(ROUTES.Drilldown),
@@ -78,8 +81,14 @@ export function configureDrilldownLink(context: object | undefined): { path: str
 
   const { datasource, expr } = queries[0];
 
-  if (!expr || datasource?.type !== 'prometheus') {
+  if (datasource?.type !== 'prometheus') {
     return;
+  }
+  // allow the user to navigate to the drilldown without a query (metrics reducer view)
+  if (!expr) {
+    return {
+      path: createAppUrl(ROUTES.Drilldown),
+    };
   }
 
   try {

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -19,7 +19,7 @@ const category = 'metrics-drilldown';
 const icon = 'gf-prometheus';
 
 export const ASSISTANT_TARGET_V0 = 'grafana-metricsdrilldown-app/grafana-assistant-app/navigateToDrilldown/v0-alpha';
-export const ASSISTANT_TARGET_V1 = 'grafana-metricsdrilldown-app/grafana-assistant-app/navigateToDrilldown/v1';
+export const ASSISTANT_TARGET_V1 = 'grafana-assistant-app/navigateToDrilldown/v1';
 
 export const ADHOC_URL_DELIMITER = '|';
 
@@ -73,6 +73,7 @@ export function configureDrilldownLink(context: object | undefined): { path: str
     return;
   }
 
+  // check that the datasource is prometheus
   const queries = (context as PluginExtensionPanelContext).targets.filter(isPromQuery);
 
   if (!queries?.length) {
@@ -81,9 +82,6 @@ export function configureDrilldownLink(context: object | undefined): { path: str
 
   const { datasource, expr } = queries[0];
 
-  if (datasource?.type !== 'prometheus') {
-    return;
-  }
   // allow the user to navigate to the drilldown without a query (metrics reducer view)
   if (!expr) {
     return {
@@ -108,7 +106,7 @@ export function configureDrilldownLink(context: object | undefined): { path: str
         : undefined;
 
     const promURLObject = createPromURLObject(
-      datasource.uid,
+      datasource?.uid,
       labels,
       metric,
       timeRange?.from,
@@ -308,5 +306,6 @@ export function appendUrlParameters(
 type PromQuery = DataQuery & { expr: string };
 
 function isPromQuery(query: DataQuery): query is PromQuery {
-  return 'expr' in query;
+  const { datasource } = query;
+  return datasource?.type === 'prometheus';
 }

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -76,7 +76,7 @@ export function configureDrilldownLink(context: object | undefined): { path: str
   // check that the datasource is prometheus
   const queries = (context as PluginExtensionPanelContext).targets.filter(isPromQuery);
 
-  if (!queries?.length) {
+  if (!queries.length) {
     return;
   }
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -55,7 +55,7 @@
   "extensions": {
     "addedLinks": [
       {
-        "targets": ["grafana/dashboard/panel/menu", "grafana/explore/toolbar/action"],
+        "targets": ["grafana/dashboard/panel/menu", "grafana/explore/toolbar/action", "grafana-metricsdrilldown-app/grafana-assistant-app/navigateToDrilldown/v1"],
         "title": "Open in Grafana Metrics Drilldown",
         "description": "Open current query in the Grafana Metrics Drilldown view"
       },

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -55,7 +55,7 @@
   "extensions": {
     "addedLinks": [
       {
-        "targets": ["grafana/dashboard/panel/menu", "grafana/explore/toolbar/action", "grafana-metricsdrilldown-app/grafana-assistant-app/navigateToDrilldown/v1"],
+        "targets": ["grafana/dashboard/panel/menu", "grafana/explore/toolbar/action", "grafana-assistant-app/navigateToDrilldown/v1"],
         "title": "Open in Grafana Metrics Drilldown",
         "description": "Open current query in the Grafana Metrics Drilldown view"
       },


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** 
Big issue: https://github.com/grafana/grafana-assistant-app/issues/956
[Grafana assistant PR](https://github.com/grafana/grafana-assistant-app/pull/1002)

### 📖 Summary of the changes

1. Allow the grafana assistant extension point to use a full query to generate a URL
2. Generate a URL with only a datasource_uid and navigate to drillldown metrics reducer view.

### 🧪 How to test?

1. Build the assistant
2. Ask the assistant to navigate to metrics drilldown with a query, metric or label filters.
3. The navigation should work.
