### PR TITLE
chore: experiment setup for sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bsull/augurs": "^0.9.0",
         "@emotion/css": "11.13.5",
         "@grafana/data": "^12.1.0",
-        "@grafana/faro-web-sdk": "^1.17.2",
+        "@grafana/faro-web-sdk": "^2.0.0-beta-2",
         "@grafana/i18n": "^12.1.0-249189",
         "@grafana/lezer-logql": "^0.2.7",
         "@grafana/prometheus": "^12.1.0",
@@ -1586,24 +1586,24 @@
       }
     },
     "node_modules/@grafana/faro-core": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.19.0.tgz",
-      "integrity": "sha512-Juo5G/aviSh3XqSGGr6D61noAC8sb+oCawBsv545ILEeOQdINyzRaoQdRpnXEY3DLS9LYtL0PYhvHZiP3rlscQ==",
+      "version": "2.0.0-beta-2",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-2.0.0-beta-2.tgz",
+      "integrity": "sha512-Ps37NkWMdN99S+NszzmPzUUUieRjAmJO0+K4G6lFGA+QLmNaQiVLNQkekvPtO/d3YtKcE/FofC+gFqKlaaeSaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/otlp-transformer": "^0.202.0"
+        "@opentelemetry/otlp-transformer": "^0.203.0"
       }
     },
     "node_modules/@grafana/faro-web-sdk": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.19.0.tgz",
-      "integrity": "sha512-3u74mV2uBWqoF6WBx71p0vtkaS1Z0QbGoZ8tuX5yiYnIybqnhKdGkApFUi7q5se0tMPIeJdMVoRFdLU8f9hfAw==",
+      "version": "2.0.0-beta-2",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-2.0.0-beta-2.tgz",
+      "integrity": "sha512-ZXf3bxljv2mDbqM31MnPi6U0W/zRCwfQGn18/NAxZ10LOyDbFVGMsVuxyRrYW6drxJj68COHol2qA7kDf5J/Ug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/faro-core": "^1.19.0",
+        "@grafana/faro-core": "^2.0.0-beta-2",
         "ua-parser-js": "^1.0.32",
-        "web-vitals": "^4.0.1"
+        "web-vitals": "^5.0.3"
       }
     },
     "node_modules/@grafana/i18n": {
@@ -1820,6 +1820,83 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@grafana/runtime/node_modules/@grafana/faro-core": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.19.0.tgz",
+      "integrity": "sha512-Juo5G/aviSh3XqSGGr6D61noAC8sb+oCawBsv545ILEeOQdINyzRaoQdRpnXEY3DLS9LYtL0PYhvHZiP3rlscQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/otlp-transformer": "^0.202.0"
+      }
+    },
+    "node_modules/@grafana/runtime/node_modules/@grafana/faro-web-sdk": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.19.0.tgz",
+      "integrity": "sha512-3u74mV2uBWqoF6WBx71p0vtkaS1Z0QbGoZ8tuX5yiYnIybqnhKdGkApFUi7q5se0tMPIeJdMVoRFdLU8f9hfAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grafana/faro-core": "^1.19.0",
+        "ua-parser-js": "^1.0.32",
+        "web-vitals": "^4.0.1"
+      }
+    },
+    "node_modules/@grafana/runtime/node_modules/@opentelemetry/api-logs": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.202.0.tgz",
+      "integrity": "sha512-fTBjMqKCfotFWfLzaKyhjLvyEyq5vDKTTFfBmx21btv3gvy8Lq6N5Dh2OzqeuN4DjtpSvNT1uNVfg08eD2Rfxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@grafana/runtime/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.202.0.tgz",
+      "integrity": "sha512-5XO77QFzs9WkexvJQL9ksxL8oVFb/dfi9NWQSq7Sv0Efr9x3N+nb1iklP1TeVgxqJ7m1xWiC/Uv3wupiQGevMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.202.0",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-logs": "0.202.0",
+        "@opentelemetry/sdk-metrics": "2.0.1",
+        "@opentelemetry/sdk-trace-base": "2.0.1",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@grafana/runtime/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.202.0.tgz",
+      "integrity": "sha512-pv8QiQLQzk4X909YKm0lnW4hpuQg4zHwJ4XBd5bZiXcd9urvrJNoNVKnxGHPiDVX/GiLFvr5DMYsDBQbZCypRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.202.0",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@grafana/runtime/node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@grafana/scenes": {
       "version": "6.27.2",
       "resolved": "https://registry.npmjs.org/@grafana/scenes/-/scenes-6.27.2.tgz",
