### PR TITLE
feat: move metric actions up into panel items for metric scene.

### DIFF
--- a/src/DataTrail.tsx
+++ b/src/DataTrail.tsx
@@ -32,7 +32,10 @@ import { PluginInfo } from 'PluginInfo/PluginInfo';
 import { displayWarning } from 'WingmanDataTrail/helpers/displayStatus';
 import { MetricsReducer } from 'WingmanDataTrail/MetricsReducer';
 
+import { DataTrailExploreAction } from './DataTrailExploreAction';
+import { DataTrailSelectMetricAction } from './DataTrailSelectMetricAction';
 import { DataTrailSettings } from './DataTrailSettings';
+import { DataTrailShareAction } from './DataTrailShareAction';
 import { MetricDatasourceHelper } from './helpers/MetricDatasourceHelper';
 import { reportChangeInLabelFilters } from './interactions';
 import { MetricScene } from './MetricScene';
@@ -83,6 +86,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
       controls: state.controls ?? [
         new VariableValueSelectors({ layout: 'vertical' }),
         new SceneControlsSpacer(),
+        new DataTrailSelectMetricAction(),
         new SceneTimePicker({}),
         new SceneRefreshPicker({}),
       ],
@@ -348,6 +352,8 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
               <control.Component key={control.state.key} model={control} />
             ))}
             <div className={styles.settingsInfo}>
+              <DataTrailExploreAction trail={model} />
+              <DataTrailShareAction trail={model} />
               <settings.Component model={settings} />
               <pluginInfo.Component model={pluginInfo} />
             </div>

--- a/src/DataTrailExploreAction.tsx
+++ b/src/DataTrailExploreAction.tsx
@@ -1,0 +1,56 @@
+import { getExploreURL, sceneGraph } from '@grafana/scenes';
+import { ToolbarButton } from '@grafana/ui';
+import React from 'react';
+
+import { logger } from 'tracking/logger/logger';
+
+import { AutoVizPanel } from './autoQuery/components/AutoVizPanel';
+import { UI_TEXT } from './constants/ui';
+import { type DataTrail } from './DataTrail';
+import { reportExploreMetrics } from './interactions';
+import { METRIC_AUTOVIZPANEL_KEY } from './MetricGraphScene';
+import { type MetricScene } from './MetricScene';
+
+interface DataTrailExploreActionProps {
+  trail: DataTrail;
+}
+
+export const DataTrailExploreAction = ({ trail }: DataTrailExploreActionProps) => {
+  const handleClick = async () => {
+    try {
+      reportExploreMetrics('selected_metric_action_clicked', { action: 'open_in_explore' });
+      
+      // Find the metric scene within the trail
+      const metricScene = trail.state.topScene as MetricScene;
+      if (!metricScene) {
+        // console.error('No metric scene found in trail');
+        return;
+      }
+
+      const autoVizPanel = sceneGraph.findByKeyAndType(metricScene, METRIC_AUTOVIZPANEL_KEY, AutoVizPanel);
+      const panelData =
+        typeof autoVizPanel.state.panel !== 'undefined'
+          ? sceneGraph.getData(autoVizPanel.state.panel).state.data
+          : undefined;
+
+      if (!panelData) {
+        // console.error('Cannot get link to explore, no panel data found');
+        return;
+      }
+
+      const link = await getExploreURL(panelData, metricScene, panelData.timeRange);
+      window.open(link, '_blank');
+    } catch (error) {
+      logger.error(error as Error);
+    }
+  };
+
+  return (
+    <ToolbarButton
+      icon="compass"
+      tooltip={UI_TEXT.METRIC_SELECT_SCENE.OPEN_EXPLORE_LABEL}
+      onClick={handleClick}
+      variant="canvas"
+    />
+  );
+};

