### PR TITLE
fix(*): Fix queries for label values containing special chars (like the equal sign)

### DIFF
--- a/src/DataTrail.tsx
+++ b/src/DataTrail.tsx
@@ -433,7 +433,7 @@ function getVariableSet(initialDS?: string, metric?: string, initialFilters?: Ad
           filters
             .filter((filter) => filter.key !== '__name__')
             // eslint-disable-next-line sonarjs/no-nested-template-literals
-            .map((filter) => `${utf8Support(filter.key)}${filter.operator}"${filter.value.replaceAll('=', `\=`)}"`)
+            .map((filter) => `${utf8Support(filter.key)}${filter.operator}"${filter.value}"`)
             .join(',')
         );
       },

--- a/src/GmdVizPanel/__test__/buildQueryExpression.spec.ts
+++ b/src/GmdVizPanel/__test__/buildQueryExpression.spec.ts
@@ -38,9 +38,9 @@ describe('buildQueryExpression(options)', () => {
             "value": "__REMOVE__",
           },
         ],
-        "\${filters}" => [
+        "\${filters:raw}" => [
           {
-            "label": "\${filters}",
+            "label": "\${filters:raw}",
             "operator": "=",
             "value": "__REMOVE__",
           },

--- a/src/GmdVizPanel/buildQueryExpression.ts
+++ b/src/GmdVizPanel/buildQueryExpression.ts
@@ -1,7 +1,7 @@
 import { isValidLegacyName, utf8Support } from '@grafana/prometheus';
 import { Expression, MatchingOperator } from 'tsqtsq';
 
-import { VAR_FILTERS_EXPR } from 'shared';
+import { VAR_FILTERS } from 'shared';
 
 export type LabelMatcher = {
   key: string;
@@ -42,7 +42,8 @@ export function buildQueryExpression(options: Options): Expression {
 
   // hack for Scenes to interpolate the VAR_FILTERS variable
   // added last so that, if filters are empty, the query is still valid
-  defaultSelectors.push({ label: VAR_FILTERS_EXPR, operator: MatchingOperator.equal, value: '__REMOVE__' });
+  // and we're using :raw for variables containing special characters (like equal signs etc.)
+  defaultSelectors.push({ label: `\${${VAR_FILTERS}:raw}`, operator: MatchingOperator.equal, value: '__REMOVE__' });
 
   return new Expression({
     metric,

--- a/src/GmdVizPanel/types/heatmap/__test__/getHeatmapQueryRunnerParams.spec.ts
+++ b/src/GmdVizPanel/types/heatmap/__test__/getHeatmapQueryRunnerParams.spec.ts
@@ -18,7 +18,7 @@ describe('getHeatmapQueryRunnerParams(options)', () => {
     expect(result.queries).toStrictEqual([
       {
         refId: 'grafana_database_all_migrations_duration_seconds-heatmap',
-        expr: 'sum(rate(grafana_database_all_migrations_duration_seconds{success="true", __ignore_usage__="", ${filters}}[$__rate_interval]))',
+        expr: 'sum(rate(grafana_database_all_migrations_duration_seconds{success="true", __ignore_usage__="", ${filters:raw}}[$__rate_interval]))',
         format: 'heatmap',
         fromExploreMetrics: true,
       },
@@ -40,7 +40,7 @@ describe('getHeatmapQueryRunnerParams(options)', () => {
     expect(result.queries).toStrictEqual([
       {
         refId: 'go_gc_heap_allocs_by_size_bytes_bucket-heatmap',
-        expr: 'sum by (le) (rate(go_gc_heap_allocs_by_size_bytes_bucket{success="true", __ignore_usage__="", ${filters}}[$__rate_interval]))',
+        expr: 'sum by (le) (rate(go_gc_heap_allocs_by_size_bytes_bucket{success="true", __ignore_usage__="", ${filters:raw}}[$__rate_interval]))',
         format: 'heatmap',
         fromExploreMetrics: true,
       },

--- a/src/GmdVizPanel/types/percentiles/__test__/getPercentilesQueryRunnerParams.spec.ts
+++ b/src/GmdVizPanel/types/percentiles/__test__/getPercentilesQueryRunnerParams.spec.ts
@@ -20,13 +20,13 @@ describe('getPercentilesQueryRunnerParams(options)', () => {
     expect(result.queries).toStrictEqual([
       {
         refId: 'go_goroutines-p99-quantile',
-        expr: 'quantile(0.99, go_goroutines{instance="us-east:5000", __ignore_usage__="", ${filters}})',
+        expr: 'quantile(0.99, go_goroutines{instance="us-east:5000", __ignore_usage__="", ${filters:raw}})',
         legendFormat: '99th Percentile',
         fromExploreMetrics: true,
       },
       {
         refId: 'go_goroutines-p90-quantile',
-        expr: 'quantile(0.9, go_goroutines{instance="us-east:5000", __ignore_usage__="", ${filters}})',
+        expr: 'quantile(0.9, go_goroutines{instance="us-east:5000", __ignore_usage__="", ${filters:raw}})',
         legendFormat: '90th Percentile',
         fromExploreMetrics: true,
       },
@@ -50,13 +50,13 @@ describe('getPercentilesQueryRunnerParams(options)', () => {
     expect(result.queries).toStrictEqual([
       {
         refId: 'go_gc_heap_frees_bytes_total-p99-quantile(rate)',
-        expr: 'quantile(0.99, rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters}}[$__rate_interval]))',
+        expr: 'quantile(0.99, rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters:raw}}[$__rate_interval]))',
         legendFormat: '99th Percentile',
         fromExploreMetrics: true,
       },
       {
         refId: 'go_gc_heap_frees_bytes_total-p50-quantile(rate)',
-        expr: 'quantile(0.5, rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters}}[$__rate_interval]))',
+        expr: 'quantile(0.5, rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters:raw}}[$__rate_interval]))',
         legendFormat: '50th Percentile',
         fromExploreMetrics: true,
       },
@@ -80,7 +80,7 @@ describe('getPercentilesQueryRunnerParams(options)', () => {
     expect(result.queries).toStrictEqual([
       {
         refId: 'grafana_database_all_migrations_duration_seconds-p50-histogram_quantile',
-        expr: 'histogram_quantile(0.5,sum(rate(grafana_database_all_migrations_duration_seconds{success="true", __ignore_usage__="", ${filters}}[$__rate_interval])))',
+        expr: 'histogram_quantile(0.5,sum(rate(grafana_database_all_migrations_duration_seconds{success="true", __ignore_usage__="", ${filters:raw}}[$__rate_interval])))',
         legendFormat: '50th Percentile',
         fromExploreMetrics: true,
       },
@@ -104,7 +104,7 @@ describe('getPercentilesQueryRunnerParams(options)', () => {
     expect(result.queries).toStrictEqual([
       {
         refId: 'go_gc_heap_allocs_by_size_bytes_bucket-p75-histogram_quantile',
-        expr: 'histogram_quantile(0.75,sum by (le) (rate(go_gc_heap_allocs_by_size_bytes_bucket{success="true", __ignore_usage__="", ${filters}}[$__rate_interval])))',
+        expr: 'histogram_quantile(0.75,sum by (le) (rate(go_gc_heap_allocs_by_size_bytes_bucket{success="true", __ignore_usage__="", ${filters:raw}}[$__rate_interval])))',
         legendFormat: '75th Percentile',
         fromExploreMetrics: true,
       },

--- a/src/GmdVizPanel/types/stat/__test__/getStatQueryRunnerParams.spec.ts
+++ b/src/GmdVizPanel/types/stat/__test__/getStatQueryRunnerParams.spec.ts
@@ -19,7 +19,7 @@ describe('getStatQueryRunnerParams(options)', () => {
     expect(result.queries).toStrictEqual([
       {
         refId: 'go_goroutines-avg',
-        expr: 'avg(go_goroutines{instance="us-east:5000", __ignore_usage__="", ${filters}})',
+        expr: 'avg(go_goroutines{instance="us-east:5000", __ignore_usage__="", ${filters:raw}})',
         legendFormat: 'avg',
         fromExploreMetrics: true,
       },
@@ -42,7 +42,7 @@ describe('getStatQueryRunnerParams(options)', () => {
     expect(result.queries).toStrictEqual([
       {
         refId: 'go_gc_heap_frees_bytes_total-sum(rate)',
-        expr: 'sum(rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters}}[$__rate_interval]))',
+        expr: 'sum(rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters:raw}}[$__rate_interval]))',
         legendFormat: 'sum(rate)',
         fromExploreMetrics: true,
       },

--- a/src/GmdVizPanel/types/statushistory/__test__/getStatushistoryQueryRunnerParams.spec.ts
+++ b/src/GmdVizPanel/types/statushistory/__test__/getStatushistoryQueryRunnerParams.spec.ts
@@ -17,7 +17,7 @@ test('getStatushistoryQueryRunnerParams(options)', () => {
   expect(result.queries).toStrictEqual([
     {
       refId: 'memcached_up-status',
-      expr: 'min(memcached_up{cluster="prod", __ignore_usage__="", ${filters}})',
+      expr: 'min(memcached_up{cluster="prod", __ignore_usage__="", ${filters:raw}})',
       legendFormat: 'status',
       fromExploreMetrics: true,
     },

--- a/src/GmdVizPanel/types/timeseries/__test__/getTimeseriesQueryRunnerParams.spec.ts
+++ b/src/GmdVizPanel/types/timeseries/__test__/getTimeseriesQueryRunnerParams.spec.ts
@@ -19,7 +19,7 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
       expect(result.queries).toStrictEqual([
         {
           refId: 'go_goroutines-avg',
-          expr: 'avg(go_goroutines{instance="us-east:5000", __ignore_usage__="", ${filters}})',
+          expr: 'avg(go_goroutines{instance="us-east:5000", __ignore_usage__="", ${filters:raw}})',
           legendFormat: 'avg',
           fromExploreMetrics: true,
         },
@@ -41,7 +41,7 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
       expect(result.queries).toStrictEqual([
         {
           refId: 'go_gc_heap_frees_bytes_total-sum(rate)',
-          expr: 'sum(rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters}}[$__rate_interval]))',
+          expr: 'sum(rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters:raw}}[$__rate_interval]))',
           legendFormat: 'sum(rate)',
           fromExploreMetrics: true,
         },
@@ -66,7 +66,7 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
       expect(result.queries).toStrictEqual([
         {
           refId: 'go_goroutines-by-job',
-          expr: 'avg by (job) (go_goroutines{instance="us-east:5000", __ignore_usage__="", ${filters}})',
+          expr: 'avg by (job) (go_goroutines{instance="us-east:5000", __ignore_usage__="", ${filters:raw}})',
           legendFormat: '{{job}}',
           fromExploreMetrics: true,
         },
@@ -89,7 +89,7 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
       expect(result.queries).toStrictEqual([
         {
           refId: 'go_gc_heap_frees_bytes_total-by-instance',
-          expr: 'sum by (instance) (rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters}}[$__rate_interval]))',
+          expr: 'sum by (instance) (rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters:raw}}[$__rate_interval]))',
           legendFormat: '{{instance}}',
           fromExploreMetrics: true,
         },


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** follow-up of https://github.com/grafana/metrics-drilldown/pull/623

The linked PR was a quick hack to prevent incorrect queries to be made when some label values contained the equal sign.

This PR solves completely the problem.

### 📖 Summary of the changes

We use the [`:raw` variable formatter](https://grafana.com/docs/grafana/latest/dashboards/variables/variable-syntax/#raw) and let Scenes interpolate and escape the value for us.

### 🧪 How to test?

- The build should pass
