### PR TITLE
feat(BreakdownTab): Apply user config on all panels

### DIFF
--- a/src/Breakdown/MetricLabelsList/behaviors/publishTimeseriesData.ts
+++ b/src/Breakdown/MetricLabelsList/behaviors/publishTimeseriesData.ts
@@ -5,10 +5,14 @@ import { EventTimeseriesDataReceived } from '../events/EventTimeseriesDataReceiv
 
 /**
  * Publishes timeseries data events when new data arrives from the VizPanel data provider.
- * These events are used by other behaviors like syncYAxis to coordinate updates across multiple panels.
+ * These events are used by the syncYAxis behaviour to coordinate updates across multiple panels.
  */
 export function publishTimeseriesData() {
   return (vizPanel: VizPanel) => {
+    if (vizPanel.state.pluginId !== 'timeseries') {
+      return;
+    }
+
     let $data = sceneGraph.getData(vizPanel);
     if ($data instanceof SceneDataTransformer) {
       $data = $data.state.$data as SceneDataProvider;
@@ -29,8 +33,13 @@ export function publishTimeseriesData() {
       if (
         newState.data?.state === LoadingState.Done &&
         newState.data.series?.length &&
-        newState.data?.series !== prevState.data?.series
+        newState.data.series !== prevState.data?.series
       ) {
+        const dataFrameType = newState.data.series[0].meta?.type;
+        if (dataFrameType && !dataFrameType.startsWith('timeseries')) {
+          return;
+        }
+
         vizPanel.publishEvent(
           new EventTimeseriesDataReceived({
             panelKey: vizPanel.state.key as string,

--- a/src/GmdVizPanel/GmdVizPanel.tsx
+++ b/src/GmdVizPanel/GmdVizPanel.tsx
@@ -178,7 +178,10 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
         }
 
         if (dataFrameType === DataFrameType.HeatmapCells) {
-          this.setState({ panelConfig: { description: 'Native Histogram ', ...panelConfig, type: 'heatmap' } });
+          this.setState({
+            histogramType: 'native',
+            panelConfig: { description: 'Native Histogram ', ...panelConfig, type: 'heatmap' },
+          });
         }
 
         bodySub.unsubscribe();

--- a/src/GmdVizPanel/types/percentiles/buildPercentilesPanel.ts
+++ b/src/GmdVizPanel/types/percentiles/buildPercentilesPanel.ts
@@ -49,5 +49,6 @@ export function buildPercentilesPanel(options: PercentilesPanelOptions) {
         });
       });
     })
+    .setBehaviors(panelConfig.behaviors || [])
     .build();
 }

--- a/src/MetricGraphScene.tsx
+++ b/src/MetricGraphScene.tsx
@@ -5,8 +5,8 @@ import {
   behaviors,
   SceneFlexItem,
   SceneFlexLayout,
+  sceneGraph,
   SceneObjectBase,
-  SceneReactObject,
   type SceneComponentProps,
   type SceneObject,
   type SceneObjectState,
@@ -39,18 +39,30 @@ interface MetricGraphSceneState extends SceneObjectState {
 }
 
 export class MetricGraphScene extends SceneObjectBase<MetricGraphSceneState> {
-  public constructor(state: { metric: MetricGraphSceneState['metric'] }) {
+  public constructor({ metric }: { metric: MetricGraphSceneState['metric'] }) {
     super({
-      metric: state.metric,
+      metric,
       topView: new SceneFlexLayout({
         direction: 'column',
         $behaviors: [new behaviors.CursorSync({ key: 'metricCrosshairSync', sync: DashboardCursorSync.Crosshair })],
         children: [
-          // prevent height flicker when landing
           new SceneFlexItem({
             minHeight: MAIN_PANEL_MIN_HEIGHT,
             maxHeight: MAIN_PANEL_MAX_HEIGHT,
-            body: new SceneReactObject({ reactNode: <div /> }),
+            body: new GmdVizPanel({
+              key: TOPVIEW_PANEL_KEY,
+              metric,
+              panelOptions: {
+                height: PANEL_HEIGHT.XL,
+                headerActions: isClassicHistogramMetric(metric)
+                  ? () => [new GmdVizPanelVariantSelector({ metric }), new ConfigurePanelAction({ metric })]
+                  : () => [new ConfigurePanelAction({ metric })],
+                menu: () => new PanelMenu({ labelName: metric }),
+              },
+              queryOptions: {
+                resolution: QUERY_RESOLUTION.HIGH,
+              },
+            }),
           }),
           new SceneFlexItem({
             ySizing: 'content',
@@ -67,39 +79,30 @@ export class MetricGraphScene extends SceneObjectBase<MetricGraphSceneState> {
   }
 
   private async onActivate() {
-    const { metric, topView } = this.state;
-    const trail = getTrailFor(this);
-    const metadata = await trail.getMetadataForMetric(metric);
-    const description = getMetricDescription(metadata);
-    const isHistogram = isClassicHistogramMetric(metric) || (await trail.isNativeHistogram(metric));
+    const { metric } = this.state;
+    const [gmdVizPanel] = sceneGraph.findDescendents(this, GmdVizPanel);
 
-    topView.setState({
-      children: [
-        new SceneFlexItem({
-          minHeight: MAIN_PANEL_MIN_HEIGHT,
-          maxHeight: MAIN_PANEL_MAX_HEIGHT,
-          body: new GmdVizPanel({
-            key: TOPVIEW_PANEL_KEY,
-            metric,
-            panelOptions: {
-              height: PANEL_HEIGHT.XL,
-              description,
-              headerActions: isHistogram
-                ? () => [new GmdVizPanelVariantSelector({ metric }), new ConfigurePanelAction({ metric })]
-                : () => [new ConfigurePanelAction({ metric })],
-              menu: () => new PanelMenu({ labelName: metric }),
-            },
-            queryOptions: {
-              resolution: QUERY_RESOLUTION.HIGH,
-            },
-          }),
-        }),
-        new SceneFlexItem({
-          ySizing: 'content',
-          body: new MetricActionBar({}),
-        }),
-      ],
+    if (gmdVizPanel.state.histogramType === 'classic') {
+      return;
+    }
+
+    const sub = gmdVizPanel.subscribeToState(async (newState) => {
+      if (newState.histogramType === 'native') {
+        sub.unsubscribe();
+
+        const metadata = await getTrailFor(this).getMetadataForMetric(metric);
+
+        gmdVizPanel.update(
+          {
+            description: getMetricDescription(metadata),
+            headerActions: () => [new GmdVizPanelVariantSelector({ metric }), new ConfigurePanelAction({ metric })],
+          },
+          {}
+        );
+      }
     });
+
+    this._subs.add(sub);
   }
 
   public static readonly Component = ({ model }: SceneComponentProps<MetricGraphScene>) => {

--- a/src/MetricGraphScene.tsx
+++ b/src/MetricGraphScene.tsx
@@ -86,8 +86,8 @@ export class MetricGraphScene extends SceneObjectBase<MetricGraphSceneState> {
       return;
     }
 
-    const sub = gmdVizPanel.subscribeToState(async (newState) => {
-      if (newState.histogramType === 'native') {
+    const sub = gmdVizPanel.subscribeToState(async (newState, prevState) => {
+      if (prevState.histogramType !== 'native' && newState.histogramType === 'native') {
         sub.unsubscribe();
 
         const metadata = await getTrailFor(this).getMetadataForMetric(metric);


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** is a follow-up of https://github.com/grafana/metrics-drilldown/pull/613/

This PR applies the preferred configuration of the user after they select a label

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The build with the new E2E tests should pass
