### PR TITLE
fix(Breakdown): Remove "le label from options

### DIFF
--- a/src/Breakdown/GroupByVariable.tsx
+++ b/src/Breakdown/GroupByVariable.tsx
@@ -31,7 +31,6 @@ export class GroupByVariable extends QueryVariable {
     this.subscribeToState((newState, prevState) => {
       if (newState.value && newState.value !== prevState.value) {
         reportExploreMetrics('groupby_label_changed', { label: String(newState.value) });
-        return;
       }
 
       if (newState.options !== prevState.options && newState.options.find((o) => o.value === 'le')) {


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** relates to https://github.com/grafana/metrics-drilldown/pull/652

https://github.com/grafana/metrics-drilldown/pull/652 introduced the filtering for "le" labels in the "Breakdown" tab but a small bug was also introduced. This PR fixes it.

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The build should pass and the "le" label should never show up for classic histograms.