--- a/src/DataTrailSelectMetricAction.tsx
+++ b/src/DataTrailSelectMetricAction.tsx
@@ -1,0 +1,40 @@
+import { SceneObjectBase, type SceneComponentProps, type SceneObjectState } from '@grafana/scenes';
+import { ToolbarButton } from '@grafana/ui';
+import React from 'react';
+
+import { UI_TEXT } from './constants/ui';
+import { reportExploreMetrics } from './interactions';
+import { MetricSelectedEvent } from './shared';
+import { getTrailFor } from './utils';
+
+interface DataTrailSelectMetricActionState extends SceneObjectState {}
+
+export class DataTrailSelectMetricAction extends SceneObjectBase<DataTrailSelectMetricActionState> {
+  constructor() {
+    super({
+      key: 'datatrail-select-metric-action',
+    });
+  }
+
+  public static readonly Component = ({ model }: SceneComponentProps<DataTrailSelectMetricAction>) => {
+    const trail = getTrailFor(model);
+    const {metric} = trail.useState();
+    
+    const handleClick = () => {
+      reportExploreMetrics('selected_metric_action_clicked', { action: 'unselect' });
+      trail.publishEvent(new MetricSelectedEvent(undefined));
+    };
+
+    return (
+      metric ? <ToolbarButton
+        variant="canvas"
+        icon="plus"
+        tooltip={UI_TEXT.METRIC_SELECT_SCENE.SELECT_NEW_METRIC_TOOLTIP}
+        onClick={handleClick}
+      >
+        Select new metric
+      </ToolbarButton>
+      : <></>
+    );
+  };
+}

--- a/src/DataTrailShareAction.tsx
+++ b/src/DataTrailShareAction.tsx
@@ -1,0 +1,39 @@
+import { config } from '@grafana/runtime';
+import { ToolbarButton } from '@grafana/ui';
+import React, { useState } from 'react';
+
+import { PLUGIN_BASE_URL } from './constants';
+import { UI_TEXT } from './constants/ui';
+import { type DataTrail } from './DataTrail';
+import { reportExploreMetrics } from './interactions';
+import { getUrlForTrail } from './utils';
+
+interface DataTrailShareActionProps {
+  trail: DataTrail;
+}
+
+export const DataTrailShareAction = ({ trail }: DataTrailShareActionProps) => {
+  const [tooltip, setTooltip] = useState(UI_TEXT.METRIC_SELECT_SCENE.COPY_URL_LABEL);
+
+  const handleClick = () => {
+    if (navigator.clipboard) {
+      reportExploreMetrics('selected_metric_action_clicked', { action: 'share_url' });
+      const appUrl = config.appUrl.endsWith('/') ? config.appUrl.slice(0, -1) : config.appUrl;
+      const url = `${appUrl}${PLUGIN_BASE_URL}/${getUrlForTrail(trail)}`;
+      navigator.clipboard.writeText(url);
+      setTooltip('Copied!');
+      setTimeout(() => {
+        setTooltip(UI_TEXT.METRIC_SELECT_SCENE.COPY_URL_LABEL);
+      }, 2000);
+    }
+  };
+
+  return (
+    <ToolbarButton
+      variant="canvas"
+      icon="share-alt"
+      tooltip={tooltip}
+      onClick={handleClick}
+    />
+  );
+};

--- a/src/MetricActionBar.tsx
+++ b/src/MetricActionBar.tsx
@@ -8,7 +8,7 @@ import {
   type SceneObject,
   type SceneObjectState,
 } from '@grafana/scenes';