@@ -2006,6 +2083,77 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@grafana/ui/node_modules/@grafana/faro-core": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.19.0.tgz",
+      "integrity": "sha512-Juo5G/aviSh3XqSGGr6D61noAC8sb+oCawBsv545ILEeOQdINyzRaoQdRpnXEY3DLS9LYtL0PYhvHZiP3rlscQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/otlp-transformer": "^0.202.0"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@grafana/faro-web-sdk": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.19.0.tgz",
+      "integrity": "sha512-3u74mV2uBWqoF6WBx71p0vtkaS1Z0QbGoZ8tuX5yiYnIybqnhKdGkApFUi7q5se0tMPIeJdMVoRFdLU8f9hfAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grafana/faro-core": "^1.19.0",
+        "ua-parser-js": "^1.0.32",
+        "web-vitals": "^4.0.1"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@opentelemetry/api-logs": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.202.0.tgz",
+      "integrity": "sha512-fTBjMqKCfotFWfLzaKyhjLvyEyq5vDKTTFfBmx21btv3gvy8Lq6N5Dh2OzqeuN4DjtpSvNT1uNVfg08eD2Rfxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.202.0.tgz",
+      "integrity": "sha512-5XO77QFzs9WkexvJQL9ksxL8oVFb/dfi9NWQSq7Sv0Efr9x3N+nb1iklP1TeVgxqJ7m1xWiC/Uv3wupiQGevMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.202.0",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-logs": "0.202.0",
+        "@opentelemetry/sdk-metrics": "2.0.1",
+        "@opentelemetry/sdk-trace-base": "2.0.1",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.202.0.tgz",
+      "integrity": "sha512-pv8QiQLQzk4X909YKm0lnW4hpuQg4zHwJ4XBd5bZiXcd9urvrJNoNVKnxGHPiDVX/GiLFvr5DMYsDBQbZCypRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.202.0",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
     "node_modules/@grafana/ui/node_modules/@wojtekmaj/date-utils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-2.0.2.tgz",
@@ -2169,6 +2317,12 @@
       "peerDependencies": {
         "react": ">=16.8"
       }
+    },
+    "node_modules/@grafana/ui/node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@gulpjs/to-absolute-glob": {
       "version": "4.0.0",
@@ -3398,9 +3552,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.202.0.tgz",
-      "integrity": "sha512-fTBjMqKCfotFWfLzaKyhjLvyEyq5vDKTTFfBmx21btv3gvy8Lq6N5Dh2OzqeuN4DjtpSvNT1uNVfg08eD2Rfxw==",
+      "version": "0.203.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.203.0.tgz",
+      "integrity": "sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -3425,15 +3579,15 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.202.0.tgz",
-      "integrity": "sha512-5XO77QFzs9WkexvJQL9ksxL8oVFb/dfi9NWQSq7Sv0Efr9x3N+nb1iklP1TeVgxqJ7m1xWiC/Uv3wupiQGevMw==",
+      "version": "0.203.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.203.0.tgz",
+      "integrity": "sha512-Y8I6GgoCna0qDQ2W6GCRtaF24SnvqvA8OfeTi7fqigD23u8Jpb4R5KFv/pRvrlGagcCLICMIyh9wiejp4TXu/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.202.0",
+        "@opentelemetry/api-logs": "0.203.0",
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1",
-        "@opentelemetry/sdk-logs": "0.202.0",
+        "@opentelemetry/sdk-logs": "0.203.0",
         "@opentelemetry/sdk-metrics": "2.0.1",
         "@opentelemetry/sdk-trace-base": "2.0.1",
         "protobufjs": "^7.3.0"
@@ -3462,12 +3616,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.202.0.tgz",
-      "integrity": "sha512-pv8QiQLQzk4X909YKm0lnW4hpuQg4zHwJ4XBd5bZiXcd9urvrJNoNVKnxGHPiDVX/GiLFvr5DMYsDBQbZCypRQ==",
+      "version": "0.203.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.203.0.tgz",
+      "integrity": "sha512-vM2+rPq0Vi3nYA5akQD2f3QwossDnTDLvKbea6u/A2NZ3XDkPxMfo/PNrDoXhDUD/0pPo2CdH5ce/thn9K0kLw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.202.0",
+        "@opentelemetry/api-logs": "0.203.0",
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1"
       },
