### PR TITLE
refactor(*): Cleanup unused variables + related refactorings

### DIFF
--- a/src/Breakdown/MetricLabelValuesList/AddToFiltersGraphAction.tsx
+++ b/src/Breakdown/MetricLabelValuesList/AddToFiltersGraphAction.tsx
@@ -1,11 +1,9 @@
-import { sceneGraph, SceneObjectBase, type SceneComponentProps, type SceneObjectState } from '@grafana/scenes';
+import { SceneObjectBase, type SceneComponentProps, type SceneObjectState } from '@grafana/scenes';
 import { Button } from '@grafana/ui';
 import React from 'react';
 
 import { reportExploreMetrics } from 'interactions';
-import { VAR_FILTERS } from 'shared';
 import { getTrailFor } from 'utils';
-import { isAdHocFiltersVariable } from 'utils/utils.variables';
 
 interface AddToFiltersGraphActionState extends SceneObjectState {
   labelName: string;
@@ -14,11 +12,6 @@ interface AddToFiltersGraphActionState extends SceneObjectState {
 
 export class AddToFiltersGraphAction extends SceneObjectBase<AddToFiltersGraphActionState> {
   public onClick = () => {
-    const variable = sceneGraph.lookupVariable(VAR_FILTERS, this);
-    if (!isAdHocFiltersVariable(variable)) {
-      return;
-    }
-
     const { labelName, labelValue } = this.state;
 
     reportExploreMetrics('label_filter_changed', { label: labelName, action: 'added', cause: 'breakdown' });

--- a/src/DataTrail.tsx
+++ b/src/DataTrail.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { urlUtil, VariableHide, type AdHocVariableFilter, type GrafanaTheme2 } from '@grafana/data';
-import { utf8Support, type PromQuery } from '@grafana/prometheus';
+import { utf8Support } from '@grafana/prometheus';
 import { config, useChromeHeaderHeight } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
@@ -21,7 +21,6 @@ import {
   type SceneObjectState,
   type SceneObjectUrlValues,
   type SceneObjectWithUrlSync,
-  type SceneQueryRunner,
   type SceneVariable,
 } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
@@ -48,7 +47,6 @@ import { reportChangeInLabelFilters, reportExploreMetrics } from './interactions
 import { MetricScene } from './MetricScene';
 import { MetricSelectedEvent, trailDS, VAR_FILTERS } from './shared';
 import { limitAdhocProviders } from './utils';
-import { isSceneQueryRunner } from './utils/utils.queries';
 import { getAppBackgroundColor } from './utils/utils.styles';
 import { isAdHocFiltersVariable } from './utils/utils.variables';
 
@@ -69,59 +67,28 @@ export interface DataTrailState extends SceneObjectState {
 
   // Synced with url
   metric?: string;
-  metricSearch?: string;
-  nativeHistogramMetric: string;
 
-  trailActivated: boolean; // this indicates that the trail has been updated by metric or filter selected
   urlNamespace?: string; // optional namespace for url params, to avoid conflicts with other plugins in embedded mode
 
   drawer: SceneDrawer;
 }
 
 export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneObjectWithUrlSync {
-  private _addingFilterWithoutReportingInteraction = false;
+  private disableReportFiltersInteraction = false;
   private datasourceHelper = new MetricDatasourceHelper(this);
 
   protected _urlSync = new SceneObjectUrlSyncConfig(this, {
-    keys: ['metric', 'metricSearch', 'nativeHistogramMetric'],
+    keys: ['metric'],
   });
 
   getUrlState(): SceneObjectUrlValues {
-    const { metric, metricSearch, nativeHistogramMetric } = this.state;
     return {
-      metric,
-      metricSearch,
-      // store the native histogram knowledge in url for the metric scene
-      nativeHistogramMetric,
+      metric: this.state.metric,
     };
   }
 
   updateFromUrl(values: SceneObjectUrlValues) {
-    const stateUpdate: Partial<DataTrailState> = {};
-
-    if (typeof values.metric === 'string') {
-      if (this.state.metric !== values.metric) {
-        // if we have a metric and we have stored in the url that it is a native histogram
-        // we can pass that info into the metric scene to generate the appropriate queries
-        let nativeHistogramMetric = false;
-        if (values.nativeHistogramMetric === '1') {
-          nativeHistogramMetric = true;
-        }
-
-        Object.assign(stateUpdate, this.getSceneUpdatesForNewMetricValue(values.metric, nativeHistogramMetric));
-      }
-    } else if (values.metric == null && !this.state.embedded) {
-      stateUpdate.metric = undefined;
-      stateUpdate.topScene = new MetricsReducer();
-    }
-
-    if (typeof values.metricSearch === 'string') {
-      stateUpdate.metricSearch = values.metricSearch;
-    } else if (values.metric == null) {
-      stateUpdate.metricSearch = undefined;
-    }
-
-    this.setState(stateUpdate);
+    this.updateStateForNewMetric((values.metric as string) || undefined);
   }
 
   public constructor(state: Partial<DataTrailState>) {
@@ -138,8 +105,6 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
       createdAt: state.createdAt ?? new Date().getTime(),
       dashboardMetrics: {},
       alertingMetrics: {},
-      nativeHistogramMetric: state.nativeHistogramMetric ?? '',
-      trailActivated: state.trailActivated ?? false,
       drawer: new SceneDrawer({}),
       ...state,
     });
@@ -150,129 +115,112 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
   private onActivate() {
     this.datasourceHelper.init();
 
-    this.subscribeToConfigEvents();
+    this.updateStateForNewMetric(this.state.metric);
+    this.subscribeToEvent(MetricSelectedEvent, (event) => this.handleMetricSelectedEvent(event));
 
-    this.setState({ trailActivated: true });
+    this.initFilters();
+    this.initConfigPrometheusFunction();
+  }
 
-    if (!this.state.topScene) {
-      this.setState({ topScene: getTopSceneFor(this.state.metric) });
+  private updateStateForNewMetric(metric?: string) {
+    if (!this.state.topScene || metric !== this.state.metric) {
+      this.setState({
+        metric,
+        topScene: metric ? new MetricScene({ metric }) : new MetricsReducer(),
+      });
     }
+  }
 
-    // Some scene elements publish this
-    this.subscribeToEvent(MetricSelectedEvent, this._handleMetricSelectedEvent.bind(this));
-
+  private initFilters() {
     const filtersVariable = sceneGraph.lookupVariable(VAR_FILTERS, this);
-
-    if (isAdHocFiltersVariable(filtersVariable)) {
-      this._subs.add(
-        filtersVariable?.subscribeToState((newState, prevState) => {
-          if (!this._addingFilterWithoutReportingInteraction) {
-            reportChangeInLabelFilters(newState.filters, prevState.filters);
-          }
-        })
-      );
-
-      // we ensure that, in the MetricsReducer, the Ad Hoc filters will display all the label names and values and
-      // we ensure that, in the MetricScene, the queries in the Scene graph will be considered and used as a filter
-      // to fetch label names and values
-      filtersVariable?.setState({
-        useQueriesAsFilterForOptions: Boolean(this.state.metric),
-      });
-
-      this.subscribeToState((newState, prevState) => {
-        if (newState.metric !== prevState.metric) {
-          filtersVariable?.setState({
-            useQueriesAsFilterForOptions: Boolean(newState.metric),
-          });
-
-          // ensure that when using browser nav, we close the drawer
-          this.state.drawer.close();
-        }
-      });
-    }
-  }
-
-  private async subscribeToConfigEvents() {
-    this._subs.add(
-      this.subscribeToEvent(EventConfigurePanel, async (event) => {
-        const { metric } = event.payload;
-
-        reportExploreMetrics('configure_panel_opened', { metricType: getMetricType(metric) });
-
-        const metadata = await this.getMetadataForMetric(metric);
-
-        this.state.drawer.open({
-          title: 'Configure the Prometheus function',
-          subTitle: `${metric} ${metadata ? ` (${metadata.type})` : ''}`, // eslint-disable-line sonarjs/no-nested-template-literals
-          body: new ConfigurePanelForm({ metric }),
-        });
-      })
-    );
-
-    this._subs.add(
-      this.subscribeToEvent(EventCancelConfigurePanel, () => {
-        this.state.drawer.close();
-      })
-    );
-
-    this._subs.add(
-      this.subscribeToEvent(EventApplyPanelConfig, (event) => {
-        const { metric, config, restoreDefault } = event.payload;
-
-        if (restoreDefault) {
-          reportExploreMetrics('default_panel_config_restored', { metricType: getMetricType(metric) });
-        } else {
-          reportExploreMetrics('panel_config_applied', { metricType: getMetricType(metric), configId: config.id });
-        }
-
-        this.state.drawer.close();
-
-        const panelsToUpdate = sceneGraph.findAllObjects(
-          this.state.topScene || this,
-          (o) =>
-            o instanceof GmdVizPanel &&
-            o.state.metric === metric &&
-            Boolean(sceneGraph.findDescendents(o, ConfigurePanelAction).length === 1)
-        ) as GmdVizPanel[];
-
-        for (const panel of panelsToUpdate) {
-          panel.update(config.panelOptions, config.queryOptions);
-        }
-
-        displaySuccess([`Configuration successfully ${restoreDefault ? 'restored' : 'applied'} for metric ${metric}!`]);
-      })
-    );
-  }
-
-  /**
-   * Assuming that the change in filter was already reported with a cause other than `'adhoc_filter'`,
-   * this will modify the adhoc filter variable and prevent the automatic reporting which would
-   * normally occur through the call to `reportChangeInLabelFilters`.
-   */
-  public addFilterWithoutReportingInteraction(filter: AdHocVariableFilter) {
-    const variable = sceneGraph.lookupVariable(VAR_FILTERS, this);
-    if (!isAdHocFiltersVariable(variable)) {
+    if (!isAdHocFiltersVariable(filtersVariable)) {
       return;
     }
 
-    this._addingFilterWithoutReportingInteraction = true;
-    variable.setState({ filters: [...variable.state.filters, filter] });
-    this._addingFilterWithoutReportingInteraction = false;
+    limitAdhocProviders(this, filtersVariable, this.datasourceHelper);
+
+    // we ensure that, in the MetricsReducer, the Ad Hoc filters will display all the label names and values and
+    // we ensure that, in the MetricScene, the queries in the Scene graph will be considered and used as a filter
+    // to fetch label names and values
+    filtersVariable?.setState({
+      useQueriesAsFilterForOptions: Boolean(this.state.metric),
+    });
+
+    this.subscribeToState((newState, prevState) => {
+      if (newState.metric !== prevState.metric) {
+        const filtersVariable = sceneGraph.lookupVariable(VAR_FILTERS, this);
+
+        if (isAdHocFiltersVariable(filtersVariable)) {
+          filtersVariable.setState({
+            useQueriesAsFilterForOptions: Boolean(newState.metric),
+          });
+        }
+      }
+    });
+
+    this._subs.add(
+      filtersVariable?.subscribeToState((newState, prevState) => {
+        if (!this.disableReportFiltersInteraction && newState.filters !== prevState.filters) {
+          reportChangeInLabelFilters(newState.filters, prevState.filters);
+        }
+      })
+    );
   }
 
-  public getPrometheusBuildInfo() {
-    return this.datasourceHelper.getPrometheusBuildInfo();
+  private initConfigPrometheusFunction() {
+    this.subscribeToState((newState, prevState) => {
+      if (newState.metric !== prevState.metric) {
+        // ensures that the drawer is closed when using browser nav buttons
+        this.state.drawer.close();
+      }
+    });
+
+    this.subscribeToEvent(EventConfigurePanel, async (event) => {
+      const { metric } = event.payload;
+
+      reportExploreMetrics('configure_panel_opened', { metricType: getMetricType(metric) });
+
+      const metadata = await this.getMetadataForMetric(metric);
+
+      this.state.drawer.open({
+        title: 'Configure the Prometheus function',
+        subTitle: `${metric} ${metadata ? ` (${metadata.type})` : ''}`, // eslint-disable-line sonarjs/no-nested-template-literals
+        body: new ConfigurePanelForm({ metric }),
+      });
+    });
+
+    this.subscribeToEvent(EventCancelConfigurePanel, () => {
+      this.state.drawer.close();
+    });
+
+    this.subscribeToEvent(EventApplyPanelConfig, (event) => {
+      const { metric, config, restoreDefault } = event.payload;
+
+      if (restoreDefault) {
+        reportExploreMetrics('default_panel_config_restored', { metricType: getMetricType(metric) });
+      } else {
+        reportExploreMetrics('panel_config_applied', { metricType: getMetricType(metric), configId: config.id });
+      }
+
+      this.state.drawer.close();
+
+      const panelsToUpdate = sceneGraph.findAllObjects(
+        this.state.topScene || this,
+        (o) =>
+          o instanceof GmdVizPanel &&
+          o.state.metric === metric &&
+          Boolean(sceneGraph.findDescendents(o, ConfigurePanelAction).length === 1)
+      ) as GmdVizPanel[];
+
+      for (const panel of panelsToUpdate) {
+        panel.update(config.panelOptions, config.queryOptions);
+      }
+
+      displaySuccess([`Configuration successfully ${restoreDefault ? 'restored' : 'applied'} for metric ${metric}!`]);
+    });
   }
 
-  public getMetadataForMetric(metric: string) {
-    return this.datasourceHelper.getMetadataForMetric(metric);
-  }
-
-  public async isNativeHistogram(metric: string) {
-    return this.datasourceHelper.isNativeHistogram(metric);
-  }
-
-  private async _handleMetricSelectedEvent(event: MetricSelectedEvent) {
+  private async handleMetricSelectedEvent(event: MetricSelectedEvent) {
     const { metric, urlValues } = event.payload;
 
     if (metric) {
@@ -287,10 +235,8 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
       });
     }
 
-    const nativeHistogramMetric = metric ? await this.isNativeHistogram(metric) : false;
-
     this._urlSync.performBrowserHistoryAction(() => {
-      this.setState(this.getSceneUpdatesForNewMetricValue(metric, nativeHistogramMetric));
+      this.updateStateForNewMetric(metric);
 
       if (urlValues) {
         // make sure we reset the filters when navigating from a bookmark where urlsValues['var_vilters']: []
@@ -305,32 +251,34 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
     });
   }
 
-  private getSceneUpdatesForNewMetricValue(metric: string | undefined, nativeHistogramMetric?: boolean) {
-    const stateUpdate: Partial<DataTrailState> = {};
-    stateUpdate.metric = metric;
-    // refactoring opportunity? Or do we pass metric knowledge all the way down?
-    // must pass this native histogram prometheus knowledge deep into
-    // the topscene set on the trail > MetricScene > getAutoQueriesForMetric() > createHistogramMetricQueryDefs();
-    stateUpdate.nativeHistogramMetric = nativeHistogramMetric ? '1' : '';
-    stateUpdate.topScene = getTopSceneFor(metric, nativeHistogramMetric);
+  /**
+   * Assuming that the change in filter was already reported with a cause other than `'adhoc_filter'`,
+   * this will modify the adhoc filter variable and prevent the automatic reporting which would
+   * normally occur through the call to `reportChangeInLabelFilters`.
+   *
+   * See AddToFiltersGraphAction.tsx
+   */
+  public addFilterWithoutReportingInteraction(filter: AdHocVariableFilter) {
+    const variable = sceneGraph.lookupVariable(VAR_FILTERS, this);
+    if (!isAdHocFiltersVariable(variable)) {
+      return;
+    }
 
-    return stateUpdate;
+    this.disableReportFiltersInteraction = true;
+    variable.setState({ filters: [...variable.state.filters, filter] });
+    this.disableReportFiltersInteraction = false;
   }
 
-  public getQueries(): PromQuery[] {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const sqrs = sceneGraph.findAllObjects(this, (b) => isSceneQueryRunner(b)) as SceneQueryRunner[];
+  public async getPrometheusBuildInfo() {
+    return this.datasourceHelper.getPrometheusBuildInfo();
+  }
 
-    return sqrs.reduce<PromQuery[]>((acc, sqr) => {
-      acc.push(
-        ...sqr.state.queries.map((q) => ({
-          ...q,
-          expr: sceneGraph.interpolate(sqr, q.expr),
-        }))
-      );
+  public async getMetadataForMetric(metric: string) {
+    return this.datasourceHelper.getMetadataForMetric(metric);
+  }
 
-      return acc;
-    }, []);
+  public async isNativeHistogram(metric: string) {
+    return this.datasourceHelper.isNativeHistogram(metric);
   }
 
   static readonly Component = ({ model }: SceneComponentProps<DataTrail>) => {
@@ -339,12 +287,6 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
     const chromeHeaderHeight = useChromeHeaderHeight() ?? 0;
     const headerHeight = embedded ? 0 : chromeHeaderHeight;
     const styles = useStyles2(getStyles, headerHeight, model);
-
-    useEffect(() => {
-      const filtersVariable = sceneGraph.lookupVariable(VAR_FILTERS, model);
-      const datasourceHelper = model.datasourceHelper;
-      limitAdhocProviders(model, filtersVariable, datasourceHelper);
-    }, [model]);
 
     // Set CSS custom property for app-controls height in embedded mode
     useEffect(() => {
@@ -397,14 +339,6 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
       </>
     );
   };
-}
-
-function getTopSceneFor(metric?: string, nativeHistogram = false) {
-  if (metric) {
-    return new MetricScene({ metric, nativeHistogram });
-  } else {
-    return new MetricsReducer();
-  }
 }
 
 function getVariableSet(initialDS?: string, metric?: string, initialFilters?: AdHocVariableFilter[]) {

--- a/src/MetricScene.tsx
+++ b/src/MetricScene.tsx
@@ -24,7 +24,6 @@ import { getVariablesWithMetricConstant, RefreshMetricsEvent, VAR_FILTERS, type 
 interface MetricSceneState extends SceneObjectState {
   body: MetricGraphScene;
   metric: string;
-  nativeHistogram?: boolean;
   actionView?: ActionViewType;
   relatedLogsCount?: number;
 }

--- a/src/bookmarks/genBookmarkKey.ts
+++ b/src/bookmarks/genBookmarkKey.ts
@@ -3,7 +3,6 @@ import { type SceneObjectUrlValues } from '@grafana/scenes';
 function filterUrlValues(urlValues: SceneObjectUrlValues) {
   delete urlValues.actionView;
   delete urlValues.layout;
-  delete urlValues.metricSearch;
   delete urlValues.refresh;
 
   if (Array.isArray(urlValues['var-filters'])) {


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

A cleanup PR, where unused `DataTrail` class variables are removed:
- `nativeHistogramMetric`,
- `metricSearch ` and
- `trailActivated`

...as well as their related code.

Additionally, the naming and the organization of the code in the class have been improved. For instance, check `onActivate` now.

### 📖 Summary of the changes

See specific comments in the diff tab.

### 🧪 How to test?

- The build should pass
