### PR TITLE
refactor(UserPreferences): Rename to UserStorage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
     '\\.svg$': '<rootDir>/src/mocks/svgMock.js',
     '^.+/logger/logger$': '<rootDir>/src/mocks/loggerMock.ts',
     '^.+/interactions$': '<rootDir>/src/mocks/interactionsMock.ts',
-    '^.+/userPreferences$': '<rootDir>/src/mocks/userPreferences.ts',
+    '^.+/userStorage$': '<rootDir>/src/mocks/userStorage.ts',
   },
   transform: {
     '^.+\\.(t|j)sx?$': [

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { initFaro } from 'tracking/faro/faro';
 import { logger } from 'tracking/logger/logger';
-import { userPreferences } from 'UserPreferences/userPreferences';
+import { userStorage } from 'UserPreferences/userStorage';
 
 import { ErrorView } from './ErrorView';
 import { Onboarding } from './Onboarding';
@@ -22,7 +22,7 @@ initFaro();
 const prometheusDatasources = Object.values(config.datasources).filter(isPrometheusDataSource);
 
 try {
-  userPreferences.migrate();
+  userStorage.migrate();
 } catch (error) {
   logger.error(error as Error, { cause: 'User preferences migration' });
 }

--- a/src/Breakdown/MetricLabelValuesList/SortBySelector.tsx
+++ b/src/Breakdown/MetricLabelValuesList/SortBySelector.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { type SortSeriesByOption } from 'services/sorting';
 
 import { PREF_KEYS } from '../../UserPreferences/pref-keys';
-import { userPreferences } from '../../UserPreferences/userPreferences';
+import { userStorage } from '../../UserPreferences/userStorage';
 
 export interface SortBySelectorState extends SceneObjectState {
   target: 'fields' | 'labels';
@@ -35,7 +35,7 @@ export class SortBySelector extends SceneObjectBase<SortBySelectorState> {
   ];
 
   constructor(state: Pick<SortBySelectorState, 'target'>) {
-    const sortBy = userPreferences.getItem(PREF_KEYS.BREAKDOWN_SORTBY);
+    const sortBy = userStorage.getItem(PREF_KEYS.BREAKDOWN_SORTBY);
 
     super({
       key: 'breakdown-sort-by',
@@ -48,7 +48,7 @@ export class SortBySelector extends SceneObjectBase<SortBySelectorState> {
 
   private onChange = (option: ComboboxOption<SortSeriesByOption>) => {
     this.setState({ value: option });
-    userPreferences.setItem(PREF_KEYS.BREAKDOWN_SORTBY, option.value);
+    userStorage.setItem(PREF_KEYS.BREAKDOWN_SORTBY, option.value);
   };
 
   public static readonly Component = ({ model }: SceneComponentProps<SortBySelector>) => {

--- a/src/GmdVizPanel/components/ConfigurePanelAction.tsx
+++ b/src/GmdVizPanel/components/ConfigurePanelAction.tsx
@@ -5,7 +5,7 @@ import { Button, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { PREF_KEYS } from 'UserPreferences/pref-keys';
-import { userPreferences } from 'UserPreferences/userPreferences';
+import { userStorage } from 'UserPreferences/userStorage';
 
 import { EventConfigurePanel } from './EventConfigurePanel';
 
@@ -23,7 +23,7 @@ export class ConfigurePanelAction extends SceneObjectBase<ConfigurePanelActionSt
     metric: ConfigurePanelActionState['metric'];
     disabled?: ConfigurePanelActionState['disabled'];
   }) {
-    const userPrefs = userPreferences.getItem(PREF_KEYS.METRIC_PREFS) || {};
+    const userPrefs = userStorage.getItem(PREF_KEYS.METRIC_PREFS) || {};
 
     super({
       metric,

--- a/src/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm.tsx
+++ b/src/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm.tsx
@@ -24,7 +24,7 @@ import { getConfigPresetsForMetric } from 'GmdVizPanel/config/presets/getConfigP
 import { type PanelConfigPreset } from 'GmdVizPanel/config/presets/types';
 import { GmdVizPanel } from 'GmdVizPanel/GmdVizPanel';
 import { PREF_KEYS } from 'UserPreferences/pref-keys';
-import { userPreferences } from 'UserPreferences/userPreferences';
+import { userStorage } from 'UserPreferences/userStorage';
 import { getTrailFor } from 'utils';
 import { displayError } from 'WingmanDataTrail/helpers/displayStatus';
 import { GRID_TEMPLATE_COLUMNS } from 'WingmanDataTrail/MetricsList/MetricsList';
@@ -132,7 +132,7 @@ export class ConfigurePanelForm extends SceneObjectBase<ConfigurePanelFormState>
     this._subs.add(
       this.subscribeToEvent(EventApplyPanelConfig, (event) => {
         const { config, restoreDefault } = event.payload;
-        const userPrefs = userPreferences.getItem(PREF_KEYS.METRIC_PREFS) || {};
+        const userPrefs = userStorage.getItem(PREF_KEYS.METRIC_PREFS) || {};
         const userPrefForMetric = userPrefs[metric];
 
         if (restoreDefault && userPrefForMetric) {
@@ -141,7 +141,7 @@ export class ConfigurePanelForm extends SceneObjectBase<ConfigurePanelFormState>
           userPrefs[metric] = { ...userPrefForMetric, config };
         }
 
-        userPreferences.setItem(PREF_KEYS.METRIC_PREFS, userPrefs);
+        userStorage.setItem(PREF_KEYS.METRIC_PREFS, userPrefs);
       })
     );
   }

--- a/src/GmdVizPanel/config/getPreferredConfigForMetric.ts
+++ b/src/GmdVizPanel/config/getPreferredConfigForMetric.ts
@@ -1,7 +1,7 @@
 import { AVAILABLE_PANEL_TYPES } from 'GmdVizPanel/types/available-panel-types';
 import { reportExploreMetrics } from 'interactions';
 import { PREF_KEYS } from 'UserPreferences/pref-keys';
-import { userPreferences } from 'UserPreferences/userPreferences';
+import { userStorage } from 'UserPreferences/userStorage';
 import { displayWarning } from 'WingmanDataTrail/helpers/displayStatus';
 
 import { CONFIG_PRESETS, type PanelConfigPreset } from './presets/types';
@@ -11,7 +11,7 @@ const availableConfigPresetIds = new Set<string>(Object.values(CONFIG_PRESETS));
 const availablePanelTypes = new Set<string>(AVAILABLE_PANEL_TYPES);
 
 export function getPreferredConfigForMetric(metric: string): PanelConfigPreset | undefined {
-  const userPrefs = userPreferences.getItem(PREF_KEYS.METRIC_PREFS) || {};
+  const userPrefs = userStorage.getItem(PREF_KEYS.METRIC_PREFS) || {};
   const metricConfig = userPrefs[metric]?.config;
 
   if (!metricConfig) {
@@ -22,7 +22,7 @@ export function getPreferredConfigForMetric(metric: string): PanelConfigPreset |
     reportExploreMetrics('invalid_metric_config', { metricConfig });
 
     delete userPrefs[metric]?.config;
-    userPreferences.setItem(PREF_KEYS.METRIC_PREFS, userPrefs);
+    userStorage.setItem(PREF_KEYS.METRIC_PREFS, userPrefs);
 
     displayWarning([
       `Invalid configuration found for metric ${metric}!`,

--- a/src/MetricsDrilldownDataSourceVariable.ts
+++ b/src/MetricsDrilldownDataSourceVariable.ts
@@ -6,7 +6,7 @@ import { logger } from 'tracking/logger/logger';
 import { isPrometheusDataSource } from 'utils/utils.datasource';
 
 import { PREF_KEYS } from './UserPreferences/pref-keys';
-import { userPreferences } from './UserPreferences/userPreferences';
+import { userStorage } from './UserPreferences/userStorage';
 
 export class MetricsDrilldownDataSourceVariable extends DataSourceVariable {
   constructor({ initialDS }: { initialDS?: string }) {
@@ -31,7 +31,7 @@ export class MetricsDrilldownDataSourceVariable extends DataSourceVariable {
     this.subscribeToState((newState, prevState) => {
       if (newState.value && newState.value !== prevState.value) {
         // store the new value for future visits
-        userPreferences.setItem(PREF_KEYS.DATASOURCE, newState.value as string);
+        userStorage.setItem(PREF_KEYS.DATASOURCE, newState.value as string);
       }
     });
   }
@@ -40,7 +40,7 @@ export class MetricsDrilldownDataSourceVariable extends DataSourceVariable {
     const prometheusDataSources = Object.values(config.datasources).filter((ds) => isPrometheusDataSource(ds));
 
     const uidFromUrl = new URL(window.location.href).searchParams.get(`var-${VAR_DATASOURCE}`);
-    const uidFromLocalStorage = userPreferences.getItem(PREF_KEYS.DATASOURCE);
+    const uidFromLocalStorage = userStorage.getItem(PREF_KEYS.DATASOURCE);
 
     const currentDataSource =
       prometheusDataSources.find((ds) => ds.uid === uidFromUrl) ||

--- a/src/TrailStore/TrailStore.test.ts
+++ b/src/TrailStore/TrailStore.test.ts
@@ -4,7 +4,7 @@ import { RECENT_TRAILS_KEY, TrailStore, type UrlSerializedTrail } from './TrailS
 import { DataSourceType, MockDataSourceSrv } from '../mocks/datasource';
 import { dataSourceStub } from '../stubs/dataSourceStub';
 import { PREF_KEYS } from '../UserPreferences/pref-keys';
-import { userPreferences } from '../UserPreferences/userPreferences';
+import { userStorage } from '../UserPreferences/userStorage';
 
 const getDataSourceSrvSpy = jest.fn();
 
@@ -106,8 +106,8 @@ describe('TrailStore', () => {
     ];
 
     beforeEach(() => {
-      userPreferences.clear();
-      userPreferences.setItem(RECENT_TRAILS_KEY, [{ urlSerializedTrails }]);
+      userStorage.clear();
+      userStorage.setItem(RECENT_TRAILS_KEY, [{ urlSerializedTrails }]);
       store.load();
     });
 
@@ -122,8 +122,8 @@ describe('TrailStore', () => {
 
   describe('Initialize store with one bookmark trail but no recent trails', () => {
     beforeEach(() => {
-      userPreferences.clear();
-      userPreferences.setItem(PREF_KEYS.BOOKMARKS, [
+      userStorage.clear();
+      userStorage.setItem(PREF_KEYS.BOOKMARKS, [
         {
           urlValues: URL_VALUES_BOOKMARK,
         },
@@ -185,7 +185,7 @@ describe('TrailStore', () => {
       expect(store.bookmarks.length).toBe(0);
 
       jest.advanceTimersByTime(2000);
-      expect(userPreferences.getItem(PREF_KEYS.BOOKMARKS)).toStrictEqual([]);
+      expect(userStorage.getItem(PREF_KEYS.BOOKMARKS)).toStrictEqual([]);
     });
   });
 
@@ -193,8 +193,8 @@ describe('TrailStore', () => {
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
     beforeEach(() => {
-      userPreferences.clear();
-      userPreferences.setItem(PREF_KEYS.BOOKMARKS, [
+      userStorage.clear();
+      userStorage.setItem(PREF_KEYS.BOOKMARKS, [
         {
           history: [
             {
@@ -243,8 +243,8 @@ describe('TrailStore', () => {
 
   describe('Initialize store with one legacy bookmark trail not bookmarked on final step', () => {
     beforeEach(() => {
-      userPreferences.clear();
-      userPreferences.setItem(PREF_KEYS.BOOKMARKS, [
+      userStorage.clear();
+      userStorage.setItem(PREF_KEYS.BOOKMARKS, [
         {
           history: [
             {
@@ -304,8 +304,8 @@ describe('TrailStore', () => {
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
     beforeEach(() => {
-      userPreferences.clear();
-      userPreferences.setItem(RECENT_TRAILS_KEY, [
+      userStorage.clear();
+      userStorage.setItem(RECENT_TRAILS_KEY, [
         {
           urlValues: {
             metric: 'other_metric',
@@ -319,7 +319,7 @@ describe('TrailStore', () => {
           },
         },
       ]);
-      userPreferences.setItem(PREF_KEYS.BOOKMARKS, [
+      userStorage.setItem(PREF_KEYS.BOOKMARKS, [
         {
           urlValues: URL_VALUES_BOOKMARK,
         },
@@ -377,7 +377,7 @@ describe('TrailStore', () => {
       expect(store.bookmarks.length).toBe(0);
 
       jest.advanceTimersByTime(2000);
-      expect(userPreferences.getItem(PREF_KEYS.BOOKMARKS)).toStrictEqual([]);
+      expect(userStorage.getItem(PREF_KEYS.BOOKMARKS)).toStrictEqual([]);
     });
   });
 });

--- a/src/TrailStore/TrailStore.ts
+++ b/src/TrailStore/TrailStore.ts
@@ -5,7 +5,7 @@ import { debounce, isEqual } from 'lodash';
 import { createBookmarkSavedNotification } from './utils';
 import { DataTrail } from '../DataTrail';
 import { PREF_KEYS } from '../UserPreferences/pref-keys';
-import { userPreferences } from '../UserPreferences/userPreferences';
+import { userStorage } from '../UserPreferences/userStorage';
 import { newMetricsTrail } from '../utils';
 
 export const RECENT_TRAILS_KEY = 'grafana.trails.recent';
@@ -47,8 +47,8 @@ export class TrailStore {
       const serializedRecent = this._recent
         .slice(0, MAX_RECENT_TRAILS)
         .map((trail) => this._serializeTrail(trail.resolve()));
-      userPreferences.setItem(RECENT_TRAILS_KEY, serializedRecent);
-      userPreferences.setItem(PREF_KEYS.BOOKMARKS, this._bookmarks);
+      userStorage.setItem(RECENT_TRAILS_KEY, serializedRecent);
+      userStorage.setItem(PREF_KEYS.BOOKMARKS, this._bookmarks);
       this._lastModified = Date.now();
     };
 
@@ -63,7 +63,7 @@ export class TrailStore {
 
   private _loadRecentTrailsFromStorage() {
     const list: Array<SceneObjectRef<DataTrail>> = [];
-    const serializedTrails: SerializedTrail[] = userPreferences.getItem(RECENT_TRAILS_KEY) || [];
+    const serializedTrails: SerializedTrail[] = userStorage.getItem(RECENT_TRAILS_KEY) || [];
     for (const t of serializedTrails) {
       const trail = this._deserializeTrail(t);
       list.push(trail.getRef());
@@ -72,7 +72,7 @@ export class TrailStore {
   }
 
   private _loadBookmarksFromStorage() {
-    const list: Array<DataTrailBookmark | SerializedTrail> = userPreferences.getItem(PREF_KEYS.BOOKMARKS) || [];
+    const list: Array<DataTrailBookmark | SerializedTrail> = userStorage.getItem(PREF_KEYS.BOOKMARKS) || [];
 
     return list.map((item) => {
       if (isSerializedTrail(item)) {

--- a/src/UserPreferences/userStorage.ts
+++ b/src/UserPreferences/userStorage.ts
@@ -3,7 +3,7 @@ import { reportExploreMetrics } from 'interactions';
 import pluginJson from '../plugin.json';
 import { PREF_KEYS } from './pref-keys';
 
-class UserPreferences {
+class UserStorage {
   private service: string;
 
   constructor(service: string) {
@@ -67,4 +67,4 @@ class UserPreferences {
   }
 }
 
-export const userPreferences = new UserPreferences(pluginJson.id);
+export const userStorage = new UserStorage(pluginJson.id);

--- a/src/WingmanDataTrail/ListControls/MetricsSorter/MetricsSorter.test.tsx
+++ b/src/WingmanDataTrail/ListControls/MetricsSorter/MetricsSorter.test.tsx
@@ -1,10 +1,10 @@
 import { addRecentMetric, getRecentMetrics, sortMetricsWithRecentFirst } from './MetricsSorter';
 import { PREF_KEYS } from '../../../UserPreferences/pref-keys';
-import { userPreferences } from '../../../UserPreferences/userPreferences';
+import { userStorage } from '../../../UserPreferences/userStorage';
 
 describe('MetricsSorter', () => {
   beforeEach(() => {
-    userPreferences.clear();
+    userStorage.clear();
   });
 
   describe('sortMetricsWithRecentFirst', () => {
@@ -101,7 +101,7 @@ describe('MetricsSorter', () => {
         { name: 'metric_a', timestamp: now - 1000 },
       ];
 
-      userPreferences.setItem(PREF_KEYS.RECENT_METRICS, recentMetrics);
+      userStorage.setItem(PREF_KEYS.RECENT_METRICS, recentMetrics);
 
       const result = getRecentMetrics();
 
@@ -114,7 +114,7 @@ describe('MetricsSorter', () => {
     it('should add a metric to the recent metrics list', () => {
       addRecentMetric('test_metric');
 
-      const recentMetrics = userPreferences.getItem(PREF_KEYS.RECENT_METRICS) || [];
+      const recentMetrics = userStorage.getItem(PREF_KEYS.RECENT_METRICS) || [];
 
       // Should have added our metric
       expect(recentMetrics.length).toBe(1);

--- a/src/WingmanDataTrail/ListControls/MetricsSorter/MetricsSorter.tsx
+++ b/src/WingmanDataTrail/ListControls/MetricsSorter/MetricsSorter.tsx
@@ -18,7 +18,7 @@ import { type MetricUsageDetails } from './fetchers/fetchDashboardMetrics';
 import { MetricUsageFetcher, type MetricUsageType } from './MetricUsageFetcher';
 import { logger } from '../../../tracking/logger/logger';
 import { PREF_KEYS } from '../../../UserPreferences/pref-keys';
-import { userPreferences } from '../../../UserPreferences/userPreferences';
+import { userStorage } from '../../../UserPreferences/userStorage';
 export type SortingOption = 'default' | 'dashboard-usage' | 'alerting-usage';
 
 const MAX_RECENT_METRICS = 6;
@@ -44,7 +44,7 @@ export function addRecentMetric(metricName: string): void {
 
     // Keep only the most recent metrics
     const updatedMetrics = filteredMetrics.slice(0, MAX_RECENT_METRICS);
-    userPreferences.setItem(PREF_KEYS.RECENT_METRICS, updatedMetrics);
+    userStorage.setItem(PREF_KEYS.RECENT_METRICS, updatedMetrics);
   } catch (error) {
     const errorObject = error instanceof Error ? error : new Error(String(error));
 
@@ -61,7 +61,7 @@ export function addRecentMetric(metricName: string): void {
  */
 export function getRecentMetrics(): RecentMetric[] {
   try {
-    const recentMetrics: RecentMetric[] = userPreferences.getItem(PREF_KEYS.RECENT_METRICS) || [];
+    const recentMetrics: RecentMetric[] = userStorage.getItem(PREF_KEYS.RECENT_METRICS) || [];
     if (!recentMetrics.length) {
       return [];
     }
@@ -74,7 +74,7 @@ export function getRecentMetrics(): RecentMetric[] {
 
     // If any metrics were removed, update storage
     if (validMetrics.length !== recentMetrics.length) {
-      userPreferences.setItem(PREF_KEYS.RECENT_METRICS, validMetrics);
+      userStorage.setItem(PREF_KEYS.RECENT_METRICS, validMetrics);
     }
 
     return validMetrics;

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -151,7 +151,7 @@ type Interactions = {
   };
   // User changes the panel type for a histogram metric (e.g., from heatmap to percentiles)
   histogram_panel_type_changed: { panelType: PanelType };
-  // App migrated some legacy user prefs (see src/UserPreferences/userPreferences.ts)
+  // App migrated some legacy user prefs (see src/UserPreferences/userStorage.ts)
   user_preferences_migrated: {};
   // User opens the "Configure panel"
   configure_panel_opened: { metricType: MetricType };

--- a/src/mocks/userStorage.ts
+++ b/src/mocks/userStorage.ts
@@ -1,6 +1,6 @@
 let localStore: Record<string, string> = {};
 
-export const userPreferences = {
+export const userStorage = {
   getItem: (key: string) => {
     return key in localStore ? JSON.parse(localStore[key]) : null;
   },


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** is a follow-up of https://github.com/grafana/metrics-drilldown/pull/618

The linked PR introduced a `UserPreferences` class, which was incorrectly named.

### 📖 Summary of the changes

Just renaming `UserPreferences` to `UserStorage`.

### 🧪 How to test?

- The build should pass
