### PR TITLE
chore(Docker): Increase health check retries count

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,9 +26,9 @@ services:
       - 'host.docker.internal:172.17.0.1'
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:3000/api/health']
-      interval: 3s
+      interval: 1s
       timeout: 1s
-      retries: 10
+      retries: 30
       start_period: 15s
 
   grafana-scopes-gmd:
@@ -47,9 +47,9 @@ services:
       - 'host.docker.internal:172.17.0.1'
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:3000/api/health']
-      interval: 3s
+      interval: 1s
       timeout: 1s
-      retries: 10
+      retries: 30
       start_period: 15s
 
   prometheus-gmd:
@@ -70,9 +70,9 @@ services:
       # healthy only when metrics metadata is returned
       # it's important because the app heavily relies on them to determine how metrics are rendered in the UI (see GmdVizPanel.tsx)
       test: ['CMD-SHELL', 'wget -qO- http://localhost:9090/api/v1/targets/metadata | grep -Fq ''"data":[{''']
-      interval: 3s
+      interval: 1s
       timeout: 1s
-      retries: 10
+      retries: 30
       start_period: 15s
 
   # e2e testing


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Just to increase the number of retries of the health checks to prevent errors when launching the E2E (at least locally I experienced it several times)

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The build should pass
