### PR TITLE
fix(MetricScene): Fix fatal error in an edge case where there's no data

### DIFF
--- a/src/Breakdown/MetricLabelsList/LabelVizPanel.tsx
+++ b/src/Breakdown/MetricLabelsList/LabelVizPanel.tsx
@@ -106,7 +106,7 @@ export class LabelVizPanel extends SceneObjectBase<LabelVizPanelState> {
   }
 
   private onActivate() {
-    const { body } = this.state;
+    const { body, label } = this.state;
 
     this._subs.add(
       (body.state.$data as SceneQueryRunner).subscribeToState((newState) => {
@@ -116,11 +116,15 @@ export class LabelVizPanel extends SceneObjectBase<LabelVizPanelState> {
 
         const { series } = newState.data;
 
-        if (series?.length) {
-          const config = this.getAllValuesConfig(series);
-
-          body.setState(merge({}, body.state, config));
+        if (!series?.length) {
+          return;
         }
+
+        const hasNoData = series.every((s) => !s.length);
+        const headerActions = hasNoData ? null : [new SelectLabelAction({ label })];
+        const config = this.getAllValuesConfig(series);
+
+        body.setState(merge({}, body.state, { headerActions }, config));
       })
     );
   }

--- a/src/services/sorting.ts
+++ b/src/services/sorting.ts
@@ -43,12 +43,18 @@ const sortByFieldReducer = (series: DataFrame[], sortBy: string, direction: Sort
   const fieldReducer = fieldReducers.get(sortBy);
 
   const seriesCalcs = series.map((dataFrame) => {
-    const value =
-      fieldReducer.reduce?.(dataFrame.fields[1], true, true) ?? doStandardCalcs(dataFrame.fields[1], true, true);
+    const field = dataFrame.fields[1];
+    if (!field) {
+      return {
+        value: 0,
+        dataFrame,
+      };
+    }
 
+    const value = fieldReducer.reduce?.(field, true, true) ?? doStandardCalcs(field, true, true);
     return {
       value: value[sortBy] ?? 0,
-      dataFrame: dataFrame,
+      dataFrame,
     };
   });
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** fixes https://github.com/grafana/metrics-drilldown/issues/615

### 📖 Summary of the changes

Two small changes:
1. We disable the "Select" button when there's no data
2. We improve the sorting code to prevent a runtime exception when the data frame is empty 

### 🧪 How to test?

- Locally, after pulling this branch. See the linked issue for the reproduction steps.
