### PR TITLE
chore: bump version to v1.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.16
+
+See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.16>
+
 ## v1.0.15
 
 See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.15>


### PR DESCRIPTION
✨ Description
As per the process described in the [Metrics Drilldown Deployment Handbook](https://wiki.grafana-ops.net/w/index.php?title=Engineering/Grafana/Grafana_Explore/Metrics_Drilldown/Deployment_Handbook#Recipe_for_engineers), this PR bumps the Metrics Drilldown app to v1.0.16.