### PR TITLE
fix(Sidebar): Fix group by status and behaviour

### DIFF
--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -29,6 +29,9 @@ import React, { useEffect } from 'react';
 import { GiveFeedbackButton } from 'AppDataTrail/header/GiveFeedbackButton';
 import { SceneDrawer } from 'MetricsReducer/components/SceneDrawer';
 import { displaySuccess } from 'MetricsReducer/helpers/displayStatus';
+import { registerRuntimeDataSources } from 'MetricsReducer/helpers/registerRuntimeDataSources';
+import { LabelsDataSource } from 'MetricsReducer/labels/LabelsDataSource';
+import { LabelsVariable } from 'MetricsReducer/labels/LabelsVariable';
 import { addRecentMetric } from 'MetricsReducer/list-controls/MetricsSorter/MetricsSorter';
 import { MetricsVariable } from 'MetricsReducer/metrics-variables/MetricsVariable';
 import { MetricsReducer } from 'MetricsReducer/MetricsReducer';
@@ -112,6 +115,8 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
   }
 
   private onActivate() {
+    registerRuntimeDataSources([new LabelsDataSource()]);
+
     this.datasourceHelper.init();
 
     this.updateStateForNewMetric(this.state.metric);
@@ -390,6 +395,7 @@ function getVariableSet(initialDS?: string, metric?: string, initialFilters?: Ad
         );
       },
     }),
