### PR TITLE
perf(*): Prevent duplicated "metrics list" queries when landing on the page

### DIFF
--- a/src/DataTrail.tsx
+++ b/src/DataTrail.tsx
@@ -186,8 +186,8 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
     if (!this.state.histogramsLoaded) {
       try {
         await this.datasourceHelper.initializeHistograms();
-      } catch {
-        displayWarning(['Error while initializing histograms!']);
+      } catch (e) {
+        displayWarning(['Error while initializing histograms!', (e as Error).toString()]);
       }
 
       this.setState({
@@ -306,8 +306,11 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
     const chromeHeaderHeight = useChromeHeaderHeight() ?? 0;
     const headerHeight = embedded ? 0 : chromeHeaderHeight;
     const styles = useStyles2(getStyles, headerHeight, model);
+
     // need to initialize this here and not on activate because it requires the data source helper to be fully initialized first
-    model.initializeHistograms();
+    useEffect(() => {
+      model.initializeHistograms();
+    }, [model]);
 
     useEffect(() => {
       const filtersVariable = sceneGraph.lookupVariable(VAR_FILTERS, model);

--- a/src/WingmanDataTrail/MetricsVariables/FilteredMetricsVariable.ts
+++ b/src/WingmanDataTrail/MetricsVariables/FilteredMetricsVariable.ts
@@ -1,17 +1,44 @@
-import { MetricsVariable } from './MetricsVariable';
+import { CustomVariable, sceneGraph } from '@grafana/scenes';
+
+import { MetricsVariable, VAR_METRICS_VARIABLE } from './MetricsVariable';
 import { withLifecycleEvents } from './withLifecycleEvents';
 
 export const VAR_FILTERED_METRICS_VARIABLE = 'filtered-metrics-wingman';
 
-export class FilteredMetricsVariable extends MetricsVariable {
+export class FilteredMetricsVariable extends CustomVariable {
   constructor() {
     super({
       key: VAR_FILTERED_METRICS_VARIABLE,
       name: VAR_FILTERED_METRICS_VARIABLE,
       label: 'Filtered Metrics',
+      loading: false,
+      error: null,
+      options: [],
+      includeAll: true,
+      value: '$__all',
+      skipUrlSync: true,
     });
+
+    this.addActivationHandler(this.onActivate.bind(this));
 
     // required for filtering and sorting
     return withLifecycleEvents<FilteredMetricsVariable>(this);
+  }
+
+  private onActivate() {
+    const metricsVariable = sceneGraph.findByKeyAndType(this, VAR_METRICS_VARIABLE, MetricsVariable);
+    const { loading, error, options } = metricsVariable.state;
+
+    this.setState({ loading, error, options });
+
+    this._subs.add(
+      metricsVariable.subscribeToState((newState) => {
+        this.setState({
+          loading: newState.loading,
+          error: newState.error,
+          options: newState.options,
+        });
+      })
+    );
   }
 }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR reduces the number of queries to fetch the list of all metrics **from 6 to 3**:

| Before | After |
|  ---   |  ---  |
| <img width="1709" height="172" alt="Screenshot 2025-07-25 at 13 16 50" src="https://github.com/user-attachments/assets/0d1e1fe1-cd3d-4370-ac1f-666088578657" /> |  <img width="1710" height="107" alt="Screenshot 2025-07-25 at 13 18 03" src="https://github.com/user-attachments/assets/9515ed2a-efdf-4c44-bc79-52a3aa921d04" /> |

Prior to this PR, when landing on the page:
- `DataTrail` would render its component,
- during render, [histograms would be initialized](https://github.com/grafana/metrics-drilldown/blob/main/src/DataTrail.tsx#L310) by calling [MetricDatasourceHelper.initializeHistograms()](https://github.com/grafana/metrics-drilldown/blob/main/src/helpers/MetricDatasourceHelper.ts#L114),
- `MetricDatasourceHelper.initializeHistograms()`would make [2 requests](https://github.com/grafana/metrics-drilldown/blob/main/src/helpers/MetricDatasourceHelper.ts#L117-L118) to get the data needed,
- several render cycles of the `DataTrail` component would occurs, resulting in duplicated queries.

Furthermore, [FilteredMetricsVariable](https://github.com/grafana/metrics-drilldown/blob/main/src/WingmanDataTrail/MetricsVariables/FilteredMetricsVariable.ts), which extended from `MetricsVariable`, would also make its own query when mounted.

### 📖 Summary of the changes

1. During the render cycle of the `DataTrail`, histograms are now initialized within `useEffect`,
2. `FilteredMetricsVariable` does now extend from `CustomVariable` and listens to the change of state of  `MetricsVariable`

### 🧪 How to test?

- See the browser's "Network" tab before and after checking out this PR
- The build should pass
