### PR TITLE
chore: capture extension point id for initializing app

### DIFF
--- a/src/App/useReportAppInitialized.ts
+++ b/src/App/useReportAppInitialized.ts
@@ -9,11 +9,13 @@ export function useReportAppInitialized() {
     if (!initRef.current) {
       initRef.current = true;
 
-      const view: ViewName = new URL(window.location.href).searchParams.get('metric')
+      const url = new URL(window.location.href);
+      const view: ViewName = url.searchParams.get('metric')
         ? 'metric-details'
         : 'metrics-reducer';
+      const uel_epid = url.searchParams.get('uel_epid') ?? '';
 
-      reportExploreMetrics('app_initialized', { view });
+      reportExploreMetrics('app_initialized', { view, uel_epid });
     }
   }, []);
 }

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -140,6 +140,7 @@ type Interactions = {
   };
   app_initialized: {
     view: ViewName;
+    uel_epid: string;
   };
   // User took an action to view an exposed component
   exposed_component_viewed: {


### PR DESCRIPTION
### ✨ Description

Capture the uel_epid param which is the extension point id.

This can indicate if the app was opened from our targets in plugin.json and future extension points.

```
          "grafana/dashboard/panel/menu",
          "grafana/explore/toolbar/action",
          "grafana-assistant-app/navigateToDrilldown/v1",
          "grafana/alerting/alertingrule/queryeditor"
```

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

### 🧪 How to test?

The build passes.

Check the `app_initialized` event after this is merged to see the uel_epid captured.
