### PR TITLE
perf(GmdVizPanel): Faster first render + small refatorings

### DIFF
--- a/src/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm.tsx
+++ b/src/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm.tsx
@@ -73,8 +73,7 @@ export class ConfigurePanelForm extends SceneObjectBase<ConfigurePanelFormState>
   private async buildBody() {
     const { metric } = this.state;
     const prefConfig = getPreferredConfigForMetric(metric);
-    const isNativeHistogram = await getTrailFor(this).isNativeHistogram(metric);
-    const presets = getConfigPresetsForMetric(metric, isNativeHistogram);
+    const presets = await getConfigPresetsForMetric(metric, getTrailFor(this));
 
     // if not found in the user preferences, we use the first preset
     // it always works because the presets are organized to always have the default one as the first element (see GmdVizPanel/config/presets)

--- a/src/GmdVizPanel/config/presets/getConfigPresetsForMetric.ts
+++ b/src/GmdVizPanel/config/presets/getConfigPresetsForMetric.ts
@@ -1,29 +1,30 @@
+import { type DataTrail } from 'DataTrail';
+import { getMetricType } from 'GmdVizPanel/matchers/getMetricType';
+
 import { DEFAULT_TIMESERIES_AGE_PRESETS } from './config-presets-ages';
 import { DEFAULT_HISTOGRAMS_PRESETS } from './config-presets-histograms';
 import { DEFAULT_STATUS_UP_DOWN_PRESETS } from './config-presets-status-updown';
 import { DEFAULT_TIMESERIES_PRESETS, DEFAULT_TIMESERIES_RATE_PRESETS } from './config-presets-timeseries';
 import { type PanelConfigPreset } from './types';
-import { isCounterMetric } from '../..//matchers/isCounterMetric';
-import { isHistogramMetric } from '../..//matchers/isHistogramMetric';
-import { isAgeMetric } from '../../matchers/isAgeMetric';
-import { isStatusUpDownMetric } from '../../matchers/isStatusUpDownMetric';
 
-export function getConfigPresetsForMetric(metric: string, isNativeHistogram: boolean): PanelConfigPreset[] {
-  if (isStatusUpDownMetric(metric)) {
-    return Object.values(DEFAULT_STATUS_UP_DOWN_PRESETS);
+export async function getConfigPresetsForMetric(metric: string, dataTrail: DataTrail): Promise<PanelConfigPreset[]> {
+  const metricType = await getMetricType(metric, dataTrail);
+
+  switch (metricType) {
+    case 'counter':
+      return Object.values(DEFAULT_TIMESERIES_RATE_PRESETS);
+
+    case 'classic-histogram':
+    case 'native-histogram':
+      return Object.values(DEFAULT_HISTOGRAMS_PRESETS);
+
+    case 'age':
+      return [Object.values(DEFAULT_TIMESERIES_PRESETS)[0], ...Object.values(DEFAULT_TIMESERIES_AGE_PRESETS)];
+
+    case 'status-updown':
+      return Object.values(DEFAULT_STATUS_UP_DOWN_PRESETS);
+
+    default:
+      return Object.values(DEFAULT_TIMESERIES_PRESETS);
   }
-
-  if (isNativeHistogram || isHistogramMetric(metric)) {
-    return Object.values(DEFAULT_HISTOGRAMS_PRESETS);
-  }
-
-  if (isAgeMetric(metric)) {
-    return [Object.values(DEFAULT_TIMESERIES_PRESETS)[0], ...Object.values(DEFAULT_TIMESERIES_AGE_PRESETS)];
-  }
-
-  if (isCounterMetric(metric)) {
-    return Object.values(DEFAULT_TIMESERIES_RATE_PRESETS);
-  }
-
-  return Object.values(DEFAULT_TIMESERIES_PRESETS);
 }

--- a/src/GmdVizPanel/matchers/__tests__/isCounterMetric.test.ts
+++ b/src/GmdVizPanel/matchers/__tests__/isCounterMetric.test.ts
@@ -1,0 +1,30 @@
+import { isCounterMetric } from '../isCounterMetric';
+
+describe('isCounterMetric(metric)', () => {
+  describe('counter metrics (ending with "_count", "_total" or "_sum")', () => {
+    test.each([['http_requests_count'], ['http_requests_total'], ['http_request_duration_seconds_sum']])(
+      'returns true (%s)',
+      (metric) => {
+        expect(isCounterMetric(metric)).toBe(true);
+      }
+    );
+  });
+
+  describe('non-counter metrics (not ending with "_count", "_total" or "_sum")', () => {
+    test.each([
+      'cpu_usage_percent',
+      'memory_available_bytes',
+      'disk_free_ratio',
+      'temperature_celsius',
+      'count_requests_processed',
+      'total_memory_available',
+      'sum_calculation_result',
+      'http_requests_counter',
+      'bytes_partialtotal',
+      'memory_summary',
+      'counting',
+    ])('returns false (%s)', (metric) => {
+      expect(isCounterMetric(metric)).toBe(false);
+    });
+  });
+});

--- a/src/GmdVizPanel/matchers/__tests__/isStatusUpDownMetric.test.ts
+++ b/src/GmdVizPanel/matchers/__tests__/isStatusUpDownMetric.test.ts
@@ -1,0 +1,15 @@
+import { isStatusUpDownMetric } from '../isStatusUpDownMetric';
+
+describe('isStatusUpDownMetric(metric)', () => {
+  describe('status up/down metrics (ending with _count, _total or _sum)', () => {
+    test.each([['up'], ['memcached_up']])('returns true (%s)', (metric) => {
+      expect(isStatusUpDownMetric(metric)).toBe(true);
+    });
+  });
+
+  describe('other metrics (not being "up" ending with "_up")', () => {
+    test.each(['server_uptime', 'up_timestamp', 'upstream'])('returns false (%s)', (metric) => {
+      expect(isStatusUpDownMetric(metric)).toBe(false);
+    });
+  });
+});

--- a/src/GmdVizPanel/matchers/getMetricType.ts
+++ b/src/GmdVizPanel/matchers/getMetricType.ts
@@ -1,25 +1,54 @@
+import { type DataTrail } from 'DataTrail';
+
 import { isAgeMetric } from './isAgeMetric';
+import { isClassicHistogramMetric } from './isClassicHistogramMetric';
 import { isCounterMetric } from './isCounterMetric';
-import { isHistogramMetric } from './isHistogramMetric';
 import { isStatusUpDownMetric } from './isStatusUpDownMetric';
 
-export type MetricType = 'status-updown' | 'histogram' | 'age' | 'counter' | 'gauge';
+export type MetricType = 'status-updown' | 'classic-histogram' | 'native-histogram' | 'age' | 'counter' | 'gauge';
 
-export function getMetricType(metric: string): MetricType {
-  if (isStatusUpDownMetric(metric)) {
-    return 'status-updown';
+export async function getMetricType(metric: string, dataTrail: DataTrail): Promise<MetricType> {
+  if (isCounterMetric(metric)) {
+    return 'counter';
   }
 
-  if (isHistogramMetric(metric)) {
-    return 'histogram';
+  if (isClassicHistogramMetric(metric)) {
+    return 'classic-histogram';
   }
 
   if (isAgeMetric(metric)) {
     return 'age';
   }
 
+  if (isStatusUpDownMetric(metric)) {
+    return 'status-updown';
+  }
+
+  if (await dataTrail.isNativeHistogram(metric)) {
+    return 'native-histogram';
+  }
+
+  return 'gauge';
+}
+
+/**
+ * A sync version to use when performance is important or when the metadata for determing native histograms is missing
+ */
+export function getMetricTypeSync(metric: string): MetricType {
   if (isCounterMetric(metric)) {
     return 'counter';
+  }
+
+  if (isClassicHistogramMetric(metric)) {
+    return 'classic-histogram';
+  }
+
+  if (isAgeMetric(metric)) {
+    return 'age';
+  }
+
+  if (isStatusUpDownMetric(metric)) {
+    return 'status-updown';
   }
 
   return 'gauge';

--- a/src/GmdVizPanel/matchers/getPanelTypeForMetric.ts
+++ b/src/GmdVizPanel/matchers/getPanelTypeForMetric.ts
@@ -26,7 +26,7 @@ export async function getPanelTypeForMetric(metric: string, dataTrail: DataTrail
 }
 
 /**
- * A sync version to use when performance is important
+ * A sync version to use when we already know the histogram type and performance is important
  */
 export function getPanelTypeForMetricSync(metric: string, histogramType: HistogramType): PanelType {
   if (isStatusUpDownMetric(metric)) {

--- a/src/GmdVizPanel/matchers/getPanelTypeForMetric.ts
+++ b/src/GmdVizPanel/matchers/getPanelTypeForMetric.ts
@@ -5,6 +5,10 @@ import { type PanelType } from 'GmdVizPanel/types/available-panel-types';
 import { isClassicHistogramMetric } from './isClassicHistogramMetric';
 import { isStatusUpDownMetric } from './isStatusUpDownMetric';
 
+/**
+ * These are functions that receive a metric name to determine in which panel type they should be displayed.
+ * Note that they don't consider user preferences stored in user storage.
+ */
 export async function getPanelTypeForMetric(metric: string, dataTrail: DataTrail): Promise<PanelType> {
   if (isStatusUpDownMetric(metric)) {
     return 'statushistory';

--- a/src/GmdVizPanel/matchers/getPanelTypeForMetric.ts
+++ b/src/GmdVizPanel/matchers/getPanelTypeForMetric.ts
@@ -1,0 +1,37 @@
+import { type DataTrail } from 'DataTrail';
+import { type HistogramType } from 'GmdVizPanel/GmdVizPanel';
+import { type PanelType } from 'GmdVizPanel/types/available-panel-types';
+
+import { isClassicHistogramMetric } from './isClassicHistogramMetric';
+import { isStatusUpDownMetric } from './isStatusUpDownMetric';
+
+export async function getPanelTypeForMetric(metric: string, dataTrail: DataTrail): Promise<PanelType> {
+  if (isStatusUpDownMetric(metric)) {
+    return 'statushistory';
+  }
+
+  if (isClassicHistogramMetric(metric)) {
+    return 'heatmap';
+  }
+
+  if (await dataTrail.isNativeHistogram(metric)) {
+    return 'heatmap';
+  }
+
+  return 'timeseries';
+}
+
+/**
+ * A sync version to use when performance is important
+ */
+export function getPanelTypeForMetricSync(metric: string, histogramType: HistogramType): PanelType {
+  if (isStatusUpDownMetric(metric)) {
+    return 'statushistory';
+  }
+
+  if (histogramType === 'classic' || histogramType === 'native') {
+    return 'heatmap';
+  }
+
+  return 'timeseries';
+}

--- a/src/GmdVizPanel/matchers/isClassicHistogramMetric.ts
+++ b/src/GmdVizPanel/matchers/isClassicHistogramMetric.ts
@@ -1,0 +1,1 @@
+export const isClassicHistogramMetric = (metric: string) => metric.endsWith('_bucket');

--- a/src/GmdVizPanel/matchers/isCounterMetric.ts
+++ b/src/GmdVizPanel/matchers/isCounterMetric.ts
@@ -1,7 +1,3 @@
-const COUNTER_METRIC_SUFFIXES = new Set(['count', 'total', 'sum']);
+const COUNTER_METRIC_REGEX = /_(count|total|sum)$/;
 
-export function isCounterMetric(metric: string) {
-  const parts = metric.split('_');
-  const suffix = parts.at(-1);
-  return suffix ? COUNTER_METRIC_SUFFIXES.has(suffix) : false;
-}
+export const isCounterMetric = (metric: string) => COUNTER_METRIC_REGEX.test(metric);

--- a/src/GmdVizPanel/matchers/isHistogramMetric.ts
+++ b/src/GmdVizPanel/matchers/isHistogramMetric.ts
@@ -1,1 +1,0 @@
-export const isHistogramMetric = (metric: string) => metric.endsWith('_bucket');

--- a/src/GmdVizPanel/matchers/isStatusUpDownMetric.ts
+++ b/src/GmdVizPanel/matchers/isStatusUpDownMetric.ts
@@ -1,1 +1,3 @@
-export const isStatusUpDownMetric = (metric: string): boolean => metric === 'up' || metric.endsWith('_up');
+const STATUS_UPDOWN_METRIC_REGEX = /_up$/;
+
+export const isStatusUpDownMetric = (metric: string) => metric === 'up' || STATUS_UPDOWN_METRIC_REGEX.test(metric);

--- a/src/MetricGraphScene.tsx
+++ b/src/MetricGraphScene.tsx
@@ -19,7 +19,7 @@ import { GmdVizPanelVariantSelector } from 'GmdVizPanel/components/GmdVizPanelVa
 import { PANEL_HEIGHT } from 'GmdVizPanel/config/panel-heights';
 import { QUERY_RESOLUTION } from 'GmdVizPanel/config/query-resolutions';
 import { GmdVizPanel } from 'GmdVizPanel/GmdVizPanel';
-import { isHistogramMetric } from 'GmdVizPanel/matchers/isHistogramMetric';
+import { isClassicHistogramMetric } from 'GmdVizPanel/matchers/isClassicHistogramMetric';
 import { getMetricDescription } from 'helpers/MetricDatasourceHelper';
 import { PanelMenu } from 'Menu/PanelMenu';
 import { MetricActionBar } from 'MetricActionBar';
@@ -71,7 +71,7 @@ export class MetricGraphScene extends SceneObjectBase<MetricGraphSceneState> {
     const trail = getTrailFor(this);
     const metadata = await trail.getMetadataForMetric(metric);
     const description = getMetricDescription(metadata);
-    const isHistogram = isHistogramMetric(metric) || (await trail.isNativeHistogram(metric));
+    const isHistogram = isClassicHistogramMetric(metric) || (await trail.isNativeHistogram(metric));
 
     topView.setState({
       children: [

--- a/src/helpers/MetricDatasourceHelper.ts
+++ b/src/helpers/MetricDatasourceHelper.ts
@@ -14,7 +14,7 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { sceneGraph, type DataSourceVariable, type SceneObject, type VariableValueOption } from '@grafana/scenes';
 import { type Unsubscribable } from 'rxjs';
 
-import { isHistogramMetric } from 'GmdVizPanel/matchers/isHistogramMetric';
+import { isClassicHistogramMetric } from 'GmdVizPanel/matchers/isClassicHistogramMetric';
 import { MetricsDrilldownDataSourceVariable } from 'MetricsDrilldownDataSourceVariable';
 import { displayError, displayWarning } from 'WingmanDataTrail/helpers/displayStatus';
 import { areArraysEqual } from 'WingmanDataTrail/MetricsVariables/helpers/areArraysEqual';
@@ -105,7 +105,7 @@ export class MetricDatasourceHelper {
     for (const metricData of metricsVariableOptions) {
       const name = metricData.value as string;
 
-      if (isHistogramMetric(name)) {
+      if (isClassicHistogramMetric(name)) {
         this.cache.classicHistograms.add(name);
       }
     }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR decreases the time to first render of the `GmdVizPanel` by determing if the metric is a native histogram or not **after** rendering the component. Indeed it's an async process that may require a call to the backend API.

Locally, some tests have shown a decrease of 100ms between the activation of the Scene object and the 1st render of the component.

Additionally:
1. prior to this PR, the metric type that was tracked when the user opened the config Prometheus form did not take into consideration if the metric was a native histogram or not. The same was happening when the config was applied or restored,
2. this PR adds matchers in `src/GmdVizPanel/matchers`: `getPanelTypeForMetric` and `getPanelTypeForMetricSync`
3. and this PR also adds some missing unit tests

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The build should pass
