### PR TITLE
feat(Breakdown): Make list controls sticky

### DIFF
--- a/src/Breakdown/GroupByVariable.tsx
+++ b/src/Breakdown/GroupByVariable.tsx
@@ -1,5 +1,6 @@
+import { css } from '@emotion/css';
 import { QueryVariable, sceneGraph, type MultiValueVariable, type SceneComponentProps } from '@grafana/scenes';
-import { Field } from '@grafana/ui';
+import { Field, useStyles2 } from '@grafana/ui';
 import React, { useCallback } from 'react';
 
 import { reportExploreMetrics } from 'interactions';
@@ -54,6 +55,7 @@ export class GroupByVariable extends QueryVariable {
   }
 
   public static readonly Component = ({ model }: SceneComponentProps<MultiValueVariable>) => {
+    const styles = useStyles2(getStyles);
     const { options, value, loading } = model.useState();
 
     const onChange = useCallback(
@@ -65,7 +67,7 @@ export class GroupByVariable extends QueryVariable {
     );
 
     return (
-      <Field label="By label" data-testid="breakdown-label-selector">
+      <Field label="By label" data-testid="breakdown-label-selector" className={styles.field}>
         <GroupBySelector
           options={options as GroupByOptions}
           value={value as string}
@@ -74,5 +76,13 @@ export class GroupByVariable extends QueryVariable {
         />
       </Field>
     );
+  };
+}
+
+function getStyles() {
+  return {
+    field: css({
+      marginBottom: 0,
+    }),
   };
 }

--- a/src/Breakdown/LabelBreakdownScene.tsx
+++ b/src/Breakdown/LabelBreakdownScene.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { type GrafanaTheme2 } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, useChromeHeaderHeight } from '@grafana/runtime';
 import {
   sceneGraph,
   SceneObjectBase,
@@ -10,6 +10,10 @@ import {
 } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 import React from 'react';
+
+import { type DataTrail } from 'DataTrail';
+import { getTrailFor } from 'utils';
+import { getAppBackgroundColor } from 'utils/utils.styles';
 
 import { RefreshMetricsEvent, VAR_GROUP_BY } from '../shared';
 import { isQueryVariable } from '../utils/utils.variables';
@@ -68,13 +72,15 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
   }
 
   public static readonly Component = ({ model }: SceneComponentProps<LabelBreakdownScene>) => {
-    const styles = useStyles2(getStyles);
+    const chromeHeaderHeight = useChromeHeaderHeight();
+    const trail = getTrailFor(model);
+    const styles = useStyles2(getStyles, trail.state.embedded ? 0 : chromeHeaderHeight ?? 0, trail);
     const { body } = model.useState();
     const groupByVariable = model.getVariable();
 
     return (
       <div className={styles.container}>
-        <div className={styles.controls}>
+        <div className={styles.stickyControls} data-testid="breakdown-controls">
           <groupByVariable.Component model={groupByVariable} />
           {body instanceof MetricLabelsList && <body.Controls model={body} />}
           {body instanceof MetricLabelValuesList && <body.Controls model={body} />}
@@ -88,7 +94,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
   };
 }
 
