### PR TITLE
refactor(SceneByFrameRepeater): Allow $data to be passed to the constructor

### DIFF
--- a/src/Breakdown/MetricLabelValuesList/MetricLabelsValuesList.tsx
+++ b/src/Breakdown/MetricLabelValuesList/MetricLabelsValuesList.tsx
@@ -44,6 +44,7 @@ import { SortBySelector, type SortBySelectorState } from './SortBySelector';
 interface MetricLabelsValuesListState extends SceneObjectState {
   metric: string;
   label: string;
+  $data: SceneDataTransformer;
   layoutSwitcher: LayoutSwitcher;
   quickSearch: QuickSearch;
   sortBySelector: SortBySelector;
@@ -62,6 +63,14 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
       key: 'metric-label-values-list',
       metric,
       label,
+      $data: new SceneDataTransformer({
+        $data: new SceneQueryRunner({
+          datasource: trailDS,
+          maxDataPoints: MDP_METRIC_PREVIEW,
+          queries: getAutoQueriesForMetric(metric).breakdown.queries,
+        }),
+        transformations: [addUnspecifiedLabel(label)],
+      }),
       layoutSwitcher: new LayoutSwitcher({
         urlSearchParamName: 'breakdownLayout',
         options: [
@@ -178,14 +187,6 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
     const unit = queryDef.unit;
 
     return new SceneByFrameRepeater({
-      $data: new SceneDataTransformer({
-        $data: new SceneQueryRunner({
-          datasource: trailDS,
-          maxDataPoints: MDP_METRIC_PREVIEW,
-          queries: getAutoQueriesForMetric(metric).breakdown.queries,
-        }),
-        transformations: [addUnspecifiedLabel(label)],
-      }),
       // we set the syncYAxis behavior here to ensure that the EventResetSyncYAxis events that are published by SceneByFrameRepeater can be received
       $behaviors: [
         syncYAxis(),

--- a/src/Breakdown/MetricLabelValuesList/MetricLabelsValuesList.tsx
+++ b/src/Breakdown/MetricLabelValuesList/MetricLabelsValuesList.tsx
@@ -44,7 +44,6 @@ import { SortBySelector, type SortBySelectorState } from './SortBySelector';
 interface MetricLabelsValuesListState extends SceneObjectState {
   metric: string;
   label: string;
-  $data: SceneDataTransformer;
   layoutSwitcher: LayoutSwitcher;
   quickSearch: QuickSearch;
   sortBySelector: SortBySelector;
@@ -63,14 +62,6 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
       key: 'metric-label-values-list',
       metric,
       label,
-      $data: new SceneDataTransformer({
-        $data: new SceneQueryRunner({
-          datasource: trailDS,
-          maxDataPoints: MDP_METRIC_PREVIEW,
-          queries: getAutoQueriesForMetric(metric).breakdown.queries,
-        }),
-        transformations: [addUnspecifiedLabel(label)],
-      }),
       layoutSwitcher: new LayoutSwitcher({
         urlSearchParamName: 'breakdownLayout',
         options: [
@@ -187,6 +178,14 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
     const unit = queryDef.unit;
 
     return new SceneByFrameRepeater({
+      $data: new SceneDataTransformer({
+        $data: new SceneQueryRunner({
+          datasource: trailDS,
+          maxDataPoints: MDP_METRIC_PREVIEW,
+          queries: getAutoQueriesForMetric(metric).breakdown.queries,
+        }),
+        transformations: [addUnspecifiedLabel(label)],
+      }),
       // we set the syncYAxis behavior here to ensure that the EventResetSyncYAxis events that are published by SceneByFrameRepeater can be received
       $behaviors: [
         syncYAxis(),

--- a/src/Breakdown/MetricLabelValuesList/SceneByFrameRepeater.tsx
+++ b/src/Breakdown/MetricLabelValuesList/SceneByFrameRepeater.tsx
@@ -29,7 +29,6 @@ import { SortBySelector } from './SortBySelector';
  * 3. Support for $behaviors, that is used to reset the y axis sync after filtering and/or sorting
  */
 interface SceneByFrameRepeaterState extends SceneObjectState {
-  $data?: SceneDataProvider;
   $behaviors: Array<SceneObject | SceneStatelessBehavior>;
   body: SceneLayout;
   getLayoutChild(data: PanelData, frame: DataFrame, frameIndex: number): SceneObject | null;
@@ -43,6 +42,7 @@ interface SceneByFrameRepeaterState extends SceneObjectState {
   errorLayout?: SceneObject;
   emptyLayout?: SceneObject;
   counts: CountsData;
+  $data?: SceneDataProvider;
 }
 
 const DEFAULT_INITIAL_PAGE_SIZE = 120;
@@ -53,7 +53,6 @@ export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterSt
   private sortBy?: SortSeriesByOption;
 
   public constructor({
-    $data,
     $behaviors,
     body,
     getLayoutChild,
@@ -62,8 +61,8 @@ export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterSt
     getLayoutEmpty,
     initialPageSize,
     pageSizeIncrement,
+    $data,
   }: {
-    $data: SceneByFrameRepeaterState['$data'];
     $behaviors: SceneByFrameRepeaterState['$behaviors'];
     body: SceneByFrameRepeaterState['body'];
     getLayoutChild: SceneByFrameRepeaterState['getLayoutChild'];
@@ -72,10 +71,10 @@ export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterSt
     getLayoutEmpty?: SceneByFrameRepeaterState['getLayoutEmpty'];
     initialPageSize?: SceneByFrameRepeaterState['initialPageSize'];
     pageSizeIncrement?: SceneByFrameRepeaterState['pageSizeIncrement'];
+    $data?: SceneByFrameRepeaterState['$data'];
   }) {
     super({
       key: 'breakdown-by-frame-repeater',
-      $data,
       $behaviors,
       body,
       getLayoutChild,
@@ -89,6 +88,7 @@ export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterSt
       errorLayout: undefined,
       emptyLayout: undefined,
       counts: { current: 0, total: 0 },
+      $data,
     });
 
     this.addActivationHandler(() => {

--- a/src/Breakdown/MetricLabelValuesList/SceneByFrameRepeater.tsx
+++ b/src/Breakdown/MetricLabelValuesList/SceneByFrameRepeater.tsx
@@ -53,6 +53,7 @@ export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterSt
   private sortBy?: SortSeriesByOption;
 
   public constructor({
+    $data,
     $behaviors,
     body,
     getLayoutChild,
@@ -61,8 +62,8 @@ export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterSt
     getLayoutEmpty,
     initialPageSize,
     pageSizeIncrement,
-    $data,
   }: {
+    $data: SceneByFrameRepeaterState['$data'];
     $behaviors: SceneByFrameRepeaterState['$behaviors'];
     body: SceneByFrameRepeaterState['body'];
     getLayoutChild: SceneByFrameRepeaterState['getLayoutChild'];
@@ -71,7 +72,6 @@ export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterSt
     getLayoutEmpty?: SceneByFrameRepeaterState['getLayoutEmpty'];
     initialPageSize?: SceneByFrameRepeaterState['initialPageSize'];
     pageSizeIncrement?: SceneByFrameRepeaterState['pageSizeIncrement'];
-    $data?: SceneByFrameRepeaterState['$data'];
   }) {
     super({
       key: 'breakdown-by-frame-repeater',

--- a/src/Breakdown/MetricLabelValuesList/SceneByFrameRepeater.tsx
+++ b/src/Breakdown/MetricLabelValuesList/SceneByFrameRepeater.tsx
@@ -53,7 +53,6 @@ export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterSt
   private sortBy?: SortSeriesByOption;
 
   public constructor({
-    $data,
     $behaviors,
     body,
     getLayoutChild,
@@ -62,8 +61,8 @@ export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterSt
     getLayoutEmpty,
     initialPageSize,
     pageSizeIncrement,
+    $data,
   }: {
-    $data: SceneByFrameRepeaterState['$data'];
     $behaviors: SceneByFrameRepeaterState['$behaviors'];
     body: SceneByFrameRepeaterState['body'];
     getLayoutChild: SceneByFrameRepeaterState['getLayoutChild'];
@@ -72,6 +71,7 @@ export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterSt
     getLayoutEmpty?: SceneByFrameRepeaterState['getLayoutEmpty'];
     initialPageSize?: SceneByFrameRepeaterState['initialPageSize'];
     pageSizeIncrement?: SceneByFrameRepeaterState['pageSizeIncrement'];
+    $data?: SceneByFrameRepeaterState['$data'];
   }) {
     super({
       key: 'breakdown-by-frame-repeater',

--- a/src/Breakdown/MetricLabelValuesList/SceneByFrameRepeater.tsx
+++ b/src/Breakdown/MetricLabelValuesList/SceneByFrameRepeater.tsx
@@ -3,6 +3,7 @@ import {
   sceneGraph,
   SceneObjectBase,
   type SceneComponentProps,
+  type SceneDataProvider,
   type SceneLayout,
   type SceneObject,
   type SceneObjectState,
@@ -28,6 +29,7 @@ import { SortBySelector } from './SortBySelector';
  * 3. Support for $behaviors, that is used to reset the y axis sync after filtering and/or sorting
  */
 interface SceneByFrameRepeaterState extends SceneObjectState {
+  $data?: SceneDataProvider;
   $behaviors: Array<SceneObject | SceneStatelessBehavior>;
   body: SceneLayout;
   getLayoutChild(data: PanelData, frame: DataFrame, frameIndex: number): SceneObject | null;
@@ -51,6 +53,7 @@ export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterSt
   private sortBy?: SortSeriesByOption;
 
   public constructor({
+    $data,
     $behaviors,
     body,
     getLayoutChild,
@@ -60,6 +63,7 @@ export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterSt
     initialPageSize,
     pageSizeIncrement,
   }: {
+    $data: SceneByFrameRepeaterState['$data'];
     $behaviors: SceneByFrameRepeaterState['$behaviors'];
     body: SceneByFrameRepeaterState['body'];
     getLayoutChild: SceneByFrameRepeaterState['getLayoutChild'];
@@ -71,6 +75,7 @@ export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterSt
   }) {
     super({
       key: 'breakdown-by-frame-repeater',
+      $data,
       $behaviors,
       body,
       getLayoutChild,


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** preparation to simplify the review on https://github.com/grafana/metrics-drilldown/pull/594

Before this PR any `$data` would have had to be attached to a parent of `SceneByFrameRepeater`, which in some cases, may not be convenient. This PR adds  a new  `$data` option to its constructor, as a convenience. 

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The build should pass
