### PR TITLE
Chore: Replace custom text styling with Text component in MetricsFilterSection components

### DIFF
--- a/src/MetricsReducer/SideBar/sections/MetricsFilterSection/CheckboxWithCount.tsx
+++ b/src/MetricsReducer/SideBar/sections/MetricsFilterSection/CheckboxWithCount.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { type GrafanaTheme2 } from '@grafana/data';
-import { Checkbox, useStyles2 } from '@grafana/ui';
+import { Checkbox, Text, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 export const CheckboxWithCount = ({
@@ -19,7 +19,11 @@ export const CheckboxWithCount = ({
   return (
     <div className={styles.checkboxWrapper} title={label}>
       <Checkbox label={label} value={checked} onChange={onChange} />
-      <span className={styles.count}>({count})</span>
+      <span className={styles.count}>
+        <Text variant="body" color="secondary">
+          ({count})
+        </Text>
+      </span>
     </div>
   );
 };
@@ -38,9 +42,7 @@ function getStyles(theme: GrafanaTheme2) {
       },
     }),
     count: css({
-      color: theme.colors.text.secondary,
       marginLeft: theme.spacing(0.5),
-      display: 'inline-block',
     }),
   };
 }

--- a/src/MetricsReducer/SideBar/sections/MetricsFilterSection/MetricsFilterSection.tsx
+++ b/src/MetricsReducer/SideBar/sections/MetricsFilterSection/MetricsFilterSection.tsx
@@ -9,7 +9,7 @@ import {
   type SceneComponentProps,
   type SceneObjectUrlValues,
 } from '@grafana/scenes';
-import { Icon, IconButton, Input, Spinner, Switch, useStyles2 } from '@grafana/ui';
+import { Icon, IconButton, Input, Spinner, Switch, Text, useStyles2 } from '@grafana/ui';
 import React, { useMemo, useState, type KeyboardEventHandler } from 'react';
 
 import {
@@ -275,7 +275,9 @@ export class MetricsFilterSection extends SceneObjectBase<MetricsFilterSectionSt
 
         {showHideEmpty && (
           <div className={styles.switchContainer}>
-            <span className={styles.switchLabel}>Hide empty</span>
+            <Text variant="bodySmall" color="primary">
+              Hide empty
+            </Text>
             <Switch value={hideEmpty} onChange={(e) => setHideEmpty(e.currentTarget.checked)} />
           </div>
         )}
@@ -322,10 +324,6 @@ function getStyles(theme: GrafanaTheme2) {
       alignItems: 'center',
       justifyContent: 'flex-end',
       gap: theme.spacing(1),
-    }),
-    switchLabel: css({
-      fontSize: '12px',
-      color: theme.colors.text.primary,
     }),
     searchInput: css({
       flexBasis: '32px',


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** <!-- Paste a GitHub issue URL or another pull request URL -->

Replace custom CSS text styling with Grafana UI Text components in filter-related components

### 📖 Summary of the changes

- `CheckboxWithCount`: Replace count span with Text variant="body" component, use wrapper span for spacing
- `MetricsFilterSection`: Replace "Hide empty" span with Text variant="bodySmall" component
- Remove ~5 lines of custom CSS while maintaining identical visual appearance


### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->
