### PR TITLE
fix(LabelsBrowser): Fix group by not applied after selecting a label

### DIFF
--- a/src/WingmanDataTrail/MetricsReducer.tsx
+++ b/src/WingmanDataTrail/MetricsReducer.tsx
@@ -82,9 +82,14 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
 
     sceneGraph.findByKeyAndType(this, 'quick-search', QuickSearch).toggleCountsDisplay(!hasGroupByValue);
 
+    if (!hasGroupByValue && this.state.body instanceof MetricsList) {
+      return;
+    }
+
     if (
-      (hasGroupByValue && this.state.body instanceof MetricsGroupByList) ||
-      (!hasGroupByValue && this.state.body instanceof MetricsList)
+      hasGroupByValue &&
+      this.state.body instanceof MetricsGroupByList &&
+      this.state.body.state.labelName === groupByValue
     ) {
       return;
     }

--- a/src/WingmanDataTrail/SideBar/sections/LabelsBrowser/LabelsBrowser.tsx
+++ b/src/WingmanDataTrail/SideBar/sections/LabelsBrowser/LabelsBrowser.tsx
@@ -75,12 +75,12 @@ export class LabelsBrowser extends SceneObjectBase<LabelsBrowserState> {
     this.publishEvent(new EventSectionValueChanged({ key: this.state.key, values: active ? [label] : [] }), true);
   }
 
-  private onClickLabel = (label: string) => {
+  private onSelectLabel = (label: string) => {
     reportExploreMetrics('sidebar_group_by_label_filter_applied', { label });
     this.selectLabel(label);
   };
 
-  private onClickClearSelection = () => {
+  private onClearSelection = () => {
     this.selectLabel(NULL_GROUP_BY_VALUE);
   };
 
@@ -166,8 +166,8 @@ export class LabelsBrowser extends SceneObjectBase<LabelsBrowserState> {
           <LabelsList
             labels={labelsList}
             selectedLabel={selectedLabel}
-            onClickLabel={model.onClickLabel}
-            onClickClearSelection={model.onClickClearSelection}
+            onSelectLabel={model.onSelectLabel}
+            onClearSelection={model.onClearSelection}
           />
         )}
       </div>

--- a/src/WingmanDataTrail/SideBar/sections/LabelsBrowser/LabelsList.tsx
+++ b/src/WingmanDataTrail/SideBar/sections/LabelsBrowser/LabelsList.tsx
@@ -8,11 +8,11 @@ import { NULL_GROUP_BY_VALUE } from 'WingmanDataTrail/Labels/LabelsDataSource';
 type LabelsListProps = {
   labels: Array<SelectableValue<string>>;
   selectedLabel: string;
-  onClickLabel: (label: string) => void;
-  onClickClearSelection: () => void;
+  onSelectLabel: (label: string) => void;
+  onClearSelection: () => void;
 };
 
-export function LabelsList({ labels, selectedLabel, onClickLabel, onClickClearSelection }: Readonly<LabelsListProps>) {
+export function LabelsList({ labels, selectedLabel, onSelectLabel, onClearSelection }: Readonly<LabelsListProps>) {
   const styles = useStyles2(getStyles);
 
   return (
@@ -24,7 +24,7 @@ export function LabelsList({ labels, selectedLabel, onClickLabel, onClickClearSe
         <Button
           variant="secondary"
           fill="text"
-          onClick={onClickClearSelection}
+          onClick={onClearSelection}
           disabled={selectedLabel === NULL_GROUP_BY_VALUE}
         >
           clear
@@ -37,7 +37,7 @@ export function LabelsList({ labels, selectedLabel, onClickLabel, onClickClearSe
         <div className={styles.list} data-testid="labels-list">
           {/* TODO: use a custom one to have option labels with ellipsis and title/tooltip when hovering
       now we're customizing too much the component CSS */}
-          <RadioButtonList name="labels-list" options={labels} onChange={onClickLabel} value={selectedLabel} />
+          <RadioButtonList name="labels-list" options={labels} onChange={onSelectLabel} value={selectedLabel} />
         </div>
       )}
     </>


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** was introduced by https://github.com/grafana/metrics-drilldown/pull/659

After selecting a label in the sidebar, the next selections do not work:

https://github.com/user-attachments/assets/50f61383-650b-4b05-8107-64ec83514fc6

### 📖 Summary of the changes

See diff tab.

### 🧪 How to test?

`-`