-import { Box, Icon, LinkButton, Stack, Tab, TabsBar, ToolbarButton, Tooltip, useStyles2 } from '@grafana/ui';
+import { Box, LinkButton, Stack, Tab, TabsBar, ToolbarButton, Tooltip, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { AutoVizPanel } from 'autoQuery/components/AutoVizPanel';
@@ -20,7 +20,6 @@ import { MetricScene } from 'MetricScene';
 import { RelatedMetricsScene } from 'RelatedMetricsScene/RelatedMetricsScene';
 import { MetricSelectedEvent } from 'shared';
 import { ShareTrailButton } from 'ShareTrailButton';
-import { useBookmarkState } from 'TrailStore/useBookmarkState';
 import { getTrailFor, getUrlForTrail } from 'utils';
 
 import { LabelBreakdownScene } from './Breakdown/LabelBreakdownScene';
@@ -91,7 +90,6 @@ export class MetricActionBar extends SceneObjectBase<MetricActionBarState> {
     const metricScene = sceneGraph.getAncestor(model, MetricScene);
     const styles = useStyles2(getStyles);
     const trail = getTrailFor(model);
-    const [isBookmarked, toggleBookmark] = useBookmarkState(trail);
     const { actionView } = metricScene.useState();
 
     return (
@@ -127,18 +125,6 @@ export class MetricActionBar extends SceneObjectBase<MetricActionBarState> {
               onClick={model.openExploreLink}
             />
             <ShareTrailButton trail={trail} />
-            <ToolbarButton
-              variant={'canvas'}
-              icon={
-                isBookmarked ? (
-                  <Icon name={'favorite'} type={'mono'} size={'lg'} />
-                ) : (
-                  <Icon name={'star'} type={'default'} size={'lg'} />
-                )
-              }
-              tooltip={UI_TEXT.METRIC_SELECT_SCENE.BOOKMARK_LABEL}
-              onClick={toggleBookmark}
-            />
           </Stack>
         </div>
 

--- a/src/autoQuery/components/AutoVizPanel.tsx
+++ b/src/autoQuery/components/AutoVizPanel.tsx
@@ -14,6 +14,7 @@ import { MDP_METRIC_OVERVIEW, trailDS } from '../../shared';
 import { getMetricSceneFor, getTrailFor } from '../../utils';
 import { type AutoQueryDef } from '../types';
 import { AutoVizPanelQuerySelector } from './AutoVizPanelQuerySelector';
+import { BookmarkPanelAction } from './BookmarkPanelAction';
 
 export interface AutoVizPanelState extends SceneObjectState {
   panel?: VizPanel;
@@ -64,7 +65,10 @@ export class AutoVizPanel extends SceneObjectBase<AutoVizPanelState> {
         })
       )
       .setDescription(description)
-      .setHeaderActions([new AutoVizPanelQuerySelector({ queryDef: def, onChangeQuery: this.onChangeQuery })])
+      .setHeaderActions([
+        new AutoVizPanelQuerySelector({ queryDef: def, onChangeQuery: this.onChangeQuery }),
+        new BookmarkPanelAction(),
+      ])
       .setShowMenuAlways(true)
       .setMenu(new PanelMenu({ labelName: metric ?? this.state.metric }))
       .build();

--- a/src/autoQuery/components/AutoVizPanel.tsx
+++ b/src/autoQuery/components/AutoVizPanel.tsx
@@ -15,6 +15,9 @@ import { getMetricSceneFor, getTrailFor } from '../../utils';
 import { type AutoQueryDef } from '../types';
 import { AutoVizPanelQuerySelector } from './AutoVizPanelQuerySelector';
 import { BookmarkPanelAction } from './BookmarkPanelAction';
+import { ExploreAction } from './ExploreAction';
+import { MetricNavigationAction } from './MetricNavigationAction';
+import { ShareTrailAction } from './ShareTrailAction';
 
 export interface AutoVizPanelState extends SceneObjectState {
   panel?: VizPanel;
@@ -67,6 +70,9 @@ export class AutoVizPanel extends SceneObjectBase<AutoVizPanelState> {
       .setDescription(description)
       .setHeaderActions([
         new AutoVizPanelQuerySelector({ queryDef: def, onChangeQuery: this.onChangeQuery }),
+        new MetricNavigationAction(),
+        new ExploreAction(),
+        new ShareTrailAction(),
         new BookmarkPanelAction(),
       ])
       .setShowMenuAlways(true)

--- a/src/autoQuery/components/BookmarkPanelAction.tsx
+++ b/src/autoQuery/components/BookmarkPanelAction.tsx
@@ -1,0 +1,39 @@
+import { SceneObjectBase, type SceneComponentProps, type SceneObjectState } from '@grafana/scenes';
+import { Button, Icon } from '@grafana/ui';
+import React from 'react';
+
+import { useBookmarkState } from '../../TrailStore/useBookmarkState';
+import { getTrailFor } from '../../utils';
+
+interface BookmarkPanelActionState extends SceneObjectState {}
+
+export class BookmarkPanelAction extends SceneObjectBase<BookmarkPanelActionState> {
+  constructor() {
+    super({
+      key: 'bookmark-action',
+    });
+  }
+
+  public static readonly Component = ({ model }: SceneComponentProps<BookmarkPanelAction>) => {
+    const trail = getTrailFor(model);
+    const [isBookmarked, toggleBookmark] = useBookmarkState(trail);
+
+    return (
+      <Button
+        variant="secondary"
+        fill="text"
+        size="sm"
+        onClick={toggleBookmark}
+        icon={
+          isBookmarked ? (
+            <Icon name={'favorite'} type={'mono'} size={'lg'} />
+          ) : (
+            <Icon name={'star'} type={'default'} size={'lg'} />
+          )
+        }
+        tooltip="Bookmark this metric scene"
+        tooltipPlacement="top"
+      />
+    );
+  };
+}

--- a/src/autoQuery/components/ExploreAction.tsx
+++ b/src/autoQuery/components/ExploreAction.tsx
@@ -1,0 +1,60 @@
+import { getExploreURL, sceneGraph, SceneObjectBase, type SceneComponentProps, type SceneObjectState } from '@grafana/scenes';
+import { Button } from '@grafana/ui';
+import React from 'react';
+
+import { AutoVizPanel } from './AutoVizPanel';
+import { UI_TEXT } from '../../constants/ui';
+import { reportExploreMetrics } from '../../interactions';
+import { METRIC_AUTOVIZPANEL_KEY } from '../../MetricGraphScene';
+import { MetricScene } from '../../MetricScene';
+
+interface ExploreActionState extends SceneObjectState {}
+
+export class ExploreAction extends SceneObjectBase<ExploreActionState> {
+  constructor() {
+    super({
+      key: 'explore-action',
+    });
+  }
+
+  private getLinkToExplore = async () => {
+    const metricScene = sceneGraph.getAncestor(this, MetricScene);
+    const autoVizPanel = sceneGraph.findByKeyAndType(this, METRIC_AUTOVIZPANEL_KEY, AutoVizPanel);
+    const panelData =
+      typeof autoVizPanel.state.panel !== 'undefined'
+        ? sceneGraph.getData(autoVizPanel.state.panel).state.data
+        : undefined;
+
+    if (!panelData) {
+      throw new Error('Cannot get link to explore, no panel data found');
+    }
+
+    return getExploreURL(panelData, metricScene, panelData.timeRange);
+  };
+
+  public openExploreLink = async () => {
+    reportExploreMetrics('selected_metric_action_clicked', { action: 'open_in_explore' });
+    this.getLinkToExplore().then((link) => {
+      // We use window.open instead of a Link or <a> because we want to compute the explore link when clicking,
+      // if we precompute it we have to keep track of a lot of dependencies
+      window.open(link, '_blank');
+    });
+  };
+
+  public static readonly Component = ({ model }: SceneComponentProps<ExploreAction>) => {
+    return (
+      <Button
+        variant={'secondary'}
+        fill={'outline'}
+        size={'sm'}
+        icon="compass"
+        tooltip={UI_TEXT.METRIC_SELECT_SCENE.OPEN_EXPLORE_LABEL}
+        onClick={() => model.openExploreLink()}
+      >
+        Explore
+      </Button>
+    );
+  };
+}
+
+

--- a/src/autoQuery/components/MetricNavigationAction.tsx
+++ b/src/autoQuery/components/MetricNavigationAction.tsx
@@ -1,0 +1,55 @@
+import { SceneObjectBase, type SceneComponentProps, type SceneObjectState } from '@grafana/scenes';
+import { Button, LinkButton } from '@grafana/ui';
+import React from 'react';
+
+import { UI_TEXT } from '../../constants/ui';
+import { createAppUrl } from '../../extensions/links';
+import { reportExploreMetrics } from '../../interactions';
+import { MetricSelectedEvent } from '../../shared';
+import { getTrailFor, getUrlForTrail } from '../../utils';
+
+interface MetricNavigationActionState extends SceneObjectState {}
+
+export class MetricNavigationAction extends SceneObjectBase<MetricNavigationActionState> {
+  constructor() {
+    super({
+      key: 'metric-navigation-action',
+    });
+  }
+
+  public static readonly Component = ({ model }: SceneComponentProps<MetricNavigationAction>) => {
+    const trail = getTrailFor(model);
+
+    if (trail.state.embedded) {
+      return (
+        <LinkButton
+          href={createAppUrl(getUrlForTrail(trail))}
+          variant={'secondary'}
+          icon="arrow-right"
+          tooltip="Open in Metrics Drilldown"
+          onClick={() => reportExploreMetrics('selected_metric_action_clicked', { action: 'open_from_embedded' })}
+        >
+          Metrics Drilldown
+        </LinkButton>
+      );
+    }
+
+    return (
+      <Button
+        variant={'secondary'}
+        fill={'outline'}
+        size={'sm'}
+        tooltip={UI_TEXT.METRIC_SELECT_SCENE.SELECT_NEW_METRIC_TOOLTIP}
+        icon="plus"
+        onClick={() => {
+          reportExploreMetrics('selected_metric_action_clicked', { action: 'unselect' });
+          trail.publishEvent(new MetricSelectedEvent(undefined));
+        }}
+      >
+        Select new metric
+      </Button>
+    );
+  };
+}
+
+

--- a/src/autoQuery/components/ShareTrailAction.tsx
+++ b/src/autoQuery/components/ShareTrailAction.tsx
@@ -1,0 +1,50 @@
+import { config } from '@grafana/runtime';
+import { SceneObjectBase, type SceneComponentProps, type SceneObjectState } from '@grafana/scenes';
+import { Button } from '@grafana/ui';
+import React, { useState } from 'react';
+
+import { PLUGIN_BASE_URL } from '../../constants';
+import { UI_TEXT } from '../../constants/ui';
+import { reportExploreMetrics } from '../../interactions';
+import { getTrailFor, getUrlForTrail } from '../../utils';
+
+interface ShareTrailActionState extends SceneObjectState {}
+
+export class ShareTrailAction extends SceneObjectBase<ShareTrailActionState> {
+  constructor() {
+    super({
+      key: 'share-trail-action',
+    });
+  }
+
+  public static readonly Component = ({ model }: SceneComponentProps<ShareTrailAction>) => {
+    const trail = getTrailFor(model);
+    const [tooltip, setTooltip] = useState(UI_TEXT.METRIC_SELECT_SCENE.COPY_URL_LABEL);
+
+    const onShare = () => {
+      if (navigator.clipboard) {
+        reportExploreMetrics('selected_metric_action_clicked', { action: 'share_url' });
+        const appUrl = config.appUrl.endsWith('/') ? config.appUrl.slice(0, -1) : config.appUrl;
+        const url = `${appUrl}${PLUGIN_BASE_URL}/${getUrlForTrail(trail)}`;
+        navigator.clipboard.writeText(url);
+        setTooltip('Copied!');
+        setTimeout(() => {
+          setTooltip(UI_TEXT.METRIC_SELECT_SCENE.COPY_URL_LABEL);
+        }, 2000);
+      }
+    };
+
+    return (
+      <Button
+        variant={'secondary'}
+        fill={'outline'}
+        size={'sm'}
+        icon="share-alt"
+        onClick={onShare}
+        tooltip={tooltip}
+      >
+        Share
+      </Button>
+    );
+  };
+}


### PR DESCRIPTION
### ✨ Description

We have a few options to move the calls to action up in the UI. 

| Mixed (panel and top) | Panel with menu items | Top with bookmark star |
| --- | --- | --- |
| <img width="1264" height="827" alt="Screenshot 2025-08-05 at 2 53 42 PM" src="https://github.com/user-attachments/assets/81715e57-1289-4cbe-af16-176c1ebed387" /> | <img width="1312" height="733" alt="Screenshot 2025-08-04 at 9 57 48 AM" src="https://github.com/user-attachments/assets/a16b7335-dbd7-4de2-b7fd-0bbd534c35f4" /> | <img width="1310" height="738" alt="Screenshot 2025-08-04 at 9 58 58 AM" src="https://github.com/user-attachments/assets/e6367e54-87a1-4b95-a153-7dafb1046b54" /> |
| --- | --- | --- |





**Related issue(s):** https://github.com/grafana/metrics-drilldown/issues/420

Move the metric actions from below the metric scene up into the panel items

### 📖 Summary of the changes

- [x] Move the metric actions into the panel items
- [x] Remove the metric actions under the metric scene
- [ ] Remove the select metric action in favor of the working back browser navigation.

### 🧪 How to test?

Use the metric panel items

1. Select new metric
2. Share trail
3. Add bookmark

Double check that e2e tests work
Make sure we keep rudderstack events