@@ -15968,9 +16122,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -19815,9 +19969,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
       "license": "Apache-2.0"
     },
     "node_modules/web-worker": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@bsull/augurs": "^0.9.0",
     "@emotion/css": "11.13.5",
     "@grafana/data": "^12.1.0",
-    "@grafana/faro-web-sdk": "^1.17.2",
+    "@grafana/faro-web-sdk": "^2.0.0-beta-2",
     "@grafana/i18n": "^12.1.0-249189",
     "@grafana/lezer-logql": "^0.2.7",
     "@grafana/prometheus": "^12.1.0",

--- a/src/WingmanDataTrail/SideBar/SideBar.tsx
+++ b/src/WingmanDataTrail/SideBar/SideBar.tsx
@@ -27,6 +27,7 @@ import { LabelsBrowser } from './sections/LabelsBrowser/LabelsBrowser';
 import { MetricsFilterSection } from './sections/MetricsFilterSection/MetricsFilterSection';
 import { Settings } from './sections/Settings';
 import { SideBarButton } from './SideBarButton';
+import { HGFeatureToggles, isFeatureToggleEnabled } from '../../utils/utils.feature-toggles';
 
 type Section = MetricsFilterSection | LabelsBrowser | BookmarksList | Settings;
 
@@ -121,6 +122,11 @@ export class SideBar extends SceneObjectBase<SideBarState> {
         this.setState({ sectionValues: newSectionValues });
       })
     );
+
+    // Open the sidebar to the prefix filters section if the "Default Open Sidebar" experiment is enabled
+    if (!this.state.visibleSection?.state.key && isFeatureToggleEnabled(HGFeatureToggles.sidebarOpenByDefault)) {
+      this.setActiveSection('filters-prefix');
+    }
 
     return () => {
       cleanupOtherMetricsVar();

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -12,6 +12,8 @@ import { type LayoutType } from 'WingmanDataTrail/ListControls/LayoutSwitcher';
 import { type SortingOption as MetricsReducerSortByOption } from 'WingmanDataTrail/ListControls/MetricsSorter/MetricsSorter';
 
 import { PLUGIN_ID } from './constants';
+import { getFaro } from './tracking/faro/faro';
+import { HGFeatureToggles, isFeatureToggleEnabled } from './utils/utils.feature-toggles';
 import { GIT_COMMIT } from './version';
 
 export type ViewName = 'metrics-reducer' | 'metric-details';
@@ -184,6 +186,15 @@ export function reportExploreMetrics<E extends keyof AllEvents, P extends AllEve
       appVersion: GIT_COMMIT,
     },
   });
