### PR TITLE
chore: replace custom text styling with Text component in Bookmarks components

### DIFF
--- a/src/MetricsReducer/SideBar/sections/BookmarksList/BookmarkListItem.tsx
+++ b/src/MetricsReducer/SideBar/sections/BookmarksList/BookmarkListItem.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { dateTimeFormat, type GrafanaTheme2 } from '@grafana/data';
 import { type SceneObjectUrlValues } from '@grafana/scenes';
-import { Card, IconButton, useStyles2 } from '@grafana/ui';
+import { Card, IconButton, Text, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { type Bookmark } from 'shared/bookmarks/useBookmarks';
@@ -57,10 +57,13 @@ export function BookmarkListItem(props: Readonly<BookmarkListItemProps>) {
         <Card.Meta className={styles.meta}>
           {filters.map(([key, operator, value], i) => (
             <div key={i} className={styles.filter}>
-              <span className={styles.secondaryFont}>
+              <Text variant="bodySmall" color="secondary">
                 {key} {operator}
-              </span>
-              <span className={styles.primaryFont}> {truncateValue(key, value, 44)}</span>
+              </Text>
+              <Text variant="bodySmall" color="primary" weight="medium">
+                {' '}
+                {truncateValue(key, value, 44)}
+              </Text>
             </div>
           ))}
         </Card.Meta>
@@ -78,8 +81,12 @@ export function BookmarkListItem(props: Readonly<BookmarkListItemProps>) {
         </div>
       </Card>
       <div className={styles.date}>
-        <div className={styles.secondaryFont}>Date created: </div>
-        <div className={styles.primaryFont}>{createdAt > 0 && dateTimeFormat(createdAt, { format: 'YYYY-MM-DD' })}</div>
+        <Text variant="bodySmall" color="secondary">
+          Date created:{' '}
+        </Text>
+        <Text variant="bodySmall" color="primary" weight="medium">
+          {createdAt > 0 && dateTimeFormat(createdAt, { format: 'YYYY-MM-DD' })}
+        </Text>
       </div>
     </article>
   );
@@ -135,21 +142,6 @@ function getStyles(theme: GrafanaTheme2) {
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
-    }),
-    primaryFont: css({
-      display: 'inline',
-      color: theme.colors.text.primary,
-      fontSize: '12px',
-      fontWeight: '500',
-      letterSpacing: '0.018px',
-    }),
-    secondaryFont: css({
-      display: 'inline',
-      color: theme.colors.text.secondary,
-      fontSize: '12px',
-      fontWeight: '400',
-      lineHeight: '18px' /* 150% */,
-      letterSpacing: '0.018px',
     }),
     deleteButton: css({
       position: 'absolute',

--- a/src/MetricsReducer/SideBar/sections/BookmarksList/BookmarksList.tsx
+++ b/src/MetricsReducer/SideBar/sections/BookmarksList/BookmarksList.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { SceneObjectBase, type SceneComponentProps } from '@grafana/scenes';
-import { useStyles2 } from '@grafana/ui';
+import { Text, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { useBookmarks } from 'shared/bookmarks/useBookmarks';
@@ -70,8 +70,12 @@ export class BookmarksList extends SceneObjectBase<BookmarksListState> {
           </div>
         ) : (
           <div className={styles.emptyState}>
-            <div>No bookmarks yet for the</div>
-            <div>current data source.</div>
+            <Text color="secondary" italic>
+              No bookmarks yet for the
+            </Text>
+            <Text color="secondary" italic>
+              current data source.
+            </Text>
           </div>
         )}
       </div>
@@ -99,8 +103,6 @@ function getStyles(theme: GrafanaTheme2) {
       flexDirection: 'column',
       alignItems: 'center',
       height: '100px',
-      color: theme.colors.text.secondary,
-      fontStyle: 'italic',
     }),
   };
 }


### PR DESCRIPTION
### ✨ Description

ref https://github.com/grafana/metrics-drilldown/issues/580

Replace custom CSS text styling with Grafana UI Text components in bookmark-related components

- `BookmarkListItem`: Replace `primaryFont`/`secondaryFont` spans with `Text variant="bodySmall"
`- `BookmarksList`: Replace empty state `divs` with `Text color="secondary" italic
`
empty bookmark list pre-changes
<img width="314" height="646" alt="emptybookmarkslist-pre-changes" src="https://github.com/user-attachments/assets/ae7af0c2-2f9a-41f8-8bbe-bce9806a5474" />

empty bookmark list post-changes
<img width="314" height="646" alt="emptybookmarkslist-post-changes" src="https://github.com/user-attachments/assets/a9fead0d-5d7d-46f9-95a1-bcdfc751c589" />

bookmark list pre-changes
<img width="314" height="646" alt="bookmarkslist-pre-changes" src="https://github.com/user-attachments/assets/8bb62d2a-f69a-4f65-9811-ad109a6bdb20" />

bookmark list post-changes
<img width="314" height="646" alt="bookmarkslist-post-changes" src="https://github.com/user-attachments/assets/4c4c3207-e4ac-4db1-95f0-fac5f035e654" />

### 🧪 How to test?

- [ ] build passes
- [ ] check bookmark list font styling is the same (empty & populated)
