### PR TITLE
fix(DataTrail): Set URL search parameters namespace when the app/components are embedded

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,7 @@ export function newMetricsTrail(state?: Partial<DataTrailState>): DataTrail {
     initialDS: state?.initialDS,
     $timeRange: state?.$timeRange ?? new SceneTimeRange({ from: 'now-1h', to: 'now' }),
     embedded: state?.embedded ?? false,
+    urlNamespace: state?.embedded ? 'gmd' : undefined,
     ...state,
   });
 }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** relates to https://github.com/grafana/metrics-drilldown/issues/426

The support for namespacing URL search parameters was added to Scenes in https://github.com/grafana/scenes/pull/1156 but Metrics Drilldown is not using it, so its variables might collide with other variables when the app is embedded. 

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

`-`
