### PR TITLE
refactor(MetricLabelValuesList): Introduce LabelValueVizPanel

### DIFF
--- a/src/Breakdown/LabelBreakdownScene.tsx
+++ b/src/Breakdown/LabelBreakdownScene.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 import { RefreshMetricsEvent, VAR_GROUP_BY } from '../shared';
 import { isQueryVariable } from '../utils/utils.variables';
 import { MetricLabelsList } from './MetricLabelsList/MetricLabelsList';
-import { MetricLabelValuesList } from './MetricLabelValuesList/MetricLabelsValuesList';
+import { MetricLabelValuesList } from './MetricLabelValuesList/MetricLabelValuesList';
 
 export interface LabelBreakdownSceneState extends SceneObjectState {
   metric: string;

--- a/src/Breakdown/MetricLabelValuesList/LabelValueVizPanel.tsx
+++ b/src/Breakdown/MetricLabelValuesList/LabelValueVizPanel.tsx
@@ -1,0 +1,94 @@
+import {
+  PanelBuilders,
+  SceneObjectBase,
+  type SceneComponentProps,
+  type SceneDataNode,
+  type SceneObjectState,
+  type VizPanel,
+  type VizPanelState,
+} from '@grafana/scenes';
+import React from 'react';
+
+import { type PanelMenu } from 'Menu/PanelMenu';
+
+import { publishTimeseriesData } from '../MetricLabelsList/behaviors/publishTimeseriesData';
+
+interface LabelValueVizPanelState extends SceneObjectState {
+  labelValue: string;
+  data: SceneDataNode;
+  unit: string;
+  fixedColor: string;
+  headerActions: VizPanelState['headerActions'];
+  menu: PanelMenu;
+  body: VizPanel;
+}
+
+export class LabelValueVizPanel extends SceneObjectBase<LabelValueVizPanelState> {
+  constructor({
+    labelValue,
+    data,
+    unit,
+    fixedColor,
+    headerActions,
+    menu,
+  }: {
+    labelValue: LabelValueVizPanelState['labelValue'];
+    data: LabelValueVizPanelState['data'];
+    unit: LabelValueVizPanelState['unit'];
+    fixedColor: LabelValueVizPanelState['fixedColor'];
+    headerActions: LabelValueVizPanelState['headerActions'];
+    menu: LabelValueVizPanelState['menu'];
+  }) {
+    super({
+      key: `label-value-viz-panel-${labelValue}`,
+      labelValue,
+      data,
+      unit,
+      fixedColor,
+      headerActions,
+      menu,
+      body: LabelValueVizPanel.buildVizPanel({
+        labelValue,
+        data,
+        unit,
+        fixedColor,
+        headerActions,
+        menu,
+      }),
+    });
+  }
+
+  private static buildVizPanel({
+    labelValue,
+    data,
+    unit,
+    fixedColor,
+    headerActions,
+    menu,
+  }: {
+    labelValue: LabelValueVizPanelState['labelValue'];
+    data: LabelValueVizPanelState['data'];
+    unit: LabelValueVizPanelState['unit'];
+    fixedColor: LabelValueVizPanelState['fixedColor'];
+    headerActions: LabelValueVizPanelState['headerActions'];
+    menu: LabelValueVizPanelState['menu'];
+  }) {
+    return PanelBuilders.timeseries()
+      .setTitle(labelValue)
+      .setBehaviors([publishTimeseriesData()]) // publishTimeseriesData is required for the syncYAxis behavior
+      .setData(data)
+      .setUnit(unit)
+      .setColor({ mode: 'fixed', fixedColor })
+      .setCustomFieldConfig('fillOpacity', 9)
+      .setHeaderActions(headerActions)
+      .setOption('legend', { showLegend: false })
+      .setShowMenuAlways(true)
+      .setMenu(menu)
+      .build();
+  }
+
+  public static readonly Component = ({ model }: SceneComponentProps<LabelValueVizPanel>) => {
+    const { body } = model.useState();
+    return <body.Component model={body} />;
+  };
+}

--- a/src/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
+++ b/src/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
@@ -22,7 +22,6 @@ import React from 'react';
 
 import { InlineBanner } from 'App/InlineBanner';
 import { getAutoQueriesForMetric } from 'autoQuery/getAutoQueriesForMetric';
-import { publishTimeseriesData } from 'Breakdown/MetricLabelsList/behaviors/publishTimeseriesData';
 import { syncYAxis } from 'Breakdown/MetricLabelsList/behaviors/syncYAxis';
 import { addUnspecifiedLabel } from 'Breakdown/MetricLabelsList/transformations/addUnspecifiedLabel';
 import { PanelMenu } from 'Menu/PanelMenu';
@@ -38,6 +37,7 @@ import { ShowMoreButton } from 'WingmanDataTrail/ShowMoreButton';
 import { AddToFiltersGraphAction } from './AddToFiltersGraphAction';
 import { getLabelValueFromDataFrame } from './getLabelValueFromDataFrame';
 import { LabelValuesCountsProvider } from './LabelValuesCountProvider';
+import { LabelValueVizPanel } from './LabelValueVizPanel';
 import { SceneByFrameRepeater } from './SceneByFrameRepeater';
 import { SortBySelector, type SortBySelectorState } from './SortBySelector';
 
@@ -226,25 +226,18 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
         }
 
         const labelValue = getLabelValueFromDataFrame(frame);
-        const panelKey = `panel-${metric}-${labelValue}`;
 
         const canAddToFilters = !labelValue.startsWith('<unspecified'); // see the "addUnspecifiedLabel" data transformation
         const headerActions = canAddToFilters ? [new AddToFiltersGraphAction({ labelName: label, labelValue })] : [];
 
-        // TODO: Use LabelVizPanel?
-        const vizPanel = queryDef
-          .vizBuilder()
-          .setTitle(labelValue)
-          .setData(new SceneDataNode({ data: { ...data, series: [frame] } }))
-          .setBehaviors([publishTimeseriesData()]) // publishTimeseriesData is required for the syncYAxis behavior
-          .setColor({ mode: 'fixed', fixedColor: getColorByIndex(frameIndex) })
-          .setHeaderActions(headerActions)
-          .setShowMenuAlways(true)
-          .setMenu(new PanelMenu({ labelName: labelValue }))
-          .setUnit(unit)
-          .build();
-
-        vizPanel.setState({ key: panelKey });
+        const vizPanel = new LabelValueVizPanel({
+          labelValue,
+          data: new SceneDataNode({ data: { ...data, series: [frame] } }),
+          unit,
+          fixedColor: getColorByIndex(frameIndex),
+          headerActions,
+          menu: new PanelMenu({ labelName: labelValue }),
+        });
 
         return new SceneCSSGridItem({ body: vizPanel });
       },


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** preparation to simplify the review on https://github.com/grafana/metrics-drilldown/pull/594

This PR adds the new `LabelValueVizPanel` component to encapsulate how we build panel in the "Breakdown" tab after selecting a label:
<img width="845" height="308" alt="image" src="https://github.com/user-attachments/assets/a1c674b1-af22-417b-b313-d94353a90486" />

This is made to simplification the panel unification in https://github.com/grafana/metrics-drilldown/pull/594

### 📖 Summary of the changes

The code for building the panel has been encapsulated in a new Scene object `LabelValueVizPanel`

### 🧪 How to test?

- The build should pass
