### PR TITLE
fix(RelatedLogs): Fix fatal error when no logs are found

### DIFF
--- a/e2e/tests/metric-scene-view.spec.ts
+++ b/e2e/tests/metric-scene-view.spec.ts
@@ -108,7 +108,7 @@ test.describe('Metric Scene view', () => {
       });
     });
 
-    test.describe('Related metric tab', () => {
+    test.describe('Related metrics tab', () => {
       test.beforeEach(async ({ metricSceneView }) => {
         await metricSceneView.selectTab('Related metrics');
       });
@@ -135,6 +135,16 @@ test.describe('Metric Scene view', () => {
             ],
           }
         );
+      });
+    });
+
+    test.describe('Related logs tab', () => {
+      test.beforeEach(async ({ metricSceneView }) => {
+        await metricSceneView.selectTab('Related logs');
+      });
+
+      test('No related logs found', async ({ metricSceneView }) => {
+        await expect(metricSceneView.getTabContent().getByText('No related logs found')).toBeVisible();
       });
     });
   });

--- a/src/RelatedLogs/RelatedLogsScene.tsx
+++ b/src/RelatedLogs/RelatedLogsScene.tsx
@@ -2,7 +2,6 @@ import { LoadingState } from '@grafana/data';
 import {
   CustomVariable,
   PanelBuilders,
-  SceneCSSGridItem,
   SceneFlexItem,
   SceneFlexLayout,
   sceneGraph,
@@ -86,7 +85,7 @@ export class RelatedLogsScene extends SceneObjectBase<RelatedLogsSceneState> {
   }
 
   private showNoLogsFound() {
-    const logsPanelContainer = sceneGraph.findByKeyAndType(this, LOGS_PANEL_CONTAINER_KEY, SceneCSSGridItem);
+    const logsPanelContainer = sceneGraph.findByKeyAndType(this, LOGS_PANEL_CONTAINER_KEY, SceneFlexItem);
     logsPanelContainer.setState({
       body: new SceneReactObject({ component: NoRelatedLogs }),
     });
@@ -144,7 +143,8 @@ export class RelatedLogsScene extends SceneObjectBase<RelatedLogsSceneState> {
         .setOption('showControls', true)
         // See https://github.com/grafana/logs-drilldown/blob/5225d621bbf24756559a15ce68d71437be8ca83e/src/services/store.ts#L243
         .setOption('controlsStorageKey', 'grafana.explore.logs')
-        .setData(this._queryRunner).build(),
+        .setData(this._queryRunner)
+        .build(),
     });
 
     // Set up variables for datasource selection


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Just a quick fix when the user goes to the `MetricScene`, clicks on the "Related logs" tab and no logs are found:

<img width="3370" height="933" alt="image" src="https://github.com/user-attachments/assets/3a77f0b1-25bc-416b-840d-d6f1b33ae51b" />


### 📖 Summary of the changes

A call to `sceneGraph.findByKeyAndType` with the wrong type of object was causing a runtime error.

### 🧪 How to test?

- A simple E2E test has been added in this PR ; the build should pass

**Note:** in the near future, we should setup and start testing with a Loki data source
