### PR TITLE
use sub url explicitly. Logs drilldown does this.

### DIFF
--- a/src/MetricScene/PanelMenu/actions/ExploreAction.ts
+++ b/src/MetricScene/PanelMenu/actions/ExploreAction.ts
@@ -1,4 +1,5 @@
 import { type PanelMenuItem } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { getExploreURL, sceneGraph, VizPanel } from '@grafana/scenes';
 
 export class ExploreAction {
@@ -31,7 +32,9 @@ export class ExploreAction {
     return {
       text: 'Explore',
       iconClassName: 'compass',
-      onClick: () => exploreUrl?.then((url) => url && window.open(url, '_blank')),
+      onClick: () => exploreUrl?.then((url) => {
+        return url && window.open(`${config.appSubUrl}${url}`, '_blank');
+      }),
       shortcut: 'p x',
     };
   }


### PR DESCRIPTION
Fixes https://github.com/grafana/metrics-drilldown/issues/683

### ✨ Description

**Related issue(s):** https://github.com/grafana/metrics-drilldown/issues/683

Sub url is not being added when using "Oped in explore" link for some cases.

The precedent for other apps is to explicitly reference the ap sub url

https://github.com/grafana/logs-drilldown/blob/40f20334c29b5bd2ae32cb17320892c78dace4db/src/Components/ServiceScene/GoToExploreButton.tsx#L68-L72

### 📖 Summary of the changes

Use sub url explicitly in open in explore link.

### 🧪 How to test?

The build should pass.
Open in explore should always contain the sub url which can be configured here in Grafana custom.ini

https://github.com/grafana/grafana/blob/22b88988a4c8e0e2e63e6143bc0627b33ff018a0/conf/defaults.ini#L59-L63
