### PR TITLE
fix(Docker): Fix GRAFANA_IMAGE env var used in playwright

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,5 +70,5 @@ services:
     environment:
       GRAFANA_PORT: ${GRAFANA_PORT:-3001}
       GRAFANA_SCOPES_PORT: ${GRAFANA_SCOPES_PORT:-3002}
-      GRAFANA_IMAGE: ${GRAFANA_VERSION:-grafana-enterprise}
+      GRAFANA_IMAGE: ${GRAFANA_IMAGE:-grafana-enterprise}
       GRAFANA_VERSION: ${GRAFANA_VERSION:-11.6.5}


### PR DESCRIPTION
### ✨ Description

Regenerating screenshots was failing due to not being able to find the grafana version due to a little bug.

### 📖 Summary of the changes

No conflicting version in docker compose yaml.

### 🧪 How to test?

Run screenshot gen script. `./scripts/e2e-gen-all-screenshots.sh `
build passes
