### PR TITLE
feat: Enable __name__ in the AdHoc filters

### DIFF
--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -34,6 +34,7 @@ import { registerRuntimeDataSources } from 'MetricsReducer/helpers/registerRunti
 import { LabelsDataSource } from 'MetricsReducer/labels/LabelsDataSource';
 import { LabelsVariable } from 'MetricsReducer/labels/LabelsVariable';
 import { addRecentMetric } from 'MetricsReducer/list-controls/MetricsSorter/MetricsSorter';
+import { AdHocFiltersForMetricsVariable } from 'MetricsReducer/metrics-variables/AdHocFiltersForMetricsVariable';
 import { MetricsVariable } from 'MetricsReducer/metrics-variables/MetricsVariable';
 import { MetricsReducer } from 'MetricsReducer/MetricsReducer';
 import { ConfigurePanelForm } from 'shared/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm';
@@ -383,6 +384,7 @@ function getVariableSet(initialDS?: string, metric?: string, initialFilters?: Ad
   let variables: SceneVariable[] = [
     new MetricsDrilldownDataSourceVariable({ initialDS }),
     new MetricsVariable(),
+    new AdHocFiltersForMetricsVariable(),
     new AdHocFiltersVariable({
       key: VAR_FILTERS,
       name: VAR_FILTERS,
@@ -397,14 +399,11 @@ function getVariableSet(initialDS?: string, metric?: string, initialFilters?: Ad
       allowCustomValue: true,
       useQueriesAsFilterForOptions: false,
       expressionBuilder: (filters: AdHocVariableFilter[]) => {
-        // remove any filters that include __name__ key in the expression
-        // to prevent the metric name from being set twice in the query and causing an error.
-        // also escapes equal signs to prevent invalid queries
-        // TODO: proper escaping as Scene does in https://github.com/grafana/scenes/blob/main/packages/scenes/src/variables/utils.ts#L45-L67
         return (
           filters
+            // remove any filters that include __name__ key in the expression
+            // to prevent the metric name from being set twice in the panel queries and causing an error
             .filter((filter) => filter.key !== '__name__')
-            // eslint-disable-next-line sonarjs/no-nested-template-literals
             .map((filter) => `${utf8Support(filter.key)}${filter.operator}"${filter.value}"`)
             .join(',')
         );

--- a/src/MetricsReducer/metrics-variables/AdHocFiltersForMetricsVariable.ts
+++ b/src/MetricsReducer/metrics-variables/AdHocFiltersForMetricsVariable.ts
@@ -1,0 +1,47 @@
+import { VariableHide, type AdHocVariableFilter } from '@grafana/data';
+import { utf8Support } from '@grafana/prometheus';
+import { AdHocFiltersVariable, sceneGraph } from '@grafana/scenes';
+
+import { VAR_FILTERS } from 'shared/shared';
+
+export const VAR_METRICS_VAR_FILTERS = 'metrics_filters';
+
+// This mirror variable keeps the main AdHoc filters in sync, allowing us to construct an expression that includes __name__ label matchers to
+// enable MetricsVariable to fetch the metrics list when __name__ is included (see DataTrail.tsx for the main AdHoc filters)
+export class AdHocFiltersForMetricsVariable extends AdHocFiltersVariable {
+  constructor() {
+    super({
+      key: VAR_METRICS_VAR_FILTERS,
+      name: VAR_METRICS_VAR_FILTERS,
+      hide: VariableHide.hideVariable,
+      allowCustomValue: true,
+      applyMode: 'manual',
+      expressionBuilder: (filters: AdHocVariableFilter[]) =>
+        filters.map((filter) => `${utf8Support(filter.key)}${filter.operator}"${filter.value}"`).join(','),
+      skipUrlSync: true,
+    });
+
+    this.addActivationHandler(() => {
+      const filtersVariable = sceneGraph.findByKeyAndType(this, VAR_FILTERS, AdHocFiltersVariable);
+
+      const update = (newState: any) => {
+        this.setState({
+          baseFilters: newState.baseFilters,
+          filters: newState.filters,
+        });
+      };
+
+      update(filtersVariable.state);
+
+      const sub = filtersVariable.subscribeToState((newState, prevState) => {
+        if (newState.baseFilters !== prevState.baseFilters || newState.filters !== prevState.filters) {
+          update(newState);
+        }
+      });
+
+      return () => {
+        sub.unsubscribe();
+      };
+    });
+  }
+}

--- a/src/MetricsReducer/metrics-variables/MetricsVariable.ts
+++ b/src/MetricsReducer/metrics-variables/MetricsVariable.ts
@@ -2,8 +2,9 @@ import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
 import { QueryVariable, type SceneObjectState } from '@grafana/scenes';
 
 import { type LabelMatcher } from 'shared/GmdVizPanel/buildQueryExpression';
-import { trailDS, VAR_FILTERS } from 'shared/shared';
+import { trailDS } from 'shared/shared';
 
+import { VAR_METRICS_VAR_FILTERS } from './AdHocFiltersForMetricsVariable';
 import { withLifecycleEvents } from './withLifecycleEvents';
 
 export const VAR_METRICS_VARIABLE = 'metrics-wingman';
@@ -25,8 +26,8 @@ export class MetricsVariable extends QueryVariable {
       label: 'Metrics',
       datasource: trailDS,
       query: labelMatcher
-        ? `label_values({${labelMatcher.key}${labelMatcher.operator}"${labelMatcher.value}",$${VAR_FILTERS}}, __name__)`
-        : `label_values({$${VAR_FILTERS}}, __name__)`,
+        ? `label_values({${labelMatcher.key}${labelMatcher.operator}"${labelMatcher.value}",$${VAR_METRICS_VAR_FILTERS}}, __name__)`
+        : `label_values({$${VAR_METRICS_VAR_FILTERS}}, __name__)`,
       includeAll: true,
       value: '$__all',
       skipUrlSync: true,


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR re-enables the `__name__` matcher:

| Before | After |
|  ---   |  ---  |
| <img width="1800" height="623" alt="image" src="https://github.com/user-attachments/assets/7ce48de3-d80c-4224-af83-0b9fb54c0a3e" /> | <img width="1800" height="433" alt="image" src="https://github.com/user-attachments/assets/5e50f220-978f-4a89-8974-c6a6caf932a2" /> |

**This PR can help mitigate the issues we received recently from customers with a very large number of metrics (> 40k).**

### 📖 Summary of the changes

This PR introduces a new AdHocFiltersForMetricsVariable that creates a specialized ad-hoc filters variable **specifically for fetching the metrics list**. This variable:
1. preserves metric name filters: unlike the main filters variable, this one keeps ` __name__` filters in its `expressionBuilder`, ensuring metric names are properly included in queries
2. automatic synchronization: listens to changes from the main `AdHocFiltersVariable` and automatically updates its own state to maintain consistency
3. hidden from UI

### 🧪 How to test?

- The build should pass
- Manually, after checking out this PR's branch: verify that adding (e.g.) `__name__=go_goroutines` to the ad hoc filters works
