### PR TITLE
perf(MetricGraphScene): Render main viz panel earlier

### DIFF
--- a/src/GmdVizPanel/GmdVizPanel.tsx
+++ b/src/GmdVizPanel/GmdVizPanel.tsx
@@ -178,7 +178,10 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
         }
 
         if (dataFrameType === DataFrameType.HeatmapCells) {
-          this.setState({ panelConfig: { description: 'Native Histogram ', ...panelConfig, type: 'heatmap' } });
+          this.setState({
+            histogramType: 'native',
+            panelConfig: { description: 'Native Histogram ', ...panelConfig, type: 'heatmap' },
+          });
         }
 
         bodySub.unsubscribe();

--- a/src/MetricGraphScene.tsx
+++ b/src/MetricGraphScene.tsx
@@ -5,8 +5,8 @@ import {
   behaviors,
   SceneFlexItem,
   SceneFlexLayout,
+  sceneGraph,
   SceneObjectBase,
-  SceneReactObject,
   type SceneComponentProps,
   type SceneObject,
   type SceneObjectState,
@@ -39,18 +39,30 @@ interface MetricGraphSceneState extends SceneObjectState {
 }
 
 export class MetricGraphScene extends SceneObjectBase<MetricGraphSceneState> {
-  public constructor(state: { metric: MetricGraphSceneState['metric'] }) {
+  public constructor({ metric }: { metric: MetricGraphSceneState['metric'] }) {
     super({
-      metric: state.metric,
+      metric,
       topView: new SceneFlexLayout({
         direction: 'column',
         $behaviors: [new behaviors.CursorSync({ key: 'metricCrosshairSync', sync: DashboardCursorSync.Crosshair })],
         children: [
-          // prevent height flicker when landing
           new SceneFlexItem({
             minHeight: MAIN_PANEL_MIN_HEIGHT,
             maxHeight: MAIN_PANEL_MAX_HEIGHT,
-            body: new SceneReactObject({ reactNode: <div /> }),
+            body: new GmdVizPanel({
+              key: TOPVIEW_PANEL_KEY,
+              metric,
+              panelOptions: {
+                height: PANEL_HEIGHT.XL,
+                headerActions: isClassicHistogramMetric(metric)
+                  ? () => [new GmdVizPanelVariantSelector({ metric }), new ConfigurePanelAction({ metric })]
+                  : () => [new ConfigurePanelAction({ metric })],
+                menu: () => new PanelMenu({ labelName: metric }),
+              },
+              queryOptions: {
+                resolution: QUERY_RESOLUTION.HIGH,
+              },
+            }),
           }),
           new SceneFlexItem({
             ySizing: 'content',
@@ -67,39 +79,30 @@ export class MetricGraphScene extends SceneObjectBase<MetricGraphSceneState> {
   }
 
   private async onActivate() {
-    const { metric, topView } = this.state;
-    const trail = getTrailFor(this);
-    const metadata = await trail.getMetadataForMetric(metric);
-    const description = getMetricDescription(metadata);
-    const isHistogram = isClassicHistogramMetric(metric) || (await trail.isNativeHistogram(metric));
+    const { metric } = this.state;
+    const [gmdVizPanel] = sceneGraph.findDescendents(this, GmdVizPanel);
 
-    topView.setState({
-      children: [
-        new SceneFlexItem({
-          minHeight: MAIN_PANEL_MIN_HEIGHT,
-          maxHeight: MAIN_PANEL_MAX_HEIGHT,
-          body: new GmdVizPanel({
-            key: TOPVIEW_PANEL_KEY,
-            metric,
-            panelOptions: {
-              height: PANEL_HEIGHT.XL,
-              description,
-              headerActions: isHistogram
-                ? () => [new GmdVizPanelVariantSelector({ metric }), new ConfigurePanelAction({ metric })]
-                : () => [new ConfigurePanelAction({ metric })],
-              menu: () => new PanelMenu({ labelName: metric }),
-            },
-            queryOptions: {
-              resolution: QUERY_RESOLUTION.HIGH,
-            },
-          }),
-        }),
-        new SceneFlexItem({
-          ySizing: 'content',
-          body: new MetricActionBar({}),
-        }),
-      ],
+    if (gmdVizPanel.state.histogramType === 'classic') {
+      return;
+    }
+
+    const sub = gmdVizPanel.subscribeToState(async (newState) => {
+      if (newState.histogramType === 'native') {
+        sub.unsubscribe();
+
+        const metadata = await getTrailFor(this).getMetadataForMetric(metric);
+
+        gmdVizPanel.update(
+          {
+            description: getMetricDescription(metadata),
+            headerActions: () => [new GmdVizPanelVariantSelector({ metric }), new ConfigurePanelAction({ metric })],
+          },
+          {}
+        );
+      }
     });
+
+    this._subs.add(sub);
   }
 
   public static readonly Component = ({ model }: SceneComponentProps<MetricGraphScene>) => {


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR ensures that the main viz panel of  the `MetricScene` is rendered faster. Indeed, before this PR, `MetricGraphScene` was waiting for:
1. the metric metadata to be fetched, so that the description of the viz panel could be updated
2. checking if the metric was a native histogram or not, so that the variant selector (percentiles/heatmap) could be added to the viz panel header actions

### 📖 Summary of the changes

The improvement is done by listening to any `GmdVizPanel` state updates, and checking if there's a change of opanel type from non-histogram to native histogram.

### 🧪 How to test?

- The build should pass
