### PR TITLE
fix(links): use template vars in links

### DIFF
--- a/src/extensions/links.test.ts
+++ b/src/extensions/links.test.ts
@@ -4,7 +4,7 @@ import { type PluginExtensionPanelContext } from '@grafana/data';
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getTemplateSrv: () => ({
-    replace: jest.fn((a: string, ...rest: unknown[]) => {
+    replace: jest.fn((a: string) => {
       if (a === '${ds}') {
         return '123abc';
       }

--- a/src/extensions/links.test.ts
+++ b/src/extensions/links.test.ts
@@ -1,3 +1,5 @@
+import { type PluginExtensionPanelContext } from '@grafana/data';
+
 import {
   buildNavigateToMetricsParams,
   configureDrilldownLink,
@@ -7,13 +9,12 @@ import {
   UrlParameters,
   type GrafanaAssistantMetricsDrilldownContext,
 } from './links';
-import { PluginExtensionPanelContext, DataQuery } from '@grafana/data';
 
 // Mock templateSrv for variable interpolation tests
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getTemplateSrv: jest.fn(() => ({
-    replace: jest.fn((query: string, scopedVars: any, interpolateQueryExpr?: any) => {
+    replace: jest.fn((query: string) => {
       // Mock variable interpolation
       if (query.includes('$job')) {
         return query.replace('$job', 'grafana');
@@ -27,7 +28,7 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 // Prometheus query type for tests
-type PromQuery = DataQuery & { expr: string };
+type PromQuery = { refId: string; expr: string; datasource?: { type: string; uid: string } };
 
 // Mock factory for PluginExtensionPanelContext
 function createMockContext(overrides: Partial<PluginExtensionPanelContext> = {}): PluginExtensionPanelContext {
@@ -182,7 +183,7 @@ describe('parsePromQLQuery - lezer parser tests', () => {
 describe('configureDrilldownLink', () => {
   describe('guard clauses', () => {
     test('should return undefined when context is undefined', () => {
-      const result = configureDrilldownLink(undefined);
+      const result = configureDrilldownLink();
       expect(result).toBeUndefined();
     });
 

--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -95,18 +95,14 @@ export function configureDrilldownLink<T extends PluginExtensionPanelContext>(co
   const templateSrv = getTemplateSrv();
   const datasourceUid = templateSrv.replace(prometheusQuery?.datasource?.uid, context.scopedVars);
 
-  const expr = templateSrv.replace(prometheusQuery.expr, context.scopedVars, interpolateQueryExpr);
-  
-  if (!datasourceUid || !expr) {
-    return;
-  }
-
   // allow the user to navigate to the drilldown without a query (metrics reducer view)
-  if (!expr) {
+  if (!prometheusQuery.expr) {
     return {
       path: createAppUrl(ROUTES.Drilldown),
     };
   }
+
+  const expr = templateSrv.replace(prometheusQuery.expr, context.scopedVars, interpolateQueryExpr);
 
   try {
     const { metric, labels, hasErrors, errors } = parsePromQLQuery(expr);


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** <!-- Paste a GitHub issue URL or another pull request URL -->
https://github.com/grafana/metrics-drilldown/issues/602

This interpolates Grafana template variables when navigating from a panel to metrics drilldown.


https://github.com/user-attachments/assets/947aa6f2-4374-4133-b6b2-f4ef5e605b14



### 📖 Summary of the changes

1. We use the `templateSrv` to interpolate variables in the query and data source
2. Update types in the links.ts file 
3. Add Prometheus functions that are not exported from the prometheus package

### 🧪 How to test?

1. Create a variable in a dashboard
2. Use a variable in a query in the dashboard (i.e. metrics or labels)
3. Exit edit mode in the dashboard and click the menu in the panel (three dots)
4. Open in metrics drilldown
5. See that the query is interpolated correctly
