### PR TITLE
fix(MetricDatasourceHelper): Fix cache refresh when changing data source

### DIFF
--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -15,6 +15,7 @@ import {
   SceneVariableSet,
   ScopesVariable,
   UrlSyncContextProvider,
+  VariableDependencyConfig,
   VariableValueSelectors,
   type SceneComponentProps,
   type SceneObject,
@@ -45,7 +46,7 @@ import { MetricDatasourceHelper } from './MetricDatasourceHelper/MetricDatasourc
 import { MetricsDrilldownDataSourceVariable } from './MetricsDrilldownDataSourceVariable';
 import { resetYAxisSync } from '../MetricScene/Breakdown/MetricLabelsList/behaviors/syncYAxis';
 import { MetricScene } from '../MetricScene/MetricScene';
-import { MetricSelectedEvent, trailDS, VAR_FILTERS } from '../shared/shared';
+import { MetricSelectedEvent, trailDS, VAR_DATASOURCE, VAR_FILTERS } from '../shared/shared';
 import { reportChangeInLabelFilters, reportExploreMetrics } from '../shared/tracking/interactions';
 import { limitAdhocProviders } from '../shared/utils/utils';
 import { getAppBackgroundColor } from '../shared/utils/utils.styles';
@@ -76,6 +77,13 @@ export interface DataTrailState extends SceneObjectState {
 export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneObjectWithUrlSync {
   private disableReportFiltersInteraction = false;
   private datasourceHelper = new MetricDatasourceHelper(this);
+
+  protected _variableDependency = new VariableDependencyConfig(this, {
+    variableNames: [VAR_DATASOURCE],
+    onReferencedVariableValueChanged: () => {
+      this.datasourceHelper.init();
+    },
+  });
 
   protected _urlSync = new SceneObjectUrlSyncConfig(this, {
     keys: ['metric'],

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -81,7 +81,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
   protected _variableDependency = new VariableDependencyConfig(this, {
     variableNames: [VAR_DATASOURCE],
     onReferencedVariableValueChanged: () => {
-      this.datasourceHelper.init();
+      this.datasourceHelper.reset();
     },
   });
 

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -120,9 +120,11 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
   }
 
   private onActivate() {
-    // we delay the call to init() because onReferencedVariableValueChanged() above seems to always call reset when landing
-    // we could rely solely on onReferencedVariableValueChanged to call init(), but there's a doubt if it'll  always called automatically
-    // see also MetricDatasourceHelper.reset()
+    // Delays init() to ensure proper initialization order and avoid race conditions.
+    // The variable dependency handler (onReferencedVariableValueChanged) calls reset()
+    // when landing, but we're uncertain whether it will always be called automatically
+    // in all scenarios. Using setTimeout ensures init() runs after variable changes
+    // are processed.
     setTimeout(() => {
       this.datasourceHelper.init();
     }, 0);

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -120,7 +120,12 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
   }
 
   private onActivate() {
-    this.datasourceHelper.init();
+    // we delay the call to init() because onReferencedVariableValueChanged() above seems to always call reset when landing
+    // we could rely solely on onReferencedVariableValueChanged to call init(), but there's a doubt if it'll  always called automatically
+    // see also MetricDatasourceHelper.reset()
+    setTimeout(() => {
+      this.datasourceHelper.init();
+    }, 0);
 
     this.updateStateForNewMetric(this.state.metric);
     this.subscribeToEvent(MetricSelectedEvent, (event) => this.handleMetricSelectedEvent(event));

--- a/src/AppDataTrail/MetricDatasourceHelper/MetricDatasourceHelper.ts
+++ b/src/AppDataTrail/MetricDatasourceHelper/MetricDatasourceHelper.ts
@@ -11,19 +11,14 @@ import {
   type PromQuery,
 } from '@grafana/prometheus';
 import { getDataSourceSrv } from '@grafana/runtime';
-import { sceneGraph, type DataSourceVariable, type SceneObject, type VariableValueOption } from '@grafana/scenes';
-import { type Unsubscribable } from 'rxjs';
+import { sceneGraph, type DataSourceVariable, type SceneObject } from '@grafana/scenes';
 
 import { type DataTrail } from 'AppDataTrail/DataTrail';
-import { MetricsDrilldownDataSourceVariable } from 'AppDataTrail/MetricsDrilldownDataSourceVariable';
 import { displayError, displayWarning } from 'MetricsReducer/helpers/displayStatus';
-import { areArraysEqual } from 'MetricsReducer/metrics-variables/helpers/areArraysEqual';
-import { MetricsVariable, VAR_METRICS_VARIABLE } from 'MetricsReducer/metrics-variables/MetricsVariable';
-import { isClassicHistogramMetric } from 'shared/GmdVizPanel/matchers/isClassicHistogramMetric';
 import { isPrometheusDataSource } from 'shared/utils/utils.datasource';
 
-import { languageProviderVersionIs } from './types/language-provider/versionCheck';
 import { VAR_DATASOURCE, VAR_DATASOURCE_EXPR } from '../../shared/shared';
+import { languageProviderVersionIs } from './types/language-provider/versionCheck';
 
 /**
  * When we fetch the Prometheus data source with `@grafana/runtime`, its language provider
@@ -42,7 +37,6 @@ export class MetricDatasourceHelper {
     metadata: new Map<string, PromMetricsMetadataItem>(),
     classicHistograms: new Set<string>(),
   };
-  private subs: Unsubscribable[] = [];
 
   constructor(trail: DataTrail) {
     this.trail = trail;
@@ -57,40 +51,6 @@ export class MetricDatasourceHelper {
   }
 
   public init() {
-    this.reset();
-
-    for (const sub of this.subs) {
-      sub.unsubscribe();
-    }
-
-    this.subs = [];
-
-    const metricsVariable = sceneGraph.findByKeyAndType(this.trail, VAR_METRICS_VARIABLE, MetricsVariable);
-    this.subs.push(
-      metricsVariable.subscribeToState((newState, prevState) => {
-        if (!areArraysEqual(newState.options, prevState.options)) {
-          this.onNewMetrics(newState.options);
-        }
-      })
-    );
-
-    const datasourceVariable = sceneGraph.findByKeyAndType(
-      this.trail,
-      VAR_DATASOURCE,
-      MetricsDrilldownDataSourceVariable
-    );
-    this.subs.push(
-      datasourceVariable.subscribeToState(async (newState, prevState) => {
-        if (newState.value !== prevState.value) {
-          this.reset();
-        }
-      })
-    );
-
-    this.onNewMetrics(metricsVariable.state.options);
-  }
-
-  private reset() {
     this.datasource = undefined;
 
     this.cache = {
@@ -99,16 +59,6 @@ export class MetricDatasourceHelper {
     };
 
     this.fetchMetricsMetadata().catch(() => {});
-  }
-
-  private onNewMetrics(metricsVariableOptions: VariableValueOption[]) {
-    for (const metricData of metricsVariableOptions) {
-      const name = metricData.value as string;
-
-      if (isClassicHistogramMetric(name)) {
-        this.cache.classicHistograms.add(name);
-      }
-    }
   }
 
   /**

--- a/src/AppDataTrail/MetricDatasourceHelper/MetricDatasourceHelper.ts
+++ b/src/AppDataTrail/MetricDatasourceHelper/MetricDatasourceHelper.ts
@@ -76,7 +76,7 @@ export class MetricDatasourceHelper {
     this.onNewMetrics(metricsVariable.state.options);
   }
 
-  private reset() {
+  public reset() {
     this.datasource = undefined;
 
     this.cache = {

--- a/src/AppDataTrail/MetricDatasourceHelper/MetricDatasourceHelper.ts
+++ b/src/AppDataTrail/MetricDatasourceHelper/MetricDatasourceHelper.ts
@@ -79,10 +79,12 @@ export class MetricDatasourceHelper {
   }
 
   public reset() {
-    // prevents fetching the metadata twice when landing because reset() is called from DataTrail:
-    // - during activation and
-    // - after activation, by onReferencedVariableValueChanged, which seems to always be called automatically regardless there's a user action or not
-    // we could rely solely on onReferencedVariableValueChanged to call init(), but there's a doubt if it'll  always called automatically
+    // Prevents duplicate metadata fetching during DataTrail initialization.
+    // This method is called twice when landing on a DataTrail:
+    // 1. During activation via init() -> reset()
+    // 2. After activation via onReferencedVariableValueChanged() (called automatically)
+    // The early return prevents the second call from clearing the cache and refetching
+    // metadata that was already loaded during the first call.
     if (!this.initialized) {
       return;
     }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR ensures that the cache metadata is _always_ cleared when the data source changes.

The previous code relied on subscribing to `MetricsDrilldownDataSourceVariable` state changes but weirdly, when (e.g.) going to the `MetricScene`, coming back to `MetricsReducer` and then changing the data source, the subscriber function would not be called 🤷🏾‍♂️.

### 📖 Summary of the changes

Instead of subscribing to `MetricsDrilldownDataSourceVariable` state changes, this PR relies on the Scenes variable dependency.

### 🧪 How to test?

Manually, after checking out this PR's branch, by looking at the network tab to see:
- that the new metadata is fetched _once_ when landing
- that the new metadata is properly refetched when changing data source
