### PR TITLE
perf(*): Improve Native Histograms detection

### DIFF
--- a/src/DataTrail.tsx
+++ b/src/DataTrail.tsx
@@ -15,7 +15,6 @@ import {
   SceneVariableSet,
   ScopesVariable,
   UrlSyncContextProvider,
-  VariableDependencyConfig,
   VariableValueSelectors,
   type SceneComponentProps,
   type SceneObject,
@@ -30,14 +29,14 @@ import React, { useEffect } from 'react';
 
 import { MetricsDrilldownDataSourceVariable } from 'MetricsDrilldownDataSourceVariable';
 import { PluginInfo } from 'PluginInfo/PluginInfo';
-import { displayWarning } from 'WingmanDataTrail/helpers/displayStatus';
 import { MetricsReducer } from 'WingmanDataTrail/MetricsReducer';
+import { MetricsVariable } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
 
 import { DataTrailSettings } from './DataTrailSettings';
 import { MetricDatasourceHelper } from './helpers/MetricDatasourceHelper';
 import { reportChangeInLabelFilters } from './interactions';
 import { MetricScene } from './MetricScene';
-import { MetricSelectedEvent, trailDS, VAR_DATASOURCE, VAR_FILTERS } from './shared';
+import { MetricSelectedEvent, trailDS, VAR_FILTERS } from './shared';
 import { getTrailStore } from './TrailStore/TrailStore';
 import { limitAdhocProviders } from './utils';
 import { isSceneQueryRunner } from './utils/utils.queries';
@@ -63,9 +62,6 @@ export interface DataTrailState extends SceneObjectState {
   // Synced with url
   metric?: string;
   metricSearch?: string;
-
-  histogramsLoadP: Promise<void> | null;
-  histogramsLoaded: boolean;
   nativeHistogramMetric: string;
 
   trailActivated: boolean; // this indicates that the trail has been updated by metric or filter selected
@@ -73,9 +69,50 @@ export interface DataTrailState extends SceneObjectState {
 }
 
 export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneObjectWithUrlSync {
+  private _addingFilterWithoutReportingInteraction = false;
+  private datasourceHelper = new MetricDatasourceHelper(this);
+
   protected _urlSync = new SceneObjectUrlSyncConfig(this, {
     keys: ['metric', 'metricSearch', 'nativeHistogramMetric'],
   });
+
+  getUrlState(): SceneObjectUrlValues {
+    const { metric, metricSearch, nativeHistogramMetric } = this.state;
+    return {
+      metric,
+      metricSearch,
+      // store the native histogram knowledge in url for the metric scene
+      nativeHistogramMetric,
+    };
+  }
+
+  updateFromUrl(values: SceneObjectUrlValues) {
+    const stateUpdate: Partial<DataTrailState> = {};
+
+    if (typeof values.metric === 'string') {
+      if (this.state.metric !== values.metric) {
+        // if we have a metric and we have stored in the url that it is a native histogram
+        // we can pass that info into the metric scene to generate the appropriate queries
+        let nativeHistogramMetric = false;
+        if (values.nativeHistogramMetric === '1') {
+          nativeHistogramMetric = true;
+        }
+
+        Object.assign(stateUpdate, this.getSceneUpdatesForNewMetricValue(values.metric, nativeHistogramMetric));
+      }
+    } else if (values.metric == null && !this.state.embedded) {
+      stateUpdate.metric = undefined;
+      stateUpdate.topScene = new MetricsReducer();
+    }
+
+    if (typeof values.metricSearch === 'string') {
+      stateUpdate.metricSearch = values.metricSearch;
+    } else if (values.metric == null) {
+      stateUpdate.metricSearch = undefined;
+    }
+
+    this.setState(stateUpdate);
+  }
 
   public constructor(state: Partial<DataTrailState>) {
     super({
@@ -92,17 +129,17 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
       createdAt: state.createdAt ?? new Date().getTime(),
       dashboardMetrics: {},
       alertingMetrics: {},
-      histogramsLoadP: state.histogramsLoadP ?? null,
-      histogramsLoaded: state.histogramsLoaded ?? false,
       nativeHistogramMetric: state.nativeHistogramMetric ?? '',
       trailActivated: state.trailActivated ?? false,
       ...state,
     });
 
-    this.addActivationHandler(this._onActivate.bind(this));
+    this.addActivationHandler(this.onActivate.bind(this));
   }
 
-  public _onActivate() {
+  private onActivate() {
+    this.datasourceHelper.init();
+
     this.setState({ trailActivated: true });
 
     if (!this.state.topScene) {
@@ -157,20 +194,6 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
     };
   }
 
-  protected _variableDependency = new VariableDependencyConfig(this, {
-    variableNames: [VAR_DATASOURCE],
-    onReferencedVariableValueChanged: async (variable: SceneVariable) => {
-      const { name } = variable.state;
-
-      if (name === VAR_DATASOURCE) {
-        this.datasourceHelper.reset();
-
-        // reset native histograms
-        this.resetNativeHistograms();
-      }
-    },
-  });
-
   /**
    * Assuming that the change in filter was already reported with a cause other than `'adhoc_filter'`,
    * this will modify the adhoc filter variable and prevent the automatic reporting which would
@@ -187,57 +210,16 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
     this._addingFilterWithoutReportingInteraction = false;
   }
 
-  private _addingFilterWithoutReportingInteraction = false;
-  private datasourceHelper = new MetricDatasourceHelper(this);
-
   public getMetricMetadata(metric: string) {
     return this.datasourceHelper.getMetadataForMetric(metric);
   }
 
-  public isNativeHistogram(metric: string) {
+  public async isNativeHistogram(metric: string) {
     return this.datasourceHelper.isNativeHistogram(metric);
-  }
-
-  // use this to initialize histograms in all scenes
-  public async initializeHistograms() {
-    if (this.state.histogramsLoadP) {
-      return this.state.histogramsLoadP;
-    }
-
-    if (!this.state.histogramsLoaded) {
-      try {
-        const histogramsLoadP = this.datasourceHelper.initializeHistograms();
-        this.setState({ histogramsLoadP });
-        await histogramsLoadP;
-      } catch (e) {
-        displayWarning(['Error while initializing histograms!', (e as Error).toString()]);
-      }
-
-      this.setState({
-        histogramsLoadP: null,
-        histogramsLoaded: true,
-      });
-    }
-  }
-
-  private resetNativeHistograms() {
-    this.setState({
-      histogramsLoaded: false,
-    });
   }
 
   private async _handleMetricSelectedEvent(evt: MetricSelectedEvent) {
     const metric = evt.payload ?? '';
-
-    // from the metric preview panel we have the info loaded to determine that a metric is a native histogram
-    let nativeHistogramMetric = false;
-    if (this.isNativeHistogram(metric)) {
-      nativeHistogramMetric = true;
-    }
-
-    this._urlSync.performBrowserHistoryAction(() => {
-      this.setState(this.getSceneUpdatesForNewMetricValue(metric, nativeHistogramMetric));
-    });
 
     // Add metric to adhoc filters baseFilter
     const filterVar = sceneGraph.lookupVariable(VAR_FILTERS, this);
@@ -246,6 +228,12 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
         baseFilters: getBaseFiltersForMetric(evt.payload),
       });
     }
+
+    const nativeHistogramMetric = await this.isNativeHistogram(metric);
+
+    this._urlSync.performBrowserHistoryAction(() => {
+      this.setState(this.getSceneUpdatesForNewMetricValue(metric, nativeHistogramMetric));
+    });
   }
 
   private getSceneUpdatesForNewMetricValue(metric: string | undefined, nativeHistogramMetric?: boolean) {
@@ -258,44 +246,6 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
     stateUpdate.topScene = getTopSceneFor(metric, nativeHistogramMetric);
 
     return stateUpdate;
-  }
-
-  getUrlState(): SceneObjectUrlValues {
-    const { metric, metricSearch, nativeHistogramMetric } = this.state;
-    return {
-      metric,
-      metricSearch,
-      // store the native histogram knowledge in url for the metric scene
-      nativeHistogramMetric,
-    };
-  }
-
-  updateFromUrl(values: SceneObjectUrlValues) {
-    const stateUpdate: Partial<DataTrailState> = {};
-
-    if (typeof values.metric === 'string') {
-      if (this.state.metric !== values.metric) {
-        // if we have a metric and we have stored in the url that it is a native histogram
-        // we can pass that info into the metric scene to generate the appropriate queries
-        let nativeHistogramMetric = false;
-        if (values.nativeHistogramMetric === '1') {
-          nativeHistogramMetric = true;
-        }
-
-        Object.assign(stateUpdate, this.getSceneUpdatesForNewMetricValue(values.metric, nativeHistogramMetric));
-      }
-    } else if (values.metric == null && !this.state.embedded) {
-      stateUpdate.metric = undefined;
-      stateUpdate.topScene = new MetricsReducer();
-    }
-
-    if (typeof values.metricSearch === 'string') {
-      stateUpdate.metricSearch = values.metricSearch;
-    } else if (values.metric == null) {
-      stateUpdate.metricSearch = undefined;
-    }
-
-    this.setState(stateUpdate);
   }
 
   public getQueries(): PromQuery[] {
@@ -320,11 +270,6 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
     const chromeHeaderHeight = useChromeHeaderHeight() ?? 0;
     const headerHeight = embedded ? 0 : chromeHeaderHeight;
     const styles = useStyles2(getStyles, headerHeight, model);
-
-    // need to initialize this here and not on activate because it requires the data source helper to be fully initialized first
-    useEffect(() => {
-      model.initializeHistograms();
-    }, [model]);
 
     useEffect(() => {
       const filtersVariable = sceneGraph.lookupVariable(VAR_FILTERS, model);
@@ -393,6 +338,7 @@ export function getTopSceneFor(metric?: string, nativeHistogram = false) {
 function getVariableSet(initialDS?: string, metric?: string, initialFilters?: AdHocVariableFilter[]) {
   let variables: SceneVariable[] = [
     new MetricsDrilldownDataSourceVariable({ initialDS }),
+    new MetricsVariable(),
     new AdHocFiltersVariable({
       key: VAR_FILTERS,
       name: VAR_FILTERS,

--- a/src/GmdVizPanel/GmdVizPanel.tsx
+++ b/src/GmdVizPanel/GmdVizPanel.tsx
@@ -119,31 +119,12 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
     this.subscribeToStateChanges();
     this.subscribeToEvents();
 
-    // isNativeHistogram() depends on an async process to load metrics metadata, so it's possible that
-    // when landing on the page, the metadata is not yet loaded and the histogram metrics are not be rendered as heatmap panels.
-    // But we still want to render them ASAP and update them later when the metadata has arrived.
-    const trail = getTrailFor(this);
-    const isNativeHistogram = trail.isNativeHistogram(metric);
+    const isNativeHistogram = await getTrailFor(this).isNativeHistogram(metric);
 
     this.setState({
       panelType: panelType || this.getDefaultPanelType(isNativeHistogram),
       isNativeHistogram,
     });
-
-    if (isNativeHistogram) {
-      return;
-    }
-
-    // force initialization
-    await trail.initializeHistograms();
-    const newIsNativeHistogram = trail.isNativeHistogram(metric);
-
-    if (newIsNativeHistogram) {
-      this.setState({
-        panelType: this.getDefaultPanelType(newIsNativeHistogram),
-        isNativeHistogram: newIsNativeHistogram,
-      });
-    }
   }
 
   private getDefaultPanelType(isNativeHistogram: boolean): PANEL_TYPE {

--- a/src/RelatedMetricsScene/RelatedMetricsScene.tsx
+++ b/src/RelatedMetricsScene/RelatedMetricsScene.tsx
@@ -21,7 +21,6 @@ import {
   FilteredMetricsVariable,
   VAR_FILTERED_METRICS_VARIABLE,
 } from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
-import { MetricsVariable } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
 import {
   MetricsVariableFilterEngine,
   type MetricFilters,
@@ -42,7 +41,7 @@ export class RelatedMetricsScene extends SceneObjectBase<RelatedMetricsSceneStat
     super({
       metric,
       $variables: new SceneVariableSet({
-        variables: [new MetricsVariable(), new FilteredMetricsVariable()],
+        variables: [new FilteredMetricsVariable()],
       }),
       key: 'RelatedMetricsScene',
       body: new MetricsList({ variableName: VAR_FILTERED_METRICS_VARIABLE }),

--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -41,7 +41,6 @@ import { EventMetricsVariableActivated } from './MetricsVariables/EventMetricsVa
 import { EventMetricsVariableDeactivated } from './MetricsVariables/EventMetricsVariableDeactivated';
 import { EventMetricsVariableLoaded } from './MetricsVariables/EventMetricsVariableLoaded';
 import { FilteredMetricsVariable, VAR_FILTERED_METRICS_VARIABLE } from './MetricsVariables/FilteredMetricsVariable';
-import { MetricsVariable } from './MetricsVariables/MetricsVariable';
 import { MetricsVariableFilterEngine, type MetricFilters } from './MetricsVariables/MetricsVariableFilterEngine';
 import { MetricsVariableSortEngine } from './MetricsVariables/MetricsVariableSortEngine';
 import { ApplyAction } from './MetricVizPanel/actions/ApplyAction';
@@ -73,7 +72,7 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
   public constructor() {
     super({
       $variables: new SceneVariableSet({
-        variables: [new MetricsVariable(), new FilteredMetricsVariable(), new LabelsVariable()],
+        variables: [new FilteredMetricsVariable(), new LabelsVariable()],
       }),
       listControls: new ListControls({}),
       sidebar: new SideBar({}),
@@ -227,8 +226,9 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
     );
   }
 
-  private openDrawer(metricName: string) {
-    const trail = getTrailFor(this);
+  private async openDrawer(metricName: string) {
+    const isNativeHistogram = await getTrailFor(this).isNativeHistogram(metricName);
+
     this.state.drawer.open({
       title: 'Choose a new Prometheus function',
       subTitle: metricName,
@@ -252,7 +252,7 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
               height: METRICS_VIZ_PANEL_HEIGHT_SMALL,
               hideLegend: true,
               highlight: colorIndex === 1,
-              isNativeHistogram: trail.isNativeHistogram(metricName),
+              isNativeHistogram,
               headerActions: [
                 new ApplyAction({
                   metricName,

--- a/src/helpers/MetricDatasourceHelper.ts
+++ b/src/helpers/MetricDatasourceHelper.ts
@@ -85,7 +85,6 @@ export class MetricDatasourceHelper {
     );
 
     this.initializeClassicHistograms(metricsVariable.state.options);
-    await this.ensureMetricsMetadata();
   }
 
   private reset() {

--- a/src/helpers/MetricDatasourceHelper.ts
+++ b/src/helpers/MetricDatasourceHelper.ts
@@ -15,7 +15,7 @@ import { sceneGraph, type DataSourceVariable, type SceneObject, type VariableVal
 import { type Unsubscribable } from 'rxjs';
 
 import { MetricsDrilldownDataSourceVariable } from 'MetricsDrilldownDataSourceVariable';
-import { displayError } from 'WingmanDataTrail/helpers/displayStatus';
+import { displayError, displayWarning } from 'WingmanDataTrail/helpers/displayStatus';
 import { areArraysEqual } from 'WingmanDataTrail/MetricsVariables/helpers/areArraysEqual';
 import { MetricsVariable, VAR_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
 
@@ -144,7 +144,16 @@ export class MetricDatasourceHelper {
     if (!this.metadataFetchP) {
       this.metadataFetchP = this.getMetricsMetadata();
     }
-    await this.metadataFetchP;
+
+    try {
+      await this.metadataFetchP;
+    } catch (error) {
+      displayWarning([
+        'Error while initializing histograms!',
+        (error as Error).toString(),
+        'Native histogram metrics might not be properly displayed.',
+      ]);
+    }
   }
 
   private async getMetricsMetadata(): Promise<void> {

--- a/src/mocks/datasource.ts
+++ b/src/mocks/datasource.ts
@@ -24,6 +24,7 @@ class MockDataSource implements DataSourceApi {
   id: number;
   uid: string;
   meta: any;
+  languageProvider: any;
 
   constructor(settings: Partial<DataSourceApi> = {}) {
     this.name = settings.name || 'Prometheus';
@@ -31,6 +32,12 @@ class MockDataSource implements DataSourceApi {
     this.id = settings.id || 1;
     this.uid = settings.uid || 'ds';
     this.meta = settings.meta || dataSourceStub.meta;
+    this.languageProvider = {
+      queryMetricsMetadata: () => [],
+      queryLabelKeys: () => [],
+      // eslint-disable-next-line no-unused-vars
+      fetchLabelValues: (_: any) => [],
+    };
   }
 
   query() {


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** follow-up of https://github.com/grafana/metrics-drilldown/pull/645

This PR aims at improving how the app determines if a metric is a native histogram or not. It achieves it by removing the extra request made to fetch all the metrics in favour of listening to the `MetricsVariable` changes. 

The strategy works well in the `MetricsReducer` because, anyway, the app needs the options of `MetricsVariable` to be able to render the metrics list.

When the user lands directly on the `MetricScene`, there's some extra loading time as the app now has to wait for `MetricsVariable` to load its options. The "reward" is that, for native histograms,  the main viz will directly render the correct panel type.

### 📖 Summary of the changes

To make things work:
1. `MetricsVariable` has been moved to `DataTrail` so it always loads its options regardless of where the user lands.
2. `MetricDatasourceHelper` has been updated to listen to any data source change and/or any `MetricsVariable` change and to react accordingly by updating its internal data.
3. the `isNativeHistogram` method has been changed to an async method so that its callers can wait for the correct result before rendering panels.
4. `isNativeHistogram`, when called, ensures that all the metrics metadata are fetched. If the fetching is in progress, no extra request is made. When the fetch results are available, it is cached for future calls.

Note: to continue improving the performance of the app, we should find a way to avoid having to fetch _all_ metrics metadata and fetch only the metadata of a single metric. There's an endpoint in Prometheus to do so, do we have a runtime datasource method?

See diff tab for specific comments.

### 🧪 How to test?

- The build should pass
