### PR TITLE
fix(Breakdown): Address Scene warnings

### DIFF
--- a/src/Breakdown/MetricLabelValuesList/LabelValueVizPanel.tsx
+++ b/src/Breakdown/MetricLabelValuesList/LabelValueVizPanel.tsx
@@ -15,11 +15,8 @@ import { publishTimeseriesData } from '../MetricLabelsList/behaviors/publishTime
 
 interface LabelValueVizPanelState extends SceneObjectState {
   labelValue: string;
-  data: SceneDataNode;
   unit: string;
   fixedColor: string;
-  headerActions: VizPanelState['headerActions'];
-  menu: PanelMenu;
   body: VizPanel;
 }
 
@@ -33,20 +30,17 @@ export class LabelValueVizPanel extends SceneObjectBase<LabelValueVizPanelState>
     menu,
   }: {
     labelValue: LabelValueVizPanelState['labelValue'];
-    data: LabelValueVizPanelState['data'];
+    data: SceneDataNode;
     unit: LabelValueVizPanelState['unit'];
     fixedColor: LabelValueVizPanelState['fixedColor'];
-    headerActions: LabelValueVizPanelState['headerActions'];
-    menu: LabelValueVizPanelState['menu'];
+    headerActions: VizPanelState['headerActions'];
+    menu: PanelMenu;
   }) {
     super({
       key: `label-value-viz-panel-${labelValue}`,
       labelValue,
-      data,
       unit,
       fixedColor,
-      headerActions,
-      menu,
       body: LabelValueVizPanel.buildVizPanel({
         labelValue,
         data,
@@ -67,11 +61,11 @@ export class LabelValueVizPanel extends SceneObjectBase<LabelValueVizPanelState>
     menu,
   }: {
     labelValue: LabelValueVizPanelState['labelValue'];
-    data: LabelValueVizPanelState['data'];
+    data: SceneDataNode;
     unit: LabelValueVizPanelState['unit'];
     fixedColor: LabelValueVizPanelState['fixedColor'];
-    headerActions: LabelValueVizPanelState['headerActions'];
-    menu: LabelValueVizPanelState['menu'];
+    headerActions: VizPanelState['headerActions'];
+    menu: PanelMenu;
   }) {
     return PanelBuilders.timeseries()
       .setTitle(labelValue)


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** is caused by https://github.com/grafana/metrics-drilldown/pull/608

After merging the linked PR, some warnings started to appear in the browser console, for instance:

<img width="3060" height="78" alt="image" src="https://github.com/user-attachments/assets/15edbea7-0876-4c43-983b-f6dae7e5c12d" />

### 📖 Summary of the changes

This PR modifies `LabelValueVizPanel` so that it does not store any Scene object in its own state. By doing so, they can be used to build the timeseries panel (and attached only to it in the Scene graph).

### 🧪 How to test?

- No warning messages related to Scene objects with multiple parents should appear in the browser's console
