### PR TITLE
feat(*): server side quick search

### DIFF
--- a/src/DataTrail.tsx
+++ b/src/DataTrail.tsx
@@ -48,7 +48,7 @@ import { MetricSelectedEvent, trailDS, VAR_FILTERS } from './shared';
 import { limitAdhocProviders } from './utils';
 import { getAppBackgroundColor } from './utils/utils.styles';
 import { isAdHocFiltersVariable } from './utils/utils.variables';
-import { OriginalMetricsVariable, SearchableMetricsVariable } from './WingmanDataTrail/MetricsVariables/MetricsVariable';
+import { MetricsVariable } from './WingmanDataTrail/MetricsVariables/MetricsVariable';
 
 export interface DataTrailState extends SceneObjectState {
   topScene?: SceneObject;
@@ -352,8 +352,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
 function getVariableSet(initialDS?: string, metric?: string, initialFilters?: AdHocVariableFilter[]) {
   let variables: SceneVariable[] = [
     new MetricsDrilldownDataSourceVariable({ initialDS }),
-    new SearchableMetricsVariable(), // Server-side searchable metrics
-    new OriginalMetricsVariable(),   // Preserves original total count
+    new MetricsVariable(),
     new AdHocFiltersVariable({
       key: VAR_FILTERS,
       name: VAR_FILTERS,

--- a/src/DataTrail.tsx
+++ b/src/DataTrail.tsx
@@ -38,7 +38,6 @@ import { PluginInfo } from 'PluginInfo/PluginInfo';
 import { displaySuccess } from 'WingmanDataTrail/helpers/displayStatus';
 import { addRecentMetric } from 'WingmanDataTrail/ListControls/MetricsSorter/MetricsSorter';
 import { MetricsReducer } from 'WingmanDataTrail/MetricsReducer';
-import { MetricsVariable } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
 import { SceneDrawer } from 'WingmanDataTrail/SceneDrawer';
 
 import { DataTrailSettings } from './DataTrailSettings';
@@ -49,6 +48,7 @@ import { MetricSelectedEvent, trailDS, VAR_FILTERS } from './shared';
 import { limitAdhocProviders } from './utils';
 import { getAppBackgroundColor } from './utils/utils.styles';
 import { isAdHocFiltersVariable } from './utils/utils.variables';
+import { OriginalMetricsVariable, SearchableMetricsVariable } from './WingmanDataTrail/MetricsVariables/MetricsVariable';
 
 export interface DataTrailState extends SceneObjectState {
   topScene?: SceneObject;
@@ -352,7 +352,8 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
 function getVariableSet(initialDS?: string, metric?: string, initialFilters?: AdHocVariableFilter[]) {
   let variables: SceneVariable[] = [
     new MetricsDrilldownDataSourceVariable({ initialDS }),
-    new MetricsVariable(),
+    new SearchableMetricsVariable(), // Server-side searchable metrics
+    new OriginalMetricsVariable(),   // Preserves original total count
     new AdHocFiltersVariable({
       key: VAR_FILTERS,
       name: VAR_FILTERS,

--- a/src/RelatedMetricsScene/RelatedMetricsScene.tsx
+++ b/src/RelatedMetricsScene/RelatedMetricsScene.tsx
@@ -17,10 +17,7 @@ import { MetricsList } from 'WingmanDataTrail/MetricsList/MetricsList';
 import { EventMetricsVariableActivated } from 'WingmanDataTrail/MetricsVariables/EventMetricsVariableActivated';
 import { EventMetricsVariableDeactivated } from 'WingmanDataTrail/MetricsVariables/EventMetricsVariableDeactivated';
 import { EventMetricsVariableLoaded } from 'WingmanDataTrail/MetricsVariables/EventMetricsVariableLoaded';
-import {
-  FilteredMetricsVariable,
-  VAR_FILTERED_METRICS_VARIABLE,
-} from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
+import { ClientSideFilteredMetricsVariable, VAR_CLIENT_FILTERED_METRICS } from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
 import {
   MetricsVariableFilterEngine,
   type MetricFilters,
@@ -41,10 +38,10 @@ export class RelatedMetricsScene extends SceneObjectBase<RelatedMetricsSceneStat
     super({
       metric,
       $variables: new SceneVariableSet({
-        variables: [new FilteredMetricsVariable()],
+        variables: [new ClientSideFilteredMetricsVariable()],
       }),
       key: 'RelatedMetricsScene',
-      body: new MetricsList({ variableName: VAR_FILTERED_METRICS_VARIABLE }),
+      body: new MetricsList({ variableName: VAR_CLIENT_FILTERED_METRICS }),
       listControls: new RelatedListControls({}),
     });
 

--- a/src/WingmanDataTrail/ListControls/QuickSearch/CountsProvider/MetricVariableCountsProvider.ts
+++ b/src/WingmanDataTrail/ListControls/QuickSearch/CountsProvider/MetricVariableCountsProvider.ts
@@ -2,42 +2,82 @@ import { sceneGraph, type MultiValueVariable } from '@grafana/scenes';
 
 import { VAR_FILTERED_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
 import { areArraysEqual } from 'WingmanDataTrail/MetricsVariables/helpers/areArraysEqual';
-import { VAR_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
+import { VAR_METRICS_VARIABLE, VAR_ORIGINAL_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
 
 import { CountsProvider } from './CountsProvider';
 
 export class MetricVariableCountsProvider extends CountsProvider {
+  private originalTotalCount: number = 0;
+
   constructor() {
     super({ key: 'MetricVariableCountsProvider' });
     this.addActivationHandler(this.onActivate.bind(this));
   }
 
   private onActivate() {
-    const nonFilteredVariable = sceneGraph.lookupVariable(VAR_METRICS_VARIABLE, this) as MultiValueVariable;
+    // Try to use the original metrics variable for total count (preserves original)
+    const originalMetricsVariable = sceneGraph.lookupVariable(VAR_ORIGINAL_METRICS_VARIABLE, this) as MultiValueVariable;
+    // Use the searchable metrics variable for current count (changes with server-side search)
+    const searchableMetricsVariable = sceneGraph.lookupVariable(VAR_METRICS_VARIABLE, this) as MultiValueVariable;
+    // Use the filtered variable for client-side filtering compatibility
     const filteredVariable = sceneGraph.lookupVariable(VAR_FILTERED_METRICS_VARIABLE, this) as MultiValueVariable;
 
-    this.setInitCounts(nonFilteredVariable, filteredVariable);
+    // Fall back to the searchable variable if original doesn't exist (backward compatibility)
+    const totalCountVariable = originalMetricsVariable || searchableMetricsVariable;
+    
+    this.setInitCounts(totalCountVariable, filteredVariable);
 
+    // Subscribe to the variable that provides the total count
     this._subs.add(
-      nonFilteredVariable.subscribeToState((newState, prevState) => {
+      totalCountVariable.subscribeToState((newState, prevState) => {
         if (!areArraysEqual(newState.options, prevState.options)) {
+          // Track the maximum count we've ever seen as the true total
+          // This handles the case where user starts with filters applied
+          if (newState.options.length > this.originalTotalCount) {
+            this.originalTotalCount = newState.options.length;
+          }
+          
+          // Update counts - fix the logic
+          // The searchable variable now contains the server-filtered results (current)
+          // The original total should be the maximum we've ever seen
+          const currentCount = searchableMetricsVariable.state.options.length; // Server-filtered results
+          const totalCount = this.originalTotalCount; // Maximum count ever seen
+          
           this.setState({
             counts: {
-              current: filteredVariable.state.options.length,
-              total: newState.options.length,
+              current: currentCount,
+              total: totalCount,
             },
           });
         }
       })
     );
 
+    // Subscribe to searchable metrics variable for current count (updates with server-side search)
+    this._subs.add(
+      searchableMetricsVariable.subscribeToState((newState, prevState) => {
+        if (!newState.loading && !prevState.loading && !areArraysEqual(newState.options, prevState.options)) {
+          // Use preserved original total, current from searchable variable
+          const totalCount = this.originalTotalCount || totalCountVariable.state.options.length;
+          this.setState({
+            counts: {
+              current: newState.options.length, // Server-side filtered count
+              total: totalCount,                // Original total preserved
+            },
+          });
+        }
+      })
+    );
+
+    // Keep filtered variable subscription for compatibility with client-side filtering
     this._subs.add(
       filteredVariable.subscribeToState((newState, prevState) => {
         if (!newState.loading && !prevState.loading && !areArraysEqual(newState.options, prevState.options)) {
+          const totalCount = this.originalTotalCount || totalCountVariable.state.options.length;
           this.setState({
             counts: {
               current: newState.options.length,
-              total: nonFilteredVariable.state.options.length,
+              total: totalCount,
             },
           });
         }

--- a/src/WingmanDataTrail/ListControls/QuickSearch/CountsProvider/MetricVariableCountsProvider.ts
+++ b/src/WingmanDataTrail/ListControls/QuickSearch/CountsProvider/MetricVariableCountsProvider.ts
@@ -1,63 +1,88 @@
 import { sceneGraph, type MultiValueVariable } from '@grafana/scenes';
 
-import { VAR_FILTERED_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
+import { VAR_DATASOURCE } from 'shared';
+import { TrueTotalService } from 'services/TrueTotalService';
 import { areArraysEqual } from 'WingmanDataTrail/MetricsVariables/helpers/areArraysEqual';
+import { VAR_CLIENT_FILTERED_METRICS } from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
 import { VAR_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
 
 import { CountsProvider } from './CountsProvider';
 
 export class MetricVariableCountsProvider extends CountsProvider {
+  private trueTotalCount: number = 0;
+
   constructor() {
     super({ key: 'MetricVariableCountsProvider' });
     this.addActivationHandler(this.onActivate.bind(this));
   }
 
   private onActivate() {
-    const nonFilteredVariable = sceneGraph.lookupVariable(VAR_METRICS_VARIABLE, this) as MultiValueVariable;
-    const filteredVariable = sceneGraph.lookupVariable(VAR_FILTERED_METRICS_VARIABLE, this) as MultiValueVariable;
+    // Use client-side filtered variable for current count (final filtered results)
+    const clientFilteredVariable = sceneGraph.lookupVariable(VAR_CLIENT_FILTERED_METRICS, this) as MultiValueVariable;
 
-    this.setInitCounts(nonFilteredVariable, filteredVariable);
+    // Load true total count once
+    this.loadTrueTotalCount();
 
+    // Subscribe to datasource changes to refresh true total
     this._subs.add(
-      nonFilteredVariable.subscribeToState((newState, prevState) => {
+      sceneGraph.findByKey(this, VAR_DATASOURCE)?.subscribeToState((newState, prevState) => {
+        if (newState.value !== prevState.value) {
+          // Datasource changed - get new true total
+          this.loadTrueTotalCount();
+        }
+      }) || (() => {})
+    );
+
+    // Subscribe to time range changes to refresh true total
+    this._subs.add(
+      sceneGraph.getTimeRange(this).subscribeToState((newState, prevState) => {
+        if (newState.value.from !== prevState.value.from || newState.value.to !== prevState.value.to) {
+          // Time range changed - get new true total
+          this.loadTrueTotalCount();
+        }
+      })
+    );
+
+    // Subscribe to client-side filtered variable for current count (final results after all filtering)
+    this._subs.add(
+      clientFilteredVariable.subscribeToState((newState, prevState) => {
         if (!areArraysEqual(newState.options, prevState.options)) {
-          this.setState({
-            counts: {
-              current: filteredVariable.state.options.length,
-              total: newState.options.length,
-            },
-          });
-        }
-      })
-    );
-
-    this._subs.add(
-      filteredVariable.subscribeToState((newState, prevState) => {
-        if (!newState.loading && !prevState.loading && !areArraysEqual(newState.options, prevState.options)) {
-          this.setState({
-            counts: {
-              current: newState.options.length,
-              total: nonFilteredVariable.state.options.length,
-            },
-          });
+          this.updateCounts(newState.options.length);
         }
       })
     );
   }
 
-  private setInitCounts(nonFilteredVariable: MultiValueVariable, filteredVariable: MultiValueVariable) {
-    const initCounts = { current: 0, total: 0 };
-
-    // We make sure the count of metrics is not 0 in a scenario where the user goes from the MetricsReducer to the MetricScene and back.
-    // Indeed, sometimes, the variables already have their options and do not load new ones.
-    if (!nonFilteredVariable.state.loading && nonFilteredVariable.state.options.length) {
-      initCounts.total = nonFilteredVariable.state.options.length;
+  /**
+   * Load the true total count using direct API calls
+   */
+  private async loadTrueTotalCount() {
+    try {
+      this.trueTotalCount = await TrueTotalService.getTrueTotalCount(this);
+      this.updateCounts();
+    } catch (error) {
+      // Fallback to current count if true total fails
+      this.trueTotalCount = 0;
     }
-
-    if (!filteredVariable.state.loading && filteredVariable.state.options.length) {
-      initCounts.current = filteredVariable.state.options.length;
-    }
-
-    this.setState({ counts: initCounts });
   }
+
+  /**
+   * Update the counts display with current count and true total
+   */
+  private updateCounts(currentCount?: number) {
+    const clientFilteredVariable = sceneGraph.lookupVariable(VAR_CLIENT_FILTERED_METRICS, this) as MultiValueVariable;
+    
+    // Current: final filtered results (server-side + client-side)
+    const current = currentCount ?? clientFilteredVariable.state.options.length;
+    // Total: unlimited count from direct API
+    const total = this.trueTotalCount || current;
+
+    this.setState({
+      counts: {
+        current,
+        total,
+      },
+    });
+  }
+
 }

--- a/src/WingmanDataTrail/ListControls/QuickSearch/CountsProvider/MetricVariableCountsProvider.ts
+++ b/src/WingmanDataTrail/ListControls/QuickSearch/CountsProvider/MetricVariableCountsProvider.ts
@@ -2,82 +2,42 @@ import { sceneGraph, type MultiValueVariable } from '@grafana/scenes';
 
 import { VAR_FILTERED_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
 import { areArraysEqual } from 'WingmanDataTrail/MetricsVariables/helpers/areArraysEqual';
-import { VAR_METRICS_VARIABLE, VAR_ORIGINAL_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
+import { VAR_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/MetricsVariable';
 
 import { CountsProvider } from './CountsProvider';
 
 export class MetricVariableCountsProvider extends CountsProvider {
-  private originalTotalCount: number = 0;
-
   constructor() {
     super({ key: 'MetricVariableCountsProvider' });
     this.addActivationHandler(this.onActivate.bind(this));
   }
 
   private onActivate() {
-    // Try to use the original metrics variable for total count (preserves original)
-    const originalMetricsVariable = sceneGraph.lookupVariable(VAR_ORIGINAL_METRICS_VARIABLE, this) as MultiValueVariable;
-    // Use the searchable metrics variable for current count (changes with server-side search)
-    const searchableMetricsVariable = sceneGraph.lookupVariable(VAR_METRICS_VARIABLE, this) as MultiValueVariable;
-    // Use the filtered variable for client-side filtering compatibility
+    const nonFilteredVariable = sceneGraph.lookupVariable(VAR_METRICS_VARIABLE, this) as MultiValueVariable;
     const filteredVariable = sceneGraph.lookupVariable(VAR_FILTERED_METRICS_VARIABLE, this) as MultiValueVariable;
 
-    // Fall back to the searchable variable if original doesn't exist (backward compatibility)
-    const totalCountVariable = originalMetricsVariable || searchableMetricsVariable;
-    
-    this.setInitCounts(totalCountVariable, filteredVariable);
+    this.setInitCounts(nonFilteredVariable, filteredVariable);
 
-    // Subscribe to the variable that provides the total count
     this._subs.add(
-      totalCountVariable.subscribeToState((newState, prevState) => {
+      nonFilteredVariable.subscribeToState((newState, prevState) => {
         if (!areArraysEqual(newState.options, prevState.options)) {
-          // Track the maximum count we've ever seen as the true total
-          // This handles the case where user starts with filters applied
-          if (newState.options.length > this.originalTotalCount) {
-            this.originalTotalCount = newState.options.length;
-          }
-          
-          // Update counts - fix the logic
-          // The searchable variable now contains the server-filtered results (current)
-          // The original total should be the maximum we've ever seen
-          const currentCount = searchableMetricsVariable.state.options.length; // Server-filtered results
-          const totalCount = this.originalTotalCount; // Maximum count ever seen
-          
           this.setState({
             counts: {
-              current: currentCount,
-              total: totalCount,
+              current: filteredVariable.state.options.length,
+              total: newState.options.length,
             },
           });
         }
       })
     );
 
-    // Subscribe to searchable metrics variable for current count (updates with server-side search)
-    this._subs.add(
-      searchableMetricsVariable.subscribeToState((newState, prevState) => {
-        if (!newState.loading && !prevState.loading && !areArraysEqual(newState.options, prevState.options)) {
-          // Use preserved original total, current from searchable variable
-          const totalCount = this.originalTotalCount || totalCountVariable.state.options.length;
-          this.setState({
-            counts: {
-              current: newState.options.length, // Server-side filtered count
-              total: totalCount,                // Original total preserved
-            },
-          });
-        }
-      })
-    );
-
-    // Keep filtered variable subscription for compatibility with client-side filtering
     this._subs.add(
       filteredVariable.subscribeToState((newState, prevState) => {
         if (!newState.loading && !prevState.loading && !areArraysEqual(newState.options, prevState.options)) {
-          const totalCount = this.originalTotalCount || totalCountVariable.state.options.length;
           this.setState({
             counts: {
               current: newState.options.length,
-              total: totalCount,
+              total: nonFilteredVariable.state.options.length,
             },
           });
         }

--- a/src/WingmanDataTrail/ListControls/QuickSearch/SearchableMetricsDataSource.ts
+++ b/src/WingmanDataTrail/ListControls/QuickSearch/SearchableMetricsDataSource.ts
@@ -1,0 +1,107 @@
+import {
+  FieldType,
+  LoadingState,
+  type DataQueryResponse,
+  type LegacyMetricFindQueryOptions,
+  type MetricFindValue,
+  type TestDataSourceResponse,
+} from '@grafana/data';
+import { RuntimeDataSource, sceneGraph, type SceneObject } from '@grafana/scenes';
+
+import { MetricDatasourceHelper } from 'helpers/MetricDatasourceHelper';
+import { isPrometheusRule } from 'WingmanDataTrail/helpers/isPrometheusRule';
+
+export class SearchableMetricsDataSource extends RuntimeDataSource {
+  static readonly uid = 'grafana-prometheus-searchable-metrics-datasource';
+
+  constructor() {
+    super(SearchableMetricsDataSource.uid, SearchableMetricsDataSource.uid);
+  }
+
+  async query(): Promise<DataQueryResponse> {
+    return {
+      state: LoadingState.Done,
+      data: [
+        {
+          name: 'Metrics',
+          fields: [
+            {
+              name: null,
+              type: FieldType.other,
+              values: [],
+              config: {},
+            },
+          ],
+          length: 0,
+        },
+      ],
+    };
+  }
+
+  async metricFindQuery(query: string, options: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
+    const sceneObject = options.scopedVars?.__sceneObject?.valueOf() as SceneObject;
+
+    const ds = await MetricDatasourceHelper.getPrometheusDataSourceForScene(sceneObject);
+    if (!ds) {
+      return [];
+    }
+
+    const timeRange = sceneGraph.getTimeRange(sceneObject).state.value;
+    let metricsList: string[] = [];
+
+    // Parse the search pattern from query (format: "searchPattern")
+    const removeRules = query.includes('removeRules');
+    const searchPattern = removeRules ? query.replace('removeRules', '') : query;
+
+    // Build matcher for Prometheus API - this is the key part!
+    const matcher = this.buildPrometheusMatcherWithSearch(searchPattern, sceneObject);
+
+    // Use the MetricDatasourceHelper which correctly calls the Prometheus API
+    metricsList = await MetricDatasourceHelper.fetchLabelValues({
+      ds,
+      labelName: '__name__',
+      matcher, // This becomes the match[] parameter
+      timeRange,
+    });
+
+    if (removeRules) {
+      metricsList = metricsList.filter((metricName) => !isPrometheusRule(metricName));
+    }
+
+    return metricsList.map((metricName) => ({ value: metricName, text: metricName }));
+  }
+
+  async testDatasource(): Promise<TestDataSourceResponse> {
+    return {
+      status: 'success',
+      message: 'OK',
+    };
+  }
+
+  /**
+   * Build the Prometheus matcher that includes both search pattern and existing filters
+   * This follows the same pattern as MetricsWithLabelValueDataSource
+   */
+  private buildPrometheusMatcherWithSearch(searchPattern: string, sceneObject: SceneObject): string {
+    // Get existing filters from the adhoc variable (like original code does)
+    const filtersExpr = sceneGraph.interpolate(sceneObject, '${filters}', {});
+    
+    if (!searchPattern || !searchPattern.trim()) {
+      // No search - return the filters expression wrapped in braces (same as original MetricsVariable)
+      return filtersExpr ? `{${filtersExpr}}` : '';
+    }
+
+    // Escape regex special characters
+    const escapedPattern = searchPattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const nameFilter = `__name__=~".*${escapedPattern}.*"`;
+
+    if (!filtersExpr || filtersExpr.trim() === '') {
+      // Only search pattern, no existing filters - wrap in braces
+      return `{${nameFilter}}`;
+    }
+
+    // Combine search pattern with existing filters - wrap in braces
+    // This creates: {__name__=~"pattern",existing_filters}
+    return `{${nameFilter},${filtersExpr}}`;
+  }
+}

--- a/src/WingmanDataTrail/MetricsList/WithUsageDataPreviewPanel.tsx
+++ b/src/WingmanDataTrail/MetricsList/WithUsageDataPreviewPanel.tsx
@@ -17,7 +17,7 @@ import {
   type SortingOption,
 } from 'WingmanDataTrail/ListControls/MetricsSorter/MetricsSorter';
 import { MetricsReducer } from 'WingmanDataTrail/MetricsReducer';
-import { VAR_FILTERED_METRICS_VARIABLE } from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
+import { VAR_CLIENT_FILTERED_METRICS } from 'WingmanDataTrail/MetricsVariables/FilteredMetricsVariable';
 
 import { UsageData } from './UsageData';
 
@@ -61,7 +61,7 @@ export class WithUsageDataPreviewPanel extends SceneObjectBase<WithUsageDataPrev
       return;
     }
 
-    const filteredMetricsEngine = metricsReducer.state.enginesMap.get(VAR_FILTERED_METRICS_VARIABLE);
+    const filteredMetricsEngine = metricsReducer.state.enginesMap.get(VAR_CLIENT_FILTERED_METRICS);
     if (!filteredMetricsEngine) {
       return;
     }

--- a/src/WingmanDataTrail/MetricsVariables/MetricsVariable.ts
+++ b/src/WingmanDataTrail/MetricsVariables/MetricsVariable.ts
@@ -2,9 +2,9 @@ import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
 import { QueryVariable, type SceneObjectState } from '@grafana/scenes';
 
 import { trailDS, VAR_FILTERS } from 'shared';
+import { SearchableMetricsDataSource } from 'WingmanDataTrail/ListControls/QuickSearch/SearchableMetricsDataSource';
 
 export const VAR_METRICS_VARIABLE = 'metrics-wingman';
-export const VAR_ORIGINAL_METRICS_VARIABLE = 'original-metrics-wingman';
 
 export type MetricOptions = Array<{ label: string; value: string }>;
 
@@ -15,14 +15,17 @@ interface MetricsVariableState extends SceneObjectState {
 }
 
 export class MetricsVariable extends QueryVariable {
+  private isSearching: boolean = false;
+  private currentSearchText: string = '';
+
   constructor(state?: MetricsVariableState) {
     super({
       key: VAR_METRICS_VARIABLE,
       name: VAR_METRICS_VARIABLE,
       label: 'Metrics',
       ...state,
-      datasource: trailDS,
-      query: `label_values({$${VAR_FILTERS}}, __name__)`,
+      datasource: trailDS, // Start with normal datasource
+      query: `label_values({$${VAR_FILTERS}}, __name__)`, // Start with normal query
       includeAll: true,
       value: '$__all',
       skipUrlSync: true,
@@ -30,126 +33,36 @@ export class MetricsVariable extends QueryVariable {
       sort: VariableSort.alphabeticalAsc,
       hide: VariableHide.hideVariable,
     });
-  }
-}
 
-// New variable that maintains the original total count
-export class OriginalMetricsVariable extends QueryVariable {
-  constructor(state?: MetricsVariableState) {
-    super({
-      key: VAR_ORIGINAL_METRICS_VARIABLE,
-      name: VAR_ORIGINAL_METRICS_VARIABLE,
-      label: 'Original Metrics',
-      ...state,
-      datasource: trailDS,
-      query: `label_values({$${VAR_FILTERS}}, __name__)`,
-      includeAll: true,
-      value: '$__all',
-      skipUrlSync: true,
-      refresh: VariableRefresh.onTimeRangeChanged,
-      sort: VariableSort.alphabeticalAsc,
-      hide: VariableHide.hideVariable,
-    });
-  }
-}
-
-// Enhanced variable that can update its query for server-side search
-export class SearchableMetricsVariable extends MetricsVariable {
-  private baseQuery: string;
-
-  constructor(state?: MetricsVariableState) {
-    super(state);
-    this.baseQuery = `label_values({$${VAR_FILTERS}}, __name__)`;
   }
 
   /**
-   * Update the query to include search filter and refresh the variable
-   * @param searchText - The text to search for in metric names
+   * Update the variable's datasource and query based on search state
+   * This is the proper Scenes way - switch datasource based on behavior needed
    */
-  public updateSearchQuery(searchText: string) {
-    let newQuery: string;
+  public updateSearchState(searchText: string) {
+    const hasSearch = searchText && searchText.trim();
+    const searchChanged = this.currentSearchText !== searchText;
     
-    if (searchText && searchText.trim()) {
-      // Escape regex special characters in search text
-      const escapedSearch = this.escapeRegex(searchText.trim());
+    this.currentSearchText = searchText;
+
+    if (hasSearch && (!this.isSearching || searchChanged)) {
+      // Switch to search datasource for server-side filtering
+      this.isSearching = true;
+      this.setState({
+        datasource: { uid: SearchableMetricsDataSource.uid },
+        query: searchText.trim(), // Pass search text as query
+      });
+      this.refreshOptions();
       
-      // The issue is that when $filters is empty, we get invalid syntax like {, __name__=~"pattern"}
-      // We need to build the query more carefully
-      
-      // Option 1: Use a conditional approach in the query itself
-      // We'll modify the base query to include the name filter
-      // The trick is to ensure we don't create invalid PromQL when filters is empty
-      
-      // Instead of trying to combine with existing filters, let's use a different approach:
-      // Use the series endpoint with a proper matcher that includes both filters and name pattern
-      
-      // Build the query using the same pattern but with additional name filtering
-      // This should work: label_values({__name__=~"pattern",$filters}, __name__)
-      // The order matters - putting __name__ first should work even if $filters is empty
-      
-      // Use the correct Prometheus API approach with match[] parameter
-      // According to Prometheus documentation, the /api/v1/label/__name__/values endpoint
-      // supports match[] parameter to filter the results
-      // 
-      // We need to construct the query so that Grafana's Prometheus datasource
-      // will use the fetchSeriesValuesWithMatch method which adds the match[] parameter
-      // 
-      // The pattern should be: label_values({match_expression}, __name__)
-      // where match_expression becomes the match[] parameter
-      
-      // Build a matcher that includes both the name pattern and existing filters
-      const namePattern = `__name__=~".*${escapedSearch}.*"`;
-      
-      // Handle empty filters properly by checking if we should include them
-      // We'll use a conditional approach to avoid trailing commas
-      const filtersExpr = `$${VAR_FILTERS}`;
-      
-      // We need to include both the name pattern AND existing filters
-      // The challenge is handling the case where $filters might be empty
-      // 
-      // Solution: Use a conditional template that handles empty filters gracefully
-      // We'll use the :raw modifier and a conditional structure
-      
-      // Construct the query to include both name pattern and existing filters
-      // Use a different approach: let's try using variable expansion with :raw modifier
-      // and see if Grafana handles empty variables gracefully
-      
-      // Use a more robust approach: modify the base query pattern
-      // Instead of trying to combine in the selector, let's use the existing pattern
-      // and modify how the filters variable is constructed
-      
-      // The key insight: we need to ensure the search pattern is included in the $filters
-      // But since we can't modify the adhoc filters variable directly, let's try a different approach
-      
-      // For now, let's include both but handle the comma issue by using a conditional approach
-      // We'll construct it so that if $filters is empty, we don't add the comma
-      
-      // Simplest approach: always include both and trust Grafana's variable interpolation
-      // The original query works with {$filters}, so {__name__=~"pattern",$filters} should work too
-      // If $filters is empty, Grafana should handle it gracefully
-      
-      newQuery = `label_values({__name__=~".*${escapedSearch}.*",$${VAR_FILTERS}}, __name__)`;
-    } else {
-      // Default query when no search
-      newQuery = this.baseQuery;
-    }
-    
-    // Only update if query actually changed to avoid unnecessary API calls
-    if (this.state.query !== newQuery) {
-      this.setState({ query: newQuery });
-      
-      // Trigger variable refresh using the QueryVariable method
+    } else if (!hasSearch && this.isSearching) {
+      // Switch back to normal datasource for all metrics
+      this.isSearching = false;
+      this.setState({
+        datasource: trailDS,
+        query: `label_values({$${VAR_FILTERS}}, __name__)`,
+      });
       this.refreshOptions();
     }
-  }
-
-
-  /**
-   * Escape regex special characters in search text
-   * @param text - The text to escape
-   * @returns Escaped text safe for regex
-   */
-  private escapeRegex(text: string): string {
-    return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 }

--- a/src/WingmanDataTrail/MetricsVariables/MetricsVariable.ts
+++ b/src/WingmanDataTrail/MetricsVariables/MetricsVariable.ts
@@ -4,6 +4,7 @@ import { QueryVariable, type SceneObjectState } from '@grafana/scenes';
 import { trailDS, VAR_FILTERS } from 'shared';
 
 export const VAR_METRICS_VARIABLE = 'metrics-wingman';
+export const VAR_ORIGINAL_METRICS_VARIABLE = 'original-metrics-wingman';
 
 export type MetricOptions = Array<{ label: string; value: string }>;
 
@@ -29,5 +30,126 @@ export class MetricsVariable extends QueryVariable {
       sort: VariableSort.alphabeticalAsc,
       hide: VariableHide.hideVariable,
     });
+  }
+}
+
+// New variable that maintains the original total count
+export class OriginalMetricsVariable extends QueryVariable {
+  constructor(state?: MetricsVariableState) {
+    super({
+      key: VAR_ORIGINAL_METRICS_VARIABLE,
+      name: VAR_ORIGINAL_METRICS_VARIABLE,
+      label: 'Original Metrics',
+      ...state,
+      datasource: trailDS,
+      query: `label_values({$${VAR_FILTERS}}, __name__)`,
+      includeAll: true,
+      value: '$__all',
+      skipUrlSync: true,
+      refresh: VariableRefresh.onTimeRangeChanged,
+      sort: VariableSort.alphabeticalAsc,
+      hide: VariableHide.hideVariable,
+    });
+  }
+}
+
+// Enhanced variable that can update its query for server-side search
+export class SearchableMetricsVariable extends MetricsVariable {
+  private baseQuery: string;
+
+  constructor(state?: MetricsVariableState) {
+    super(state);
+    this.baseQuery = `label_values({$${VAR_FILTERS}}, __name__)`;
+  }
+
+  /**
+   * Update the query to include search filter and refresh the variable
+   * @param searchText - The text to search for in metric names
+   */
+  public updateSearchQuery(searchText: string) {
+    let newQuery: string;
+    
+    if (searchText && searchText.trim()) {
+      // Escape regex special characters in search text
+      const escapedSearch = this.escapeRegex(searchText.trim());
+      
+      // The issue is that when $filters is empty, we get invalid syntax like {, __name__=~"pattern"}
+      // We need to build the query more carefully
+      
+      // Option 1: Use a conditional approach in the query itself
+      // We'll modify the base query to include the name filter
+      // The trick is to ensure we don't create invalid PromQL when filters is empty
+      
+      // Instead of trying to combine with existing filters, let's use a different approach:
+      // Use the series endpoint with a proper matcher that includes both filters and name pattern
+      
+      // Build the query using the same pattern but with additional name filtering
+      // This should work: label_values({__name__=~"pattern",$filters}, __name__)
+      // The order matters - putting __name__ first should work even if $filters is empty
+      
+      // Use the correct Prometheus API approach with match[] parameter
+      // According to Prometheus documentation, the /api/v1/label/__name__/values endpoint
+      // supports match[] parameter to filter the results
+      // 
+      // We need to construct the query so that Grafana's Prometheus datasource
+      // will use the fetchSeriesValuesWithMatch method which adds the match[] parameter
+      // 
+      // The pattern should be: label_values({match_expression}, __name__)
+      // where match_expression becomes the match[] parameter
+      
+      // Build a matcher that includes both the name pattern and existing filters
+      const namePattern = `__name__=~".*${escapedSearch}.*"`;
+      
+      // Handle empty filters properly by checking if we should include them
+      // We'll use a conditional approach to avoid trailing commas
+      const filtersExpr = `$${VAR_FILTERS}`;
+      
+      // We need to include both the name pattern AND existing filters
+      // The challenge is handling the case where $filters might be empty
+      // 
+      // Solution: Use a conditional template that handles empty filters gracefully
+      // We'll use the :raw modifier and a conditional structure
+      
+      // Construct the query to include both name pattern and existing filters
+      // Use a different approach: let's try using variable expansion with :raw modifier
+      // and see if Grafana handles empty variables gracefully
+      
+      // Use a more robust approach: modify the base query pattern
+      // Instead of trying to combine in the selector, let's use the existing pattern
+      // and modify how the filters variable is constructed
+      
+      // The key insight: we need to ensure the search pattern is included in the $filters
+      // But since we can't modify the adhoc filters variable directly, let's try a different approach
+      
+      // For now, let's include both but handle the comma issue by using a conditional approach
+      // We'll construct it so that if $filters is empty, we don't add the comma
+      
+      // Simplest approach: always include both and trust Grafana's variable interpolation
+      // The original query works with {$filters}, so {__name__=~"pattern",$filters} should work too
+      // If $filters is empty, Grafana should handle it gracefully
+      
+      newQuery = `label_values({__name__=~".*${escapedSearch}.*",$${VAR_FILTERS}}, __name__)`;
+    } else {
+      // Default query when no search
+      newQuery = this.baseQuery;
+    }
+    
+    // Only update if query actually changed to avoid unnecessary API calls
+    if (this.state.query !== newQuery) {
+      this.setState({ query: newQuery });
+      
+      // Trigger variable refresh using the QueryVariable method
+      this.refreshOptions();
+    }
+  }
+
+
+  /**
+   * Escape regex special characters in search text
+   * @param text - The text to escape
+   * @returns Escaped text safe for regex
+   */
+  private escapeRegex(text: string): string {
+    return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 }

--- a/src/services/TrueTotalService.ts
+++ b/src/services/TrueTotalService.ts
@@ -1,0 +1,159 @@
+import { getBackendSrv, getDataSourceSrv, type BackendSrvRequest } from '@grafana/runtime';
+import { sceneGraph, type SceneObject } from '@grafana/scenes';
+
+import { VAR_DATASOURCE } from 'shared';
+import { logger } from 'tracking/logger/logger';
+
+interface TrueTotalCache {
+  [key: string]: {
+    count: number;
+    timestamp: number;
+    timeRange: string;
+  };
+}
+
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes cache
+const REQUEST_OPTIONS: Partial<BackendSrvRequest> = {
+  showSuccessAlert: false,
+  showErrorAlert: false,
+} as const;
+
+/**
+ * Service to get unlimited metric counts via direct Prometheus API calls.
+ * Bypasses Grafana's series limits to show true total available metrics.
+ */
+export class TrueTotalService {
+  private static cache: TrueTotalCache = {};
+
+  /**
+   * Get the true total count of metrics from Prometheus directly
+   * @param sceneObject - Scene object to get datasource and time range from
+   * @returns Promise that resolves to the total count of available metrics
+   */
+  public static async getTrueTotalCount(sceneObject: SceneObject): Promise<number> {
+    try {
+      // Get datasource UID
+      const dsVariable = sceneGraph.findByKey(sceneObject, VAR_DATASOURCE);
+      const dsUid = dsVariable?.state.value as string;
+      
+      if (!dsUid) {
+        logger.warn('TrueTotalService: No datasource UID found');
+        return 0;
+      }
+
+      // Get time range for cache key
+      const timeRange = sceneGraph.getTimeRange(sceneObject).state.value;
+      const timeRangeKey = `${timeRange.from}-${timeRange.to}`;
+      const cacheKey = `${dsUid}-${timeRangeKey}`;
+
+      // Check cache first
+      const cached = this.cache[cacheKey];
+      if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+        return cached.count;
+      }
+
+      // Make direct API call to Prometheus via Grafana's datasource proxy
+      // This bypasses Grafana's series limits by calling the API directly
+      const response = await getBackendSrv().get<any>(
+        `/api/datasources/uid/${dsUid}/resources/api/v1/label/__name__/values`,
+        {
+          start: this.convertTimeToUnixTimestamp(timeRange.from),
+          end: this.convertTimeToUnixTimestamp(timeRange.to),
+          // No match[] parameter means get ALL metric names without limits
+        },
+        `grafana-metricsdrilldown-true-total-${dsUid}`,
+        REQUEST_OPTIONS
+      );
+
+      // Extract metric names from response
+      const metricNames = Array.isArray(response) ? response : response.data || [];
+      const totalCount = metricNames.length;
+
+      // Cache the result
+      this.cache[cacheKey] = {
+        count: totalCount,
+        timestamp: Date.now(),
+        timeRange: timeRangeKey,
+      };
+
+      logger.info(`TrueTotalService: Got ${totalCount} total metrics from ${dsUid}`);
+      return totalCount;
+
+    } catch (error) {
+      logger.error('TrueTotalService: Failed to fetch true total count', error);
+      return 0;
+    }
+  }
+
+  /**
+   * Clear the cache for a specific datasource or all caches
+   * @param dsUid - Optional datasource UID to clear, if not provided clears all
+   */
+  public static clearCache(dsUid?: string) {
+    if (dsUid) {
+      // Clear cache entries for specific datasource
+      Object.keys(this.cache).forEach(key => {
+        if (key.startsWith(dsUid)) {
+          delete this.cache[key];
+        }
+      });
+    } else {
+      // Clear all cache
+      this.cache = {};
+    }
+  }
+
+  /**
+   * Convert Grafana time format to Unix timestamp
+   * @param time - Grafana time value (could be string, DateTime, or number)
+   * @returns Unix timestamp in seconds
+   */
+  private static convertTimeToUnixTimestamp(time: any): number {
+    // Handle different time format types that Grafana uses
+    
+    // If it's already a number (Unix timestamp), convert to seconds if needed
+    if (typeof time === 'number') {
+      // If it looks like milliseconds (> year 2000 in seconds), convert to seconds
+      return time > 946684800 ? Math.floor(time / 1000) : time;
+    }
+    
+    // If it's a DateTime object with valueOf method
+    if (time && typeof time.valueOf === 'function') {
+      return Math.floor(time.valueOf() / 1000);
+    }
+    
+    // If it's a string
+    if (typeof time === 'string') {
+      if (time === 'now') {
+        return Math.floor(Date.now() / 1000);
+      }
+      
+      // Handle relative times like "now-1h"
+      if (time.startsWith('now-')) {
+        const now = Date.now();
+        const duration = time.substring(4); // Remove "now-"
+        
+        // Simple parsing for common cases
+        if (duration.endsWith('h')) {
+          const hours = parseInt(duration);
+          return Math.floor((now - hours * 60 * 60 * 1000) / 1000);
+        }
+        if (duration.endsWith('d')) {
+          const days = parseInt(duration);
+          return Math.floor((now - days * 24 * 60 * 60 * 1000) / 1000);
+        }
+      }
+      
+      // Try to parse as ISO date
+      try {
+        return Math.floor(new Date(time).getTime() / 1000);
+      } catch {
+        // Fallback to current time
+        return Math.floor(Date.now() / 1000);
+      }
+    }
+    
+    // Fallback to current time
+    return Math.floor(Date.now() / 1000);
+  }
+}


### PR DESCRIPTION
# What is this? ✨  

Server-Side quick search that does not limit customers who have more metrics that the Prometheus series limit configuration. [See this slack thread for more context](https://raintank-corp.slack.com/archives/C075BDBTX96/p1756999294441589)

**[WIP] - Work in Progress - Proof of Concept**

## Overview
Implements server-side search to enable searching across all available metrics instead of being limited by Prometheus datasource series limit configuration. Users can now search through the complete metric catalog while maintaining UI performance.

## Implementation

### Two-Layer Filtering Architecture:
- **Server-Side Layer**: Quick search + adhoc filters processed by Prometheus API
- **Client-Side Layer**: Sidebar filters (rules, prefixes, suffixes) applied to server results  
- **BONUS ✨  True Metric Count System**: Final filtered count / unlimited total from direct API 

### Key Components:
- **MetricsVariable**: Always uses SearchableMetricsDataSource for server-side processing
- **SearchableMetricsDataSource**: Handles search patterns + adhoc filters via `match[]` parameter
- **ClientSideFilteredMetricsVariable**: Applies sidebar filters to server results
- **TrueTotalService**: Direct Prometheus API calls for unlimited metric counts

### Filter Flow
```
User Input → Server-Side Filtering → Client-Side Filtering → Display
      ↓                               ↓                                   ↓
Quick Search      Adhoc Filters                Sidebar Filters
All metrics             (Env, labels)           (Rules, prefixes, suffixes)
searchable
```

## Test Scenarios

### Page Load Tests:
- Clean load → Shows first 100 metrics with correct total count
- Load with search term → Shows filtered results matching search pattern
- Load with adhoc filters → Shows metrics matching label filters
- Load with sidebar filters → Shows client-filtered results from server data

### User Interaction Tests:
- Add search term → Results filter to matching metrics across all available
- Add adhoc filter → Results filter further with server-side processing  
- Add sidebar filter → Results filter with client-side processing
- Remove filters → Results expand as filters are removed

### Count Validation:
- Current count reflects final filtered results (server + client layers)
- Total count shows unlimited metrics (bypasses series limit)
- Format: "current/total" (e.g., "45/676")

## ⚠️ Breaking Changes
- `FilteredMetricsVariable` renamed to `ClientSideFilteredMetricsVariable`
- `MetricsVariable` always uses server-side datasource
- Sidebar filter counts simplified for new architecture

## Benefits
- **Searchability**: All metrics searchable, not just first batch
- **Performance**: Display still limited for UI responsiveness
- **Accuracy**: True total counts via direct API
- **Compatibility**: Existing sidebar filters preserved

---
**Status**: Proof of Concept - needs further testing and refinement  
**Next Steps**: Additional testing, edge case validation, performance optimization, e2e tests, fix all the tests this will break 😭 