-function getStyles(theme: GrafanaTheme2) {
+function getStyles(theme: GrafanaTheme2, headerHeight: number, trail: DataTrail) {
   return {
     container: css({
       flexGrow: 1,
@@ -96,14 +102,18 @@ function getStyles(theme: GrafanaTheme2) {
       minHeight: '100%',
       flexDirection: 'column',
     }),
-    controls: css({
-      flexGrow: 0,
+    stickyControls: css({
       display: 'flex',
-      gap: theme.spacing(1),
-      height: '77px',
       justifyContent: 'space-between',
       alignItems: 'end',
-      overflowX: 'auto',
+      gap: theme.spacing(1),
+      margin: theme.spacing(1, 0, 1.5, 0),
+      position: 'sticky',
+      top: `calc(var(--app-controls-height, 0px) + ${headerHeight}px + var(--action-bar-height, 0px))`,
+      zIndex: 10,
+      background: getAppBackgroundColor(theme, trail),
+      paddingBottom: theme.spacing(1),
+      height: '60px', // prevent small jumps when switching from group by "All" to a label
     }),
     searchField: css({
       flexGrow: 1,

--- a/src/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
+++ b/src/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { DashboardCursorSync, LoadingState, type DataFrame, type GrafanaTheme2, type PanelData } from '@grafana/data';
 import {
   behaviors,
@@ -277,13 +277,13 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
       <>
         {body instanceof SceneByFrameRepeater && (
           <>
-            <Field className={styles.quickSearchField} label="Search">
+            <Field className={cx(styles.field, styles.quickSearchField)} label="Search">
               <quickSearch.Component model={quickSearch} />
             </Field>
             <sortBySelector.Component model={sortBySelector} />
           </>
         )}
-        <Field label="View">
+        <Field label="View" className={styles.field}>
           <layoutSwitcher.Component model={layoutSwitcher} />
         </Field>
       </>
@@ -369,6 +369,9 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     quickSearchField: css({
       flexGrow: 1,
+    }),
+    field: css({
+      marginBottom: 0,
     }),
   };
 }

--- a/src/Breakdown/MetricLabelValuesList/SortBySelector.tsx
+++ b/src/Breakdown/MetricLabelValuesList/SortBySelector.tsx
@@ -57,6 +57,7 @@ export class SortBySelector extends SceneObjectBase<SortBySelectorState> {
 
     return (
       <Field
+        className={styles.field}
         data-testid="sort-by-select"
         htmlFor="sort-by-criteria"
         label={
@@ -90,6 +91,9 @@ function getStyles(theme: GrafanaTheme2) {
     sortByTooltip: css({
       display: 'flex',
       gap: theme.spacing(1),
+    }),
+    field: css({
+      marginBottom: 0,
     }),
   };
 }

--- a/src/Breakdown/MetricLabelsList/MetricLabelsList.tsx
+++ b/src/Breakdown/MetricLabelsList/MetricLabelsList.tsx
@@ -163,9 +163,11 @@ export class MetricLabelsList extends SceneObjectBase<MetricLabelsListState> {
   }
 
   public Controls({ model }: { model: MetricLabelsList }) {
+    const styles = useStyles2(getStyles); // eslint-disable-line react-hooks/rules-of-hooks
     const { layoutSwitcher } = model.useState();
+
     return (
-      <Field label="View">
+      <Field label="View" className={styles.field}>
         <layoutSwitcher.Component model={layoutSwitcher} />
       </Field>
     );
@@ -204,6 +206,9 @@ export class MetricLabelsList extends SceneObjectBase<MetricLabelsListState> {
 function getStyles(theme: GrafanaTheme2) {
   return {
     container: css({ width: '100%' }),
+    field: css({
+      marginBottom: 0,
+    }),
     footer: css({
       display: 'flex',
       justifyContent: 'center',

--- a/src/RelatedMetricsScene/RelatedListControls.tsx
+++ b/src/RelatedMetricsScene/RelatedListControls.tsx
@@ -61,7 +61,7 @@ export class RelatedListControls extends EmbeddedScene {
     const { body } = model.useState();
 
     return (
-      <div className={styles.headerWrapper} data-testid="related-list-controls">
+      <div className={styles.controls} data-testid="related-list-controls">
         <body.Component model={body} />
       </div>
     );
@@ -70,7 +70,7 @@ export class RelatedListControls extends EmbeddedScene {
 
 function getStyles() {
   return {
-    headerWrapper: css({
+    controls: css({
       display: 'flex',
       alignItems: 'center',
       '& > div': {

--- a/src/RelatedMetricsScene/RelatedMetricsScene.tsx
+++ b/src/RelatedMetricsScene/RelatedMetricsScene.tsx
@@ -143,10 +143,8 @@ export class RelatedMetricsScene extends SceneObjectBase<RelatedMetricsSceneStat
         <div className={styles.searchSticky}>
           <listControls.Component model={listControls} />
         </div>
-        <div className={styles.body}>
-          <div className={styles.list} data-testid="panels-list">
-            <body.Component model={body} />
-          </div>
+        <div data-testid="panels-list">
+          <body.Component model={body} />
         </div>
         <div className={styles.variables}>
           {$variables?.state.variables.map((variable) => (
@@ -160,8 +158,6 @@ export class RelatedMetricsScene extends SceneObjectBase<RelatedMetricsSceneStat
 
 function getStyles(theme: GrafanaTheme2, headerHeight: number, trail: DataTrail) {
   return {
-    body: css({}),
-    list: css({}),
     variables: css({
       display: 'none',
     }),


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** relates to https://github.com/grafana/metrics-drilldown/pull/635

Similar to https://github.com/grafana/metrics-drilldown/pull/635, this PR makes the labels breakdown controls sticky:

https://github.com/user-attachments/assets/d6f28db0-fa82-4ab9-a016-af9459b0bc38

### 📖 Summary of the changes

Additionally, this PR does a bit of cleanup to keep markup and styles minimal.

### 🧪 How to test?

- Manually, after checking out this branch 
- The build should pass
