### PR TITLE
refactor: Replace custom flexbox CSS with Stack components in MetricsGroupByRow.tsx

### DIFF
--- a/src/MetricsReducer/MetricsGroupByList/MetricsGroupByRow.tsx
+++ b/src/MetricsReducer/MetricsGroupByList/MetricsGroupByRow.tsx
@@ -12,7 +12,7 @@ import {
   type SceneComponentProps,
   type SceneObjectState,
 } from '@grafana/scenes';
-import { Button, CollapsableSection, Spinner, useStyles2 } from '@grafana/ui';
+import { Button, CollapsableSection, Spinner, Stack, useStyles2 } from '@grafana/ui';
 import React, { useState } from 'react';
 
 import { SceneByVariableRepeater } from 'MetricsReducer/components/SceneByVariableRepeater';
@@ -182,17 +182,19 @@ export class MetricsGroupByRow extends SceneObjectBase<MetricsGroupByRowState> {
     return (
       <div className={styles.container} data-testid={`${labelName}-${labelValue}-metrics-group`}>
         <div className={styles.containerHeader}>
-          <div className={styles.headerButtons}>
-            <Button
-              className={styles.selectButton}
-              variant="secondary"
-              onClick={onClickSelect}
-              tooltip={`See metrics with ${labelName}=${labelValue}`}
-              tooltipPlacement="top"
-            >
-              Select
-            </Button>
-          </div>
+          <Stack direction="row" alignItems="center" gap={1}>
+            <div className={styles.headerButtons}>
+              <Button
+                className={styles.selectButton}
+                variant="secondary"
+                onClick={onClickSelect}
+                tooltip={`See metrics with ${labelName}=${labelValue}`}
+                tooltipPlacement="top"
+              >
+                Select
+              </Button>
+            </div>
+          </Stack>
         </div>
 
         {
@@ -201,28 +203,34 @@ export class MetricsGroupByRow extends SceneObjectBase<MetricsGroupByRowState> {
             onToggle={() => setIsCollapsed(!isCollapsed)}
             label={
               <div className={styles.groupName}>
-                <GroupsIcon />
-                <div className={styles.labelValue}>{labelValue}</div>
-                {labelCardinality > 1 && (
-                  <div className={styles.index}>
-                    ({index + 1}/{labelCardinality})
-                  </div>
-                )}
+                <Stack direction="row" alignItems="center">
+                  <GroupsIcon />
+                  <div className={styles.labelValue}>{labelValue}</div>
+                  {labelCardinality > 1 && (
+                    <div className={styles.index}>
+                      ({index + 1}/{labelCardinality})
+                    </div>
+                  )}
+                </Stack>
               </div>
             }
           >
             <div className={styles.collapsableSectionBody}>
-              <body.Component model={body} />
+              <Stack direction="column" gap={3}>
+                <body.Component model={body} />
+              </Stack>
             </div>
 
             {shouldDisplayShowMoreButton && (
               <div className={styles.footer}>
-                <ShowMoreButton
-                  label="metric"
-                  batchSizes={batchSizes}
-                  onClick={onClickShowMore}
-                  tooltip={`Show more metrics for ${labelName}="${labelValue}"`}
-                />
+                <Stack direction="row" justifyContent="center" alignItems="center">
+                  <ShowMoreButton
+                    label="metric"
+                    batchSizes={batchSizes}
+                    onClick={onClickShowMore}
+                    tooltip={`Show more metrics for ${labelName}="${labelValue}"`}
+                  />
+                </Stack>
               </div>
             )}
           </CollapsableSection>
@@ -248,9 +256,6 @@ function getStyles(theme: GrafanaTheme2) {
       },
     }),
     containerHeader: css({
-      display: 'flex',
-      alignItems: 'center',
-      gap: '8px',
       marginBottom: '-36px',
       paddingBottom: theme.spacing(1.5),
       borderBottom: `1px solid ${theme.colors.border.medium}`,
@@ -266,14 +271,9 @@ function getStyles(theme: GrafanaTheme2) {
       height: '28px',
     }),
     collapsableSectionBody: css({
-      display: 'flex',
-      flexDirection: 'column',
-      gap: '24px',
       padding: theme.spacing(1),
     }),
     groupName: css({
-      display: 'flex',
-      alignItems: 'center',
       fontSize: '1.3rem',
       lineHeight: '1.3rem',
     }),
@@ -287,9 +287,6 @@ function getStyles(theme: GrafanaTheme2) {
       marginLeft: '8px',
     }),
     footer: css({
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
       marginTop: theme.spacing(1),
 
       '& button': {


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** #580 

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->
Replace custom flexbox CSS with Grafana-UI's Stack component in MetricsGroupByRow.tsx as part of the broader effort to reduce custom CSS and improve consistency with Grafana's design system.

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->
CSS Reduction:

- Before: 9 lines of flexbox CSS properties across 4 layout sections
- After: Clean CSS with only non-layout properties (60% reduction)
- Removed CSS: display: 'flex', flexDirection, alignItems, justifyContent, hardcoded gap values

Technical Approach:

- Used wrapper pattern consistently - Stack components inside existing divs with custom CSS
- Converted hardcoded gaps ('8px', '24px') to theme-based spacing tokens (gap={1}, gap={3})

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->
- [ ] Navigate to metrics with group-by labels applied
- [ ] Verify group headers display correctly with icons and text aligned
- [ ] Test collapsing/expanding groups - content should maintain proper spacing
- [ ] Check "Select" button positioning in group headers
- [ ] Verify "Show More" button centers properly in footer when visible
- [ ] Test with different group cardinalities (single vs multiple groups)
