### PR TITLE
fix(Docker): Add Prometheus health check to ensure metadata availability before running the E2E tests

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
       interval: 3s
       timeout: 1s
       retries: 10
-      start_period: 5s
+      start_period: 15s
 
   grafana-scopes-gmd:
     container_name: 'grafana-scopes-gmd'
@@ -50,7 +50,7 @@ services:
       interval: 3s
       timeout: 1s
       retries: 10
-      start_period: 5s
+      start_period: 15s
 
   prometheus-gmd:
     container_name: 'prometheus-gmd'
@@ -66,6 +66,14 @@ services:
       --config.file=/etc/prometheus/prometheus.yml
       --storage.tsdb.path=/prometheus/data
       --storage.tsdb.retention.time=42y
+    healthcheck:
+      # healthy only when metrics metadata is returned
+      # it's important because the app heavily relies on them to determine how metrics are rendered in the UI (see GmdVizPanel.tsx)
+      test: ['CMD-SHELL', 'wget -qO- http://localhost:9090/api/v1/targets/metadata | grep -Fq ''"data":[{''']
+      interval: 3s
+      timeout: 1s
+      retries: 10
+      start_period: 15s
 
   # e2e testing
   playwright:
@@ -86,7 +94,7 @@ services:
       grafana-gmd:
         condition: service_healthy
       prometheus-gmd:
-        condition: service_started
+        condition: service_healthy
     environment:
       # required for screenshot testing across Grafana versions
       GRAFANA_VERSION: ${GRAFANA_VERSION:-11.6.5}


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR adds a healthcheck for the `prometheus-gmd`service that waits until the metadata API returns data, indicating at least one successful scrape.

**Why?**

1. To ensure Playwright doesn’t start until Prometheus is not only up, but has scraped targets and populated metadata
2. The app relies on Prometheus metadata to render the panels and build queries ; waiting for metadata reduces early-run flakiness in E2E tests

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The build should pass

**Locally:**
- Start the stack and observe that `prometheus-gmd` health transition only after metadata appears
- Confirm `playwright` starts only after `prometheus-gmd` is healthy (use `docker inspect --format "{{json .State.Health }}" prometheus-gmd | jq`)
