### PR TITLE
fix(*): Prevent flickering

### DIFF
--- a/src/MetricGraphScene.tsx
+++ b/src/MetricGraphScene.tsx
@@ -52,6 +52,10 @@ export class MetricGraphScene extends SceneObjectBase<MetricGraphSceneState> {
             maxHeight: MAIN_PANEL_MAX_HEIGHT,
             body: new SceneReactObject({ reactNode: <div /> }),
           }),
+          new SceneFlexItem({
+            ySizing: 'content',
+            body: new MetricActionBar({}),
+          }),
         ],
       }),
       selectedTab: undefined,

--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -46,7 +46,7 @@ import { SideBar } from './SideBar/SideBar';
 interface MetricsReducerState extends SceneObjectState {
   listControls: ListControls;
   sidebar: SideBar;
-  body: SceneObjectBase;
+  body?: SceneObjectBase;
   enginesMap: Map<string, { filterEngine: MetricsVariableFilterEngine; sortEngine: MetricsVariableSortEngine }>;
 }
 
@@ -65,7 +65,7 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
       }),
       listControls: new ListControls({}),
       sidebar: new SideBar({}),
-      body: new MetricsList({ variableName: VAR_FILTERED_METRICS_VARIABLE }) as unknown as SceneObjectBase,
+      body: undefined,
       enginesMap: new Map(),
     });
 
@@ -87,6 +87,13 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
     const hasGroupByValue = Boolean(groupByValue && groupByValue !== NULL_GROUP_BY_VALUE);
 
     sceneGraph.findByKeyAndType(this, 'quick-search', QuickSearch).toggleCountsDisplay(!hasGroupByValue);
+
+    if (
+      (hasGroupByValue && this.state.body instanceof MetricsGroupByList) ||
+      (!hasGroupByValue && this.state.body instanceof MetricsList)
+    ) {
+      return;
+    }
 
     this.setState({
       body: hasGroupByValue
@@ -217,9 +224,7 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
           <div className={styles.sidebar} data-testid="sidebar">
             <sidebar.Component model={sidebar} />
           </div>
-          <div className={styles.list}>
-            <body.Component model={body} />
-          </div>
+          <div className={styles.list}>{body && <body.Component model={body} />}</div>
         </div>
         <div className={styles.variables}>
           {$variables?.state.variables.map((variable) => (


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR to prevent flicker in the `MetricsReducer` (the list was rendered twice in a row) and the `MetricScene` (the action bar was missing when landing on the page and it would then appear):

| Before | After |
|  ---   |  ---  |
|  https://github.com/user-attachments/assets/abe7d574-70dd-42cf-93a8-4687bd551b09 | https://github.com/user-attachments/assets/c7f61298-aa50-48ff-8f25-2bcbac429092 |

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

`-`
