### PR TITLE
chore: update changelog, bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.14
+
+See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.14>
+
 ## v1.0.13
 
 See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.13>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-metricsdrilldown-app",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "AGPL-3.0",
       "dependencies": {
         "@bsull/augurs": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-metricsdrilldown-app",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "author": "Grafana",
   "license": "AGPL-3.0",
   "scripts": {


### PR DESCRIPTION
This PR bumps the version to 1.0.14 to prepare the next release. It follows the **Versioning** steps described in the Metrics Drilldown [Deployment Handbook](https://wiki.grafana-ops.net/w/index.php/Engineering/Grafana/Grafana_Explore/Metrics_Drilldown/Deployment_Handbook#Recipe_for_engineers).