+    new LabelsVariable(),
   ];
 
   if (isScopesSupported()) {

--- a/src/MetricsReducer/MetricsReducer.tsx
+++ b/src/MetricsReducer/MetricsReducer.tsx
@@ -16,9 +16,8 @@ import React from 'react';
 
 import { reportExploreMetrics } from 'shared/tracking/interactions';
 
-import { registerRuntimeDataSources } from './helpers/registerRuntimeDataSources';
-import { LabelsDataSource, NULL_GROUP_BY_VALUE } from './labels/LabelsDataSource';
-import { LabelsVariable, VAR_WINGMAN_GROUP_BY } from './labels/LabelsVariable';
+import { NULL_GROUP_BY_VALUE } from './labels/LabelsDataSource';
+import { VAR_WINGMAN_GROUP_BY, type LabelsVariable } from './labels/LabelsVariable';
 import { ListControls } from './list-controls/ListControls';
 import { EventSortByChanged } from './list-controls/MetricsSorter/events/EventSortByChanged';
 import { MetricsSorter, VAR_WINGMAN_SORT_BY, type SortingOption } from './list-controls/MetricsSorter/MetricsSorter';
@@ -54,15 +53,13 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
   public constructor() {
     super({
       $variables: new SceneVariableSet({
-        variables: [new FilteredMetricsVariable(), new LabelsVariable()],
+        variables: [new FilteredMetricsVariable()],
       }),
       listControls: new ListControls({}),
       sidebar: new SideBar({}),
       body: undefined,
       enginesMap: new Map(),
     });
-
-    registerRuntimeDataSources([new LabelsDataSource()]);
 
     this.addActivationHandler(this.onActivate.bind(this));
   }

--- a/src/MetricsReducer/SideBar/SideBar.tsx
+++ b/src/MetricsReducer/SideBar/SideBar.tsx
@@ -12,7 +12,7 @@ import { IconButton, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { NULL_GROUP_BY_VALUE } from 'MetricsReducer/labels/LabelsDataSource';
-import { VAR_WINGMAN_GROUP_BY } from 'MetricsReducer/labels/LabelsVariable';
+import { LabelsVariable, VAR_WINGMAN_GROUP_BY } from 'MetricsReducer/labels/LabelsVariable';
 import { computeMetricPrefixGroups } from 'MetricsReducer/metrics-variables/computeMetricPrefixGroups';
 import { computeMetricSuffixGroups } from 'MetricsReducer/metrics-variables/computeMetricSuffixGroups';
 import { computeRulesGroups } from 'MetricsReducer/metrics-variables/computeRulesGroups';
@@ -85,7 +85,6 @@ export class SideBar extends SceneObjectBase<SideBarState> {
           title: 'Group by labels',
           description: 'Group metrics by their label values',
           icon: 'groups',
-          active: sectionValues.has('groupby-labels'),
         }),
         new BookmarksList({
           key: 'bookmarks',
@@ -212,12 +211,6 @@ export class SideBar extends SceneObjectBase<SideBarState> {
       sectionValues.set(filterKey, filterValueFromUrl ? filterValueFromUrl.split(',').map((v) => v.trim()) : []);
     }
 
-    const labelValue = urlSearchParams.get(`var-${VAR_WINGMAN_GROUP_BY}`);
-    const isLabelsBrowserActive = Boolean(labelValue && labelValue !== NULL_GROUP_BY_VALUE);
-    if (isLabelsBrowserActive) {
-      sectionValues.set('groupby-labels', [labelValue!]);
-    }
-
     return sectionValues;
   }
 
@@ -259,24 +252,46 @@ export class SideBar extends SceneObjectBase<SideBarState> {
     const styles = useStyles2(getStyles);
     const { sections, visibleSection, sectionValues } = model.useState();
 
+    const labelsVariableValue = sceneGraph
+      .findByKeyAndType(model, VAR_WINGMAN_GROUP_BY, LabelsVariable)
+      .useState().value;
+
     return (
       <div className={styles.container}>
         <div className={styles.buttonsBar} data-testid="sidebar-buttons">
           {sections.map((section) => {
             const { key, title, icon: iconOrText, disabled, active } = section.state;
             const visible = visibleSection?.state.key === key;
-            const tooltip = sectionValues.get(key)?.length ? `${title}: ${sectionValues.get(key)?.join(', ')}` : title;
+
+            const isActive =
+              key === 'groupby-labels'
+                ? Boolean(labelsVariableValue && labelsVariableValue !== NULL_GROUP_BY_VALUE)
+                : active;
+
+            const tooltip =
+              key === 'groupby-labels'
+                ? `${title}: ${labelsVariableValue}`
+                : // eslint-disable-next-line sonarjs/no-nested-conditional
+                sectionValues.get(key)?.length
+                ? `${title}: ${sectionValues.get(key)?.join(', ')}`
+                : title;
 
             return (
               <div
                 key={key}
-                className={cx(styles.buttonContainer, visible && 'visible', active && 'active', disabled && 'disabled')}
+                className={cx(
+                  styles.buttonContainer,
+                  visible && 'visible',
+                  isActive && 'active',
+                  disabled && 'disabled'
+                )}
               >
                 <SideBarButton
+                  key={key}
                   ariaLabel={title}
                   disabled={disabled}
                   visible={visible}
-                  active={active}
+                  active={isActive}
                   tooltip={tooltip}
                   onClick={() => model.setActiveSection(key)}
                   iconOrText={iconOrText}

--- a/src/MetricsReducer/SideBar/SideBarButton.tsx
+++ b/src/MetricsReducer/SideBar/SideBarButton.tsx
@@ -73,6 +73,9 @@ function getStyles(theme: GrafanaTheme2) {
         color: theme.colors.text.maxContrast,
         background: 'transparent',
       },
+      '&.disabled': {
+        opacity: 0.4,
+      },
       '&.disabled:hover': {
         color: theme.colors.text.secondary,
       },

--- a/src/MetricsReducer/SideBar/sections/LabelsBrowser/LabelsBrowser.tsx
+++ b/src/MetricsReducer/SideBar/sections/LabelsBrowser/LabelsBrowser.tsx
@@ -8,7 +8,6 @@ import { NULL_GROUP_BY_VALUE } from 'MetricsReducer/labels/LabelsDataSource';
 import { type LabelsVariable } from 'MetricsReducer/labels/LabelsVariable';
 
 import { reportExploreMetrics } from '../../../../shared/tracking/interactions';
-import { EventSectionValueChanged } from '../EventSectionValueChanged';
 import { SectionTitle } from '../SectionTitle';
 import { type SideBarSectionState } from '../types';
 import { LabelsList } from './LabelsList';
@@ -44,36 +43,6 @@ export class LabelsBrowser extends SceneObjectBase<LabelsBrowserState> {
       disabled: disabled ?? false,
       active: active ?? false,
     });
-
-    this.addActivationHandler(this.onActivate.bind(this));
-  }
-
-  private onActivate() {
-    const labelsVariable = sceneGraph.lookupVariable(this.state.variableName, this) as LabelsVariable;
-    const labelValue = labelsVariable.state.value;
-
-    this.setState({ active: Boolean(labelValue && labelValue !== NULL_GROUP_BY_VALUE) });
-
-    // Subscribe to variable changes to update active state when the variable is changed externally
-    this._subs.add(
-      labelsVariable.subscribeToState((newState, prevState) => {
-        if (newState.value === prevState.value) {
-          return;
-        }
-
-        const active = Boolean(newState.value && newState.value !== NULL_GROUP_BY_VALUE);
-        if (active === this.state.active) {
-          return;
-        }
-
-        this.setState({ active });
-
-        this.publishEvent(
-          new EventSectionValueChanged({ key: this.state.key, values: active ? [newState.value as string] : [] }),
-          true
-        );
-      })
-    );
   }
 
   private selectLabel(label: string) {


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** relates to https://github.com/grafana/metrics-drilldown/issues/359



### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

### 🧪 How to test?

- The build should pass

#### Manually:

Go to [this URL](http://localhost:3001/a/grafana-metricsdrilldown-app/drilldown?from=2025-05-26T11:00:00.000Z&to=2025-05-26T12:05:00.000Z&var-ds=gdev-prometheus).

#### Scenario 1

1. Group by `db_name`
2. Close the sidebar
3. Click on the "Select" button of the `grafana` group

**Expected:** the sidebar shows the "group by" button as inactive

#### Scenario 2

1. Group by `db_name`
2. Select the first `go_sql_stats_connections_closed_max_idle` metric
3. Click on the "Select new metric" button (or use the browser's back button)

**Expected:**
- the sidebar shows the "group by" button as active and
- the list of metrics is grouped by `db_name`

#### Scenario 3

1. Group by `db_name`
2. Leave the sidebar open
3. Add an ad hoc filter:  `active=false`

**Expected:**
- the sidebar shows the "group by" button as active,
- `db_name` is selected,
- the list of metrics is grouped by `db_name` but no metrics are found (the filter is properly applied)

#### Scenario 4

1. Group by `db_name`
2. Leave the sidebar open
3. Add an ad hoc filter:  `action=add_client`

**Expected:**
- the sidebar shows the "group by" button as active,
- `db_name` is selected,
- `db_name` is the only item in the labels list,
- the list of metrics is grouped by `action` but no metrics are found (the filter is properly applied)

#### Scenario 5

1. Start at the end of scenario 4,
2. Clear the label

**Expected:**
- the sidebar shows the "group by" button as inactive,
- the "No selection" text is displayed,
- the `db_name` radio button is displayed and is not selected