+
+  // Extra event tracking with Faro for "Default Open Sidebar" experiment
+  if (event.includes('sidebar')) {
+    getFaro()?.api.pushEvent(event, {
+      // Convert all payload values to strings
+      ...Object.fromEntries(Object.entries(payload).map(([key, value]) => [key, String(value)])),
+      defaultOpenSidebar: String(isFeatureToggleEnabled(HGFeatureToggles.sidebarOpenByDefault)),
+    });
+  }
 }
 
 /**

--- a/src/utils/utils.feature-toggles.ts
+++ b/src/utils/utils.feature-toggles.ts
@@ -1,0 +1,21 @@
+import { type FeatureToggles } from '@grafana/data';
+import { config } from '@grafana/runtime';
+
+/**
+ * Feature toggles defined in Hosted Grafana (not OSS).
+ * @remarks See https://github.com/grafana/hosted-grafana/wiki/All-Things-Feature-Toggles#grafana-plugins for details.
+ */
+export const HGFeatureToggles = {
+  // Add new feature toggles here
+  sidebarOpenByDefault: 'metricsDrilldownDefaultOpenSidebar',
+} as const;
+
+type HGFeatureToggleName = (typeof HGFeatureToggles)[keyof typeof HGFeatureToggles];
+
+type OssAndHGFeatureToggles = FeatureToggles & {
+  [key in HGFeatureToggleName]: boolean;
+};
+
+export function isFeatureToggleEnabled(featureToggle: HGFeatureToggleName): boolean {
+  return (config.featureToggles as OssAndHGFeatureToggles)[featureToggle] ?? false;
+}


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** Supports #663.

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

This PR sets up a little experiment, with the intention of making the results measurable. In this experiment, we're testing to see if opening the sidebar to the Prefix Filters by default (instead of defaulting to the sidebar being closed) changes user engagement with sidebar features.

To measure this, we are sending any sidebar-related events to Faro as [custom events](https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/instrument/custom-signals/events). We continue reporting these same events with `reportExploreMetrics`, but also send them to Faro to support the goals of #663.

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

- Default to opening the sidebar to the Prefix Filters tab when the (forthcoming) `metricsDrilldownDefaultOpenSidebar` feature toggle evaluates to true.
- Upgrades Faro to the latest major (still in beta) version. See [announcement](https://raintank-corp.slack.com/archives/CKF4X4H1D/p1755847859778749) for details. It doesn't appear that we use any of the [deprecated configs or features](https://raintank-corp.slack.com/archives/C01T8C5CNTE/p1755803366547429) from the previous major version, so we should be fine to use it without hassle.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

I tested this by uncommenting the `local` config in `src/tracking/faro/faro-environments.ts` and changing the `isFeatureToggleEnabled` function in `src/utils/utils.feature-toggles.ts` to just `return true`.

With that, I was able to see the custom event collected by Faro, [via Logs Drilldown](https://ops.grafana-ops.net/a/grafana-lokiexplore-app/explore/app_id/50/field/event_data_defaultOpenSidebar?var-ds=grafanacloud-logs&from=now-15m&to=now&var-filters=app_id%7C%3D%7C__CV%CE%A9__50,50&var-fields=k6_isK6Browser%7C%21%3D%7C__CV%CE%A9__%7B%22value%22:%22true%22__gfc__%22parser%22:%22logfmt%22%7D,true&var-fields=kind%7C%3D%7C__CV%CE%A9__%7B%22value%22:%22event%22__gfc__%22parser%22:%22logfmt%22%7D,event&patterns=%5B%5D&var-lineFormat=&var-levels=&var-metadata=&var-jsonFields=&var-patterns=&var-lineFilterV2=&var-lineFilters=&displayedFields=%5B%5D&urlColumns=%5B%22timestamp%22,%22body%22,%22Time%22,%22Line%22%5D&visualizationType=%22table%22&var-fieldBy=event_data_defaultOpenSidebar&timezone=utc&var-all-fields=k6_isK6Browser%7C%21%3D%7C__CV%CE%A9__%7B%22value%22:%22true%22__gfc__%22parser%22:%22logfmt%22%7D,true&var-all-fields=kind%7C%3D%7C__CV%CE%A9__%7B%22value%22:%22event%22__gfc__%22parser%22:%22logfmt%22%7D,event&drillDownLabel=event_data_defaultOpenSidebar):

<img width="1482" height="882" alt="demo event_data_defaultOpenSidebar logs drilldown" src="https://github.com/user-attachments/assets/656286ef-7572-423c-b202-862f6ddd94b5" />

I was also seeing signals come through as expected in Frontend O11y ([`grafana-metricsdrilldown-app-local`](https://ops.grafana-ops.net/a/grafana-kowalski-app/apps/50/overview?from=1756515022151&to=1756515922151&var-Filters=&var-lab_filter=0)).