### PR TITLE
refactor: prepare for embedded metrics reducer

### DIFF
--- a/src/TrailStore/TrailStore.test.ts
+++ b/src/TrailStore/TrailStore.test.ts
@@ -1,7 +1,8 @@
 import { setDataSourceSrv, type DataSourceWithBackend } from '@grafana/runtime';
 
 import { RECENT_TRAILS_KEY, TrailStore, type UrlSerializedTrail } from './TrailStore';
-import { DataSourceType, mockDataSource, MockDataSourceSrv } from '../mocks/datasource';
+import { DataSourceType, MockDataSourceSrv } from '../mocks/datasource';
+import { dataSourceStub } from '../stubs/dataSourceStub';
 import { PREF_KEYS } from '../UserPreferences/pref-keys';
 import { userPreferences } from '../UserPreferences/userPreferences';
 
@@ -37,7 +38,7 @@ describe('TrailStore', () => {
     getDataSourceSrvSpy.mockImplementation(() => {
       return {
         get: (ds: DataSourceWithBackend) => Promise.resolve(ds),
-        getList: () => [mockDataSource],
+        getList: () => [dataSourceStub],
         getInstanceSettings: () => ({
           id: 1,
           uid: 'ds',

--- a/src/WingmanDataTrail/MetricsVariables/computeRulesGroups.ts
+++ b/src/WingmanDataTrail/MetricsVariables/computeRulesGroups.ts
@@ -3,9 +3,10 @@ import { ruleGroupLabels } from './metricLabels';
 type MetricType = 'metrics' | 'rules';
 
 /**
- * Type guard that checks if a string follows Prometheus recording rule naming convention
- * Recording rules follow the pattern: level:metric:operations or level:metric
- * Where level, metric, and operations can contain underscores and alphanumeric characters
+ * Checks if a metric name follows Prometheus recording rule naming conventions.
+ *
+ * @remarks Recording rules follow the pattern: `level:metric:operations` or `level:metric`
+ * Where `level`, `metric`, and `operations` can contain underscores and alphanumeric characters.
  */
 export function isRecordingRule(value: string): boolean {
   // Matches patterns like:

--- a/src/WingmanDataTrail/MetricsVariables/computeRulesGroups.ts
+++ b/src/WingmanDataTrail/MetricsVariables/computeRulesGroups.ts
@@ -6,8 +6,8 @@ type MetricType = 'metrics' | 'rules';
  * Checks if a metric name follows Prometheus recording rule naming conventions.
  *
  * @remarks Recording rules follow the pattern: `level:metric:operations` or `level:metric`.
- * The `level` component might be empty. Where `level`, `metric`, and `operations` can contain
- * underscores and alphanumeric characters.
+ * The `level` component might be empty. Where `level` and `operations` can contain
+ * underscores and alphanumeric characters. The `metric` part can contain any character, but can't be empty.
  */
 export function isRecordingRule(value: string): boolean {
   // Matches patterns like:
@@ -17,7 +17,7 @@ export function isRecordingRule(value: string): boolean {
   // - apiserver_request:availability30d
   // - asserts:container_memory
   // - :requests:rate5m
-  return /^\w*:\w+(?::\w+)?$/.test(value);
+  return /^\w*:.*?(?::\w+)?$/.test(value);
 }
 
 export function computeRulesGroups(options: Array<{ label: string; value: string }>) {

--- a/src/WingmanDataTrail/MetricsVariables/computeRulesGroups.ts
+++ b/src/WingmanDataTrail/MetricsVariables/computeRulesGroups.ts
@@ -5,8 +5,9 @@ type MetricType = 'metrics' | 'rules';
 /**
  * Checks if a metric name follows Prometheus recording rule naming conventions.
  *
- * @remarks Recording rules follow the pattern: `level:metric:operations` or `level:metric`
- * Where `level`, `metric`, and `operations` can contain underscores and alphanumeric characters.
+ * @remarks Recording rules follow the pattern: `level:metric:operations` or `level:metric`.
+ * The `level` component might be empty. Where `level`, `metric`, and `operations` can contain
+ * underscores and alphanumeric characters.
  */
 export function isRecordingRule(value: string): boolean {
   // Matches patterns like:
@@ -15,7 +16,8 @@ export function isRecordingRule(value: string): boolean {
   // - job:request_failures_per_requests:ratio_rate5m
   // - apiserver_request:availability30d
   // - asserts:container_memory
-  return /^\w+:\w+(?::\w+)?$/.test(value);
+  // - :requests:rate5m
+  return /^\w*:\w+(?::\w+)?$/.test(value);
 }
 
 export function computeRulesGroups(options: Array<{ label: string; value: string }>) {

--- a/src/WingmanDataTrail/MetricsVariables/computeRulesGroups.ts
+++ b/src/WingmanDataTrail/MetricsVariables/computeRulesGroups.ts
@@ -2,6 +2,21 @@ import { ruleGroupLabels } from './metricLabels';
 
 type MetricType = 'metrics' | 'rules';
 
+/**
+ * Type guard that checks if a string follows Prometheus recording rule naming convention
+ * Recording rules follow the pattern: level:metric:operations or level:metric
+ * Where level, metric, and operations can contain underscores and alphanumeric characters
+ */
+export function isRecordingRule(value: string): boolean {
+  // Matches patterns like:
+  // - instance_path:requests:rate5m
+  // - path:requests:rate5m
+  // - job:request_failures_per_requests:ratio_rate5m
+  // - apiserver_request:availability30d
+  // - asserts:container_memory
+  return /^\w+:\w+(?::\w+)?$/.test(value);
+}
+
 export function computeRulesGroups(options: Array<{ label: string; value: string }>) {
   const rulesMap = new Map<MetricType, string[]>([
     ['metrics', []],
@@ -10,7 +25,7 @@ export function computeRulesGroups(options: Array<{ label: string; value: string
 
   for (const option of options) {
     const { value } = option;
-    const key: MetricType = /:/i.test(value) ? 'rules' : 'metrics';
+    const key: MetricType = isRecordingRule(value) ? 'rules' : 'metrics';
 
     const values = rulesMap.get(key) ?? [];
     values.push(value);

--- a/src/autoQuery/behaviors/ExtremeValueFilterBehavior.tsx
+++ b/src/autoQuery/behaviors/ExtremeValueFilterBehavior.tsx
@@ -6,11 +6,11 @@ import { parser } from '@prometheus-io/lezer-promql';
 import React from 'react';
 import { type Unsubscribable } from 'rxjs';
 
-import { processLabelMatcher } from 'extensions/links';
 import { reportExploreMetrics } from 'interactions';
 
 import { VAR_FILTERS_EXPR, VAR_METRIC_EXPR } from '../../shared';
 import { logger } from '../../tracking/logger/logger';
+import { processLabelMatcher } from '../../utils/utils.promql';
 import { buildPrometheusQuery, isNonRateQueryFunction, type NonRateQueryFunction } from '../buildPrometheusQuery';
 
 /**

--- a/src/exposedComponents/LabelBreakdown/LabelBreakdown.tsx
+++ b/src/exposedComponents/LabelBreakdown/LabelBreakdown.tsx
@@ -1,5 +1,4 @@
-import { dateMath, type DataSourceApi } from '@grafana/data';
-import { SceneTimeRange } from '@grafana/scenes';
+import { type DataSourceApi } from '@grafana/data';
 import React, { useEffect, useRef } from 'react';
 
 import { ErrorView } from 'App/ErrorView';
@@ -9,6 +8,7 @@ import { reportExploreMetrics } from 'interactions';
 import { newMetricsTrail } from 'utils';
 
 import { parsePromQLQuery } from '../../extensions/links';
+import { toSceneTimeRange } from '../../utils/utils.timerange';
 
 export interface LabelBreakdownProps {
   query: string;
@@ -17,20 +17,9 @@ export interface LabelBreakdownProps {
   dataSource: DataSourceApi;
 }
 
-function toSceneTime(time: string | number): string {
-  if (typeof time === 'string' && dateMath.isMathString(time)) {
-    // 'now', 'now-1h', etc.
-    return time;
-  }
-
-  return dateMath.toDateTime(new Date(time), { roundUp: false })!.toISOString();
-}
-
 const LabelBreakdown = ({ query, initialStart, initialEnd, dataSource }: LabelBreakdownProps) => {
   const [error] = useCatchExceptions();
   const { metric, labels } = parsePromQLQuery(query);
-  const from = toSceneTime(initialStart);
-  const to = toSceneTime(initialEnd);
   const trail = newMetricsTrail({
     metric,
     initialDS: dataSource.uid,
@@ -39,7 +28,7 @@ const LabelBreakdown = ({ query, initialStart, initialEnd, dataSource }: LabelBr
       operator: op,
       value,
     })),
-    $timeRange: new SceneTimeRange({ from, to }),
+    $timeRange: toSceneTimeRange(initialStart, initialEnd),
     embedded: true,
   });
 

--- a/src/mocks/datasource.ts
+++ b/src/mocks/datasource.ts
@@ -1,42 +1,18 @@
-import { PluginType, type DataSourceApi, type DataSourceInstanceSettings } from '@grafana/data';
+import { type DataSourceApi, type DataSourceInstanceSettings } from '@grafana/data';
 import { type DataSourceSrv } from '@grafana/runtime';
 import { type DataSourceRef } from '@grafana/schema';
 
-export const mockDataSource: DataSourceApi = {
-  name: 'Prometheus',
-  type: 'prometheus',
-  id: 1,
-  uid: 'ds',
-  meta: {
-    id: 'prometheus',
-    name: 'Prometheus',
-    type: PluginType.datasource,
-    info: {
-      version: '',
-      logos: { small: '', large: '' },
-      updated: '',
-      author: { name: '' },
-      description: '',
-      links: [],
-      screenshots: [],
-    },
-    module: '',
-    baseUrl: '',
-  },
-  query: () => Promise.resolve({ data: [] }),
-  testDatasource: () => Promise.resolve({ status: 'success', message: 'Success' }),
-  getRef: () => ({ type: 'prometheus', uid: 'ds' }),
-};
+import { dataSourceStub } from '../stubs/dataSourceStub';
 
 export function createMockDataSource(settings: Partial<DataSourceInstanceSettings> = {}): DataSourceInstanceSettings {
   return {
-    id: settings.id || mockDataSource.id,
-    uid: settings.uid || mockDataSource.uid,
-    type: settings.type || mockDataSource.type,
-    name: settings.name || mockDataSource.name,
+    id: settings.id || dataSourceStub.id,
+    uid: settings.uid || dataSourceStub.uid,
+    type: settings.type || dataSourceStub.type,
+    name: settings.name || dataSourceStub.name,
     access: settings.access || 'proxy',
     readOnly: settings.readOnly || false,
-    meta: settings.meta || mockDataSource.meta,
+    meta: settings.meta || dataSourceStub.meta,
     jsonData: {},
     ...settings,
   };
@@ -54,7 +30,7 @@ class MockDataSource implements DataSourceApi {
     this.type = settings.type || 'prometheus';
     this.id = settings.id || 1;
     this.uid = settings.uid || 'ds';
-    this.meta = settings.meta || mockDataSource.meta;
+    this.meta = settings.meta || dataSourceStub.meta;
   }
 
   query() {
@@ -91,10 +67,10 @@ export class MockDataSourceSrv implements DataSourceSrv {
     if (!ref) {
       return Object.values(this.datasources)[0];
     }
-    
+
     // Handle DataSourceRef objects
     let uid = typeof ref === 'string' ? ref : ref.uid;
-    
+
     // Handle template literals like '${ds}' with scoped variables
     if (typeof uid === 'string' && uid.startsWith('${') && uid.endsWith('}') && scopedVars) {
       if (scopedVars.__sceneObject && scopedVars.__sceneObject.value) {
@@ -102,11 +78,11 @@ export class MockDataSourceSrv implements DataSourceSrv {
         return Object.values(this.datasources)[0];
       }
     }
-    
+
     if (!uid) {
       return Object.values(this.datasources)[0];
     }
-    
+
     const ds = this.datasources[uid];
     if (!ds) {
       throw new Error(`Data source ${uid} not found`);

--- a/src/stubs/dataSourceStub.ts
+++ b/src/stubs/dataSourceStub.ts
@@ -1,0 +1,27 @@
+import { PluginType, type DataSourceApi } from '@grafana/data';
+
+export const dataSourceStub: DataSourceApi = {
+  name: 'Prometheus',
+  type: 'prometheus',
+  id: 1,
+  uid: 'ds',
+  meta: {
+    id: 'prometheus',
+    name: 'Prometheus',
+    type: PluginType.datasource,
+    info: {
+      version: '',
+      logos: { small: '', large: '' },
+      updated: '',
+      author: { name: '' },
+      description: '',
+      links: [],
+      screenshots: [],
+    },
+    module: '',
+    baseUrl: '',
+  },
+  query: () => Promise.resolve({ data: [] }),
+  testDatasource: () => Promise.resolve({ status: 'success', message: 'Success' }),
+  getRef: () => ({ type: 'prometheus', uid: 'ds' }),
+};

--- a/src/types/language-provider/v11-6-x.ts
+++ b/src/types/language-provider/v11-6-x.ts
@@ -8,8 +8,8 @@ import {
 import { type PrometheusDatasource, type PromMetricsMetadata, type PromQuery } from '@grafana/prometheus';
 import { type BackendSrvRequest } from '@grafana/runtime';
 
-import { type PromQLLabelMatcher } from 'extensions/links';
-import { type PrometheusRuntimeDatasource } from 'helpers/MetricDatasourceHelper';
+import { type PrometheusRuntimeDatasource } from '../../helpers/MetricDatasourceHelper';
+import { type PromQLLabelMatcher } from '../../utils/utils.promql';
 
 export interface PromQlLanguageProviderElevenDotSix extends LanguageProvider {
   histogramMetrics: string[];

--- a/src/types/language-provider/v12-0-0.ts
+++ b/src/types/language-provider/v12-0-0.ts
@@ -8,8 +8,8 @@ import {
 import { type PrometheusDatasource, type PromMetricsMetadata, type PromQuery } from '@grafana/prometheus';
 import { type BackendSrvRequest } from '@grafana/runtime';
 
-import { type PromQLLabelMatcher } from 'extensions/links';
-import { type PrometheusRuntimeDatasource } from 'helpers/MetricDatasourceHelper';
+import { type PrometheusRuntimeDatasource } from '../../helpers/MetricDatasourceHelper';
+import { type PromQLLabelMatcher } from '../../utils/utils.promql';
 
 export interface PromQlLanguageProviderTwelveDotZero extends LanguageProvider {
   histogramMetrics: string[];

--- a/src/utils/utils.promql.ts
+++ b/src/utils/utils.promql.ts
@@ -1,5 +1,18 @@
 import { parser } from '@prometheus-io/lezer-promql';
 
+export interface PromQLLabelMatcher {
+  label: string;
+  op: string;
+  value: string;
+}
+
+export interface ParsedPromQLQuery {
+  metric: string;
+  labels: PromQLLabelMatcher[];
+  hasErrors: boolean;
+  errors: string[];
+}
+
 /**
  * Extracts all metric names from a PromQL expression
  * @param {string} promqlExpression - The PromQL expression to parse
@@ -35,4 +48,33 @@ export function extractMetricNames(promqlExpression: string): string[] {
   } while (cursor.next());
 
   return Array.from(metricNames);
+}
+
+// Helper function to process label matcher nodes
+export function processLabelMatcher(node: any, expr: string): PromQLLabelMatcher | null {
+  if (node.name !== 'UnquotedLabelMatcher') {
+    return null;
+  }
+
+  const labelNode = node.node;
+  let labelName = '';
+  let op = '';
+  let value = '';
+
+  // Get children of UnquotedLabelMatcher
+  for (let child = labelNode.firstChild; child; child = child.nextSibling) {
+    if (child.type.name === 'LabelName') {
+      labelName = expr.slice(child.from, child.to);
+    } else if (child.type.name === 'MatchOp') {
+      op = expr.slice(child.from, child.to);
+    } else if (child.type.name === 'StringLiteral') {
+      value = expr.slice(child.from + 1, child.to - 1); // Remove quotes
+    }
+  }
+
+  if (labelName && op) {
+    // Allow empty string values
+    return { label: labelName, op, value };
+  }
+  return null;
 }

--- a/src/utils/utils.timerange.ts
+++ b/src/utils/utils.timerange.ts
@@ -1,9 +1,5 @@
-import {
-  type SceneObject,
-  type SceneObjectState,
-  type SceneTimeRange,
-  type SceneTimeRangeState,
-} from '@grafana/scenes';
+import { dateMath } from '@grafana/data';
+import { SceneTimeRange, type SceneObject, type SceneObjectState, type SceneTimeRangeState } from '@grafana/scenes';
 
 export function isSceneTimeRange(input: SceneObject | null | undefined): input is SceneTimeRange {
   return typeof input !== 'undefined' && input !== null && 'getTimeZone' in input && isSceneTimeRangeState(input.state);
@@ -11,4 +7,57 @@ export function isSceneTimeRange(input: SceneObject | null | undefined): input i
 
 export function isSceneTimeRangeState(input: SceneObjectState | null | undefined): input is SceneTimeRangeState {
   return typeof input !== 'undefined' && input !== null && 'value' in input && 'from' in input && 'to' in input;
+}
+
+type MathStringOrUnixTimestamp = string | number;
+
+/**
+ * Convert a time string or unix timestamp to a SceneTimeRange.
+ *
+ * @param time - The time string or unix timestamp.
+ * @returns The SceneTimeRange.
+ *
+ * @example
+ * ```ts
+ * toSceneTime('now-1h')
+ * ```
+ *
+ * @example
+ * ```ts
+ * toSceneTime(1723756800000)
+ * ```
+ */
+function toSceneTime(time: MathStringOrUnixTimestamp): string {
+  if (typeof time === 'string' && dateMath.isMathString(time)) {
+    // 'now', 'now-1h', etc.
+    return time;
+  }
+
+  return dateMath.toDateTime(new Date(time), { roundUp: false })!.toISOString();
+}
+
+/**
+ * Convert a time string or unix timestamp to a SceneTimeRange.
+ *
+ * @param from - The start time.
+ * @param to - The end time.
+ * @returns The SceneTimeRange.
+ *
+ * @example
+ * ```ts
+ * toSceneTimeRange('now-1h', 'now')
+ * ```
+ *
+ * @example
+ * ```ts
+ * toSceneTimeRange(1723756800000, 1723756800000)
+ * ```
+ *
+ * @example
+ * ```ts
+ * toSceneTimeRange('now-1h', 1723756800000)
+ * ```
+ */
+export function toSceneTimeRange(from: MathStringOrUnixTimestamp, to: MathStringOrUnixTimestamp): SceneTimeRange {
+  return new SceneTimeRange({ from: toSceneTime(from), to: toSceneTime(to) });
 }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** This PR supports #625. It's purely a refactor PR, and it's job is to keep the "real PR" for #625 smaller and more focused.

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

- Our check for whether or not a metric is a recording rule is more robust. It's guided by the Prometheus best practices for rules naming as described in https://prometheus.io/docs/practices/rules/#naming.
- The `processLabelMatcher` utility has been moved to `utils/utils.promql`. In general, I think it'd be nice for `utils/utils.promql` to be the canonical place where the PromQL magic happens.
- Simplified handling of `SceneTimeRange` creation. The new `toSceneTimeRange` util makes it easier to deal with time ranges in our `exposedComponents`.
- The datasource stub is [correctly called a stub](https://stackoverflow.com/a/17810004/6387812), and has moved to a separate file in the new `src/stubs` directory.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

All CI should pass.
