### PR TITLE
chore: upgrade `@grafana/prometheus`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@grafana/faro-web-sdk": "^2.0.0-beta-2",
         "@grafana/i18n": "^12.2.0",
         "@grafana/lezer-logql": "^0.2.7",
-        "@grafana/prometheus": "^12.2.0-258070",
+        "@grafana/prometheus": "^12.2.0",
         "@grafana/runtime": "^12.2.0",
         "@grafana/scenes": "^6.39.0",
         "@grafana/schema": "^12.2.0",
@@ -1698,9 +1698,9 @@
       }
     },
     "node_modules/@grafana/plugin-ui": {
-      "version": "0.10.9",
-      "resolved": "https://registry.npmjs.org/@grafana/plugin-ui/-/plugin-ui-0.10.9.tgz",
-      "integrity": "sha512-mKB/JbKKcbteVNel4UkmQ3inWBOufWjBibk0XSJ62BJkptNnmN0kA8qMfkFtMXKgnQnrDGXJ0hVTVS4iqdDlUQ==",
+      "version": "0.10.10",
+      "resolved": "https://registry.npmjs.org/@grafana/plugin-ui/-/plugin-ui-0.10.10.tgz",
+      "integrity": "sha512-escK3Dpm2eP4VimCRt+tQfjpOrH2cNJ8Ku1DouVxzH9+o8aPcLRP36629e+kv4RrYl1Fs8qgu9gbF8Nr8vKIww==",
       "dependencies": {
         "@emotion/css": "^11.11.2",
         "@hello-pangea/dnd": "^17.0.0",
@@ -1777,20 +1777,20 @@
       }
     },
     "node_modules/@grafana/prometheus": {
-      "version": "12.2.0-17027759091",
-      "resolved": "https://registry.npmjs.org/@grafana/prometheus/-/prometheus-12.2.0-17027759091.tgz",
-      "integrity": "sha512-028mqDB+vegCSOPCmohBQ0zKa0yGQ7KYW3leq5d+jItCEsNWr6JaoyRaHm3f3nl5SODyxrpFAJvce9zbjCLPww==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@grafana/prometheus/-/prometheus-12.2.0.tgz",
+      "integrity": "sha512-vu05a0QM9XeiZH1aUPHnmugEBiKgA7z8FxzuX9Rg2aYFeXjfPZN1VGwH+ZT0guMJfGCpQSvGSO5+axcHxlyKxQ==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@emotion/css": "11.13.5",
-        "@floating-ui/react": "0.27.15",
-        "@grafana/data": "12.2.0-17027759091",
-        "@grafana/e2e-selectors": "12.2.0-17027759091",
-        "@grafana/i18n": "12.2.0-17027759091",
-        "@grafana/plugin-ui": "0.10.9",
-        "@grafana/runtime": "12.2.0-17027759091",
-        "@grafana/schema": "12.2.0-17027759091",
-        "@grafana/ui": "12.2.0-17027759091",
+        "@floating-ui/react": "0.27.16",
+        "@grafana/data": "12.2.0",
+        "@grafana/e2e-selectors": "12.2.0",
+        "@grafana/i18n": "12.2.0",
+        "@grafana/plugin-ui": "^0.10.10",
+        "@grafana/runtime": "12.2.0",
+        "@grafana/schema": "12.2.0",
+        "@grafana/ui": "12.2.0",
         "@hello-pangea/dnd": "18.0.1",
         "@leeoniya/ufuzzy": "1.0.18",
         "@lezer/common": "1.2.3",
@@ -1824,412 +1824,6 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
-    },
-    "node_modules/@grafana/prometheus/node_modules/@floating-ui/react": {
-      "version": "0.27.15",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.15.tgz",
-      "integrity": "sha512-0LGxhBi3BB1DwuSNQAmuaSuertFzNAerlMdPbotjTVnvPtdOs7CkrHLaev5NIXemhzDXNC0tFzuseut7cWA5mw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.5",
-        "@floating-ui/utils": "^0.2.10",
-        "tabbable": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/@grafana/data": {
-      "version": "12.2.0-17027759091",
-      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-12.2.0-17027759091.tgz",
-      "integrity": "sha512-25m5mnVVGPdEa1Z324rQteycQNT2/cnv/ax2RSknVjUPPggy7TK5jihWuCFlPUgu6fHEbT48sQhD/tDc18+H7g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@braintree/sanitize-url": "7.0.1",
-        "@grafana/i18n": "12.2.0-17027759091",
-        "@grafana/schema": "12.2.0-17027759091",
-        "@leeoniya/ufuzzy": "1.0.18",
-        "@types/d3-interpolate": "^3.0.0",
-        "@types/string-hash": "1.1.3",
-        "@types/systemjs": "6.15.3",
-        "d3-interpolate": "3.0.1",
-        "date-fns": "4.1.0",
-        "dompurify": "3.2.6",
-        "eventemitter3": "5.0.1",
-        "fast_array_intersect": "1.1.0",
-        "history": "4.10.1",
-        "lodash": "4.17.21",
-        "marked": "16.1.1",
-        "marked-mangle": "1.1.11",
-        "moment": "2.30.1",
-        "moment-timezone": "0.5.47",
-        "ol": "10.6.1",
-        "papaparse": "5.5.3",
-        "react-use": "17.6.0",
-        "rxjs": "7.8.2",
-        "string-hash": "^1.1.3",
-        "tinycolor2": "1.6.0",
-        "tslib": "2.8.1",
-        "uplot": "1.6.32",
-        "xss": "^1.0.14"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/@grafana/e2e-selectors": {
-      "version": "12.2.0-17027759091",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.2.0-17027759091.tgz",
-      "integrity": "sha512-R7tYbAl0X0Wa76wWKB3g8cPrJuL2P3GDmIRHcXd8pSQ212J2FVEgMcd4RY6YgWdfebIJuKAvFIEv87qSWZ3DSQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "semver": "^7.7.0",
-        "tslib": "2.8.1",
-        "typescript": "5.9.2"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/@grafana/faro-core": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.19.0.tgz",
-      "integrity": "sha512-Juo5G/aviSh3XqSGGr6D61noAC8sb+oCawBsv545ILEeOQdINyzRaoQdRpnXEY3DLS9LYtL0PYhvHZiP3rlscQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/otlp-transformer": "^0.202.0"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/@grafana/faro-web-sdk": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.19.0.tgz",
-      "integrity": "sha512-3u74mV2uBWqoF6WBx71p0vtkaS1Z0QbGoZ8tuX5yiYnIybqnhKdGkApFUi7q5se0tMPIeJdMVoRFdLU8f9hfAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grafana/faro-core": "^1.19.0",
-        "ua-parser-js": "^1.0.32",
-        "web-vitals": "^4.0.1"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/@grafana/i18n": {
-      "version": "12.2.0-17027759091",
-      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.2.0-17027759091.tgz",
-      "integrity": "sha512-D/IkICvG3+on7NoQNOT2/I8jNjLAzFQ1PFGdbEiTpVDBuZLmJ999vXw74RkslODBJfKfWOWlSfggRxhKQXJSog==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@formatjs/intl-durationformat": "^0.7.0",
-        "@typescript-eslint/utils": "^8.33.1",
-        "fast-deep-equal": "^3.1.3",
-        "i18next": "^25.0.0",
-        "i18next-browser-languagedetector": "^8.0.0",
-        "i18next-pseudo": "^2.2.1",
-        "micro-memoize": "^4.1.2",
-        "react-i18next": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/@grafana/runtime": {
-      "version": "12.2.0-17027759091",
-      "resolved": "https://registry.npmjs.org/@grafana/runtime/-/runtime-12.2.0-17027759091.tgz",
-      "integrity": "sha512-XW/SInjC4Ija87zzyJmdjYYjKTZun6AM/hoCZLPFNXOBzfkT1jP635MffKYvDtiJf6IkeL2+soJvKgpNKiorMA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grafana/data": "12.2.0-17027759091",
-        "@grafana/e2e-selectors": "12.2.0-17027759091",
-        "@grafana/faro-web-sdk": "^1.13.2",
-        "@grafana/schema": "12.2.0-17027759091",
-        "@grafana/ui": "12.2.0-17027759091",
-        "@types/systemjs": "6.15.3",
-        "history": "4.10.1",
-        "lodash": "4.17.21",
-        "react-loading-skeleton": "3.5.0",
-        "react-use": "17.6.0",
-        "rxjs": "7.8.2",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/@grafana/schema": {
-      "version": "12.2.0-17027759091",
-      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-12.2.0-17027759091.tgz",
-      "integrity": "sha512-ee5UwMcSP8KCaVpjVJ9IzYfbr4MmfXtFFrHfxp4oBoN538ywNfL2I+hd8dn9kVUdWx2+Fo2xUt2Yt53f+bn+7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "2.8.1"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/@grafana/ui": {
-      "version": "12.2.0-17027759091",
-      "resolved": "https://registry.npmjs.org/@grafana/ui/-/ui-12.2.0-17027759091.tgz",
-      "integrity": "sha512-bj1qJRGrDKq5gMPAxE4SkTo1Yx2kmIorScABcRagC649JaXYpsdxiB0xdGvv64yp7PZnvPHwvD1fXlD+L5dflQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@emotion/css": "11.13.5",
-        "@emotion/react": "11.14.0",
-        "@emotion/serialize": "1.3.3",
-        "@floating-ui/react": "0.27.15",
-        "@grafana/data": "12.2.0-17027759091",
-        "@grafana/e2e-selectors": "12.2.0-17027759091",
-        "@grafana/faro-web-sdk": "^1.13.2",
-        "@grafana/i18n": "12.2.0-17027759091",
-        "@grafana/schema": "12.2.0-17027759091",
-        "@hello-pangea/dnd": "18.0.1",
-        "@monaco-editor/react": "4.7.0",
-        "@popperjs/core": "2.11.8",
-        "@react-aria/dialog": "3.5.28",
-        "@react-aria/focus": "3.21.0",
-        "@react-aria/overlays": "3.28.0",
-        "@react-aria/utils": "3.30.0",
-        "@tanstack/react-virtual": "^3.5.1",
-        "@types/jquery": "3.5.32",
-        "@types/lodash": "4.17.20",
-        "@types/react-table": "7.7.20",
-        "calculate-size": "1.1.1",
-        "classnames": "2.5.1",
-        "clsx": "^2.1.1",
-        "d3": "7.9.0",
-        "date-fns": "4.1.0",
-        "downshift": "^9.0.6",
-        "hoist-non-react-statics": "3.3.2",
-        "i18next": "^25.0.0",
-        "i18next-browser-languagedetector": "^8.0.0",
-        "immutable": "5.1.3",
-        "is-hotkey": "0.2.0",
-        "jquery": "3.7.1",
-        "lodash": "4.17.21",
-        "micro-memoize": "^4.1.2",
-        "moment": "2.30.1",
-        "monaco-editor": "0.34.1",
-        "ol": "10.6.1",
-        "prismjs": "1.30.0",
-        "rc-cascader": "3.34.0",
-        "rc-drawer": "7.3.0",
-        "rc-picker": "4.11.3",
-        "rc-slider": "11.1.8",
-        "rc-tooltip": "6.4.0",
-        "react-calendar": "^6.0.0",
-        "react-colorful": "5.6.1",
-        "react-custom-scrollbars-2": "4.5.0",
-        "react-data-grid": "github:grafana/react-data-grid#a922856b5ede21d55db3fdffb6d38dc76bdc7c58",
-        "react-dropzone": "14.3.8",
-        "react-highlight-words": "0.21.0",
-        "react-hook-form": "^7.49.2",
-        "react-i18next": "^15.0.0",
-        "react-inlinesvg": "4.2.0",
-        "react-loading-skeleton": "3.5.0",
-        "react-router-dom": "5.3.4",
-        "react-router-dom-v5-compat": "^6.26.1",
-        "react-select": "5.10.2",
-        "react-table": "7.8.0",
-        "react-transition-group": "4.4.5",
-        "react-use": "17.6.0",
-        "react-window": "1.8.11",
-        "rxjs": "7.8.2",
-        "slate": "0.47.9",
-        "slate-plain-serializer": "0.7.13",
-        "slate-react": "0.22.10",
-        "tinycolor2": "1.6.0",
-        "tslib": "2.8.1",
-        "uplot": "1.6.32",
-        "uuid": "11.1.0",
-        "uwrap": "0.1.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/@opentelemetry/api-logs": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.202.0.tgz",
-      "integrity": "sha512-fTBjMqKCfotFWfLzaKyhjLvyEyq5vDKTTFfBmx21btv3gvy8Lq6N5Dh2OzqeuN4DjtpSvNT1uNVfg08eD2Rfxw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.202.0.tgz",
-      "integrity": "sha512-5XO77QFzs9WkexvJQL9ksxL8oVFb/dfi9NWQSq7Sv0Efr9x3N+nb1iklP1TeVgxqJ7m1xWiC/Uv3wupiQGevMw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.202.0",
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1",
-        "@opentelemetry/sdk-logs": "0.202.0",
-        "@opentelemetry/sdk-metrics": "2.0.1",
-        "@opentelemetry/sdk-trace-base": "2.0.1",
-        "protobufjs": "^7.3.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.202.0.tgz",
-      "integrity": "sha512-pv8QiQLQzk4X909YKm0lnW4hpuQg4zHwJ4XBd5bZiXcd9urvrJNoNVKnxGHPiDVX/GiLFvr5DMYsDBQbZCypRQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.202.0",
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/i18next": {
-      "version": "25.3.6",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.3.6.tgz",
-      "integrity": "sha512-dThZ0CTCM3sUG/qS0ZtQYZQcUI6DtBN8yBHK+SKEqihPcEYmjVWh/YJ4luic73Iq6Uxhp6q7LJJntRK5+1t7jQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.27.6"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
-    "node_modules/@grafana/prometheus/node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/react-router-dom-v5-compat": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.0.tgz",
-      "integrity": "sha512-MAVRASbdQ3+ZOTPPjAa7jKcF0F9LkHWKB/iib3hf+jzzIazL4GEpMDDdTswCsqRQNU+zNnT3qD0WiNbzJ6ncPw==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "history": "^5.3.0",
-        "react-router": "6.30.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8",
-        "react-router-dom": "4 || 5"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/react-router-dom-v5-compat/node_modules/history": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/react-router-dom-v5-compat/node_modules/react-router": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
-      "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/@grafana/prometheus/node_modules/web-vitals": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
-      "license": "Apache-2.0"
     },
     "node_modules/@grafana/runtime": {
       "version": "12.2.0",
@@ -18643,9 +18237,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/spel2js": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/spel2js/-/spel2js-0.2.8.tgz",
-      "integrity": "sha512-dzYq+v4YV7SPIdNrmvFAUjc0HcgI7b0yoMw7kzOBmlj/GjdOb/+8dVn1I7nLuOS5X2SW+LK3tf2SVkXRjCkWBA==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/spel2js/-/spel2js-0.2.9.tgz",
+      "integrity": "sha512-wquA+u9as+6cV6DBDHi2UKMEYBpI8L5kn4i2MUIDKZSv5AgDQiw00Z8nH2hxrRypuz+BGDJsfjOLAb9eiaylig==",
       "engines": {
         "node": ">=8"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@grafana/faro-web-sdk": "^2.0.0-beta-2",
     "@grafana/i18n": "^12.2.0",
     "@grafana/lezer-logql": "^0.2.7",
-    "@grafana/prometheus": "^12.2.0-258070",
+    "@grafana/prometheus": "^12.2.0",
     "@grafana/runtime": "^12.2.0",
     "@grafana/scenes": "^6.39.0",
     "@grafana/schema": "^12.2.0",


### PR DESCRIPTION
### ✨ Description

Nearly all of the `@grafana/<some-package-versioned-with-grafana-core>` packages have been updated to `^12.2.0`. `@grafana/prometheus` is an exception, and is currently using a prerelease version.

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

This PR bumps `@grafana/prometheus` to match the other `12.2.0` dependencies.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

All CI should pass.
