### PR TITLE
ci(EndToEnd): Skip Grafana dev image

### DIFF
--- a/.github/workflows/playwright-published.yml
+++ b/.github/workflows/playwright-published.yml
@@ -81,6 +81,7 @@ jobs:
       report-path: e2e/test-reports/
       grafana-compose-file: docker-compose.yaml
       grafana-url: http://localhost:3001
+      skip-grafana-dev-image: true
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/metrics-drilldown/pull/565

Since the PR to support multiple Grafana versions for E2E screenshot testing [has been merged](https://github.com/grafana/metrics-drilldown/commit/4562d75cae5c71badd301d8ef48249e286f3382d), our build has been failing in main.

The reason is that, in main, the [playwright-published workflow](https://github.com/grafana/metrics-drilldown/blob/main/.github/workflows/playwright-published.yml) is executed and it does not skip E2E tests with the Grafana dev image. As a consequence, Playwright does not find any screenshot for the Grafana dev version.

### 📖 Summary of the changes

We just skip E2E tests with the Grafana dev image

### 🧪 How to test?

- After merging this PR to `main`, the build should pass
