### PR TITLE
fix: ignore certain errors

### DIFF
--- a/src/shared/logger/faro/faro.ts
+++ b/src/shared/logger/faro/faro.ts
@@ -10,6 +10,19 @@ let faro: Faro | null = null;
 export const getFaro = () => faro;
 export const setFaro = (instance: Faro | null) => (faro = instance);
 
+const errorsToIgnore = [
+  // Matches core Grafana config (see https://github.com/grafana grafana/pull/54824)
+  'ResizeObserver loop limit exceeded',
+  'ResizeObserver loop completed',
+  'Non-Error exception captured with keys',
+  'Failed sending payload to the receiver',
+];
+const errorsToIgnoreSet = new Set(errorsToIgnore);
+/**
+ * Determines if an error message is in the list of known non-critical errors that should not be reported to Faro.
+ */
+export const shouldIgnoreError = (errorMessage: string) => errorsToIgnoreSet.has(errorMessage);
+
 export function initFaro() {
   if (getFaro()) {
     return;
@@ -37,6 +50,7 @@ export function initFaro() {
       user: {
         email: userEmail,
       },
+      ignoreErrors: errorsToIgnore,
       instrumentations: [
         ...getWebInstrumentations({
           captureConsole: false,


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** Fixes #848

https://github.com/grafana/grafana/pull/54824 captured a handful of error messages that don't correspond to user-facing issues and should rightfully be ignored, as they are [in other Grafana projects](https://github.com/search?q=org%3Agrafana%20ResizeObserver%20loop%20limit%20exceeded&type=code).

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

This PR ignores certain errors, slightly enriches the context for browser extension errors, and adds more explicit code comments that aim to improve clarity.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

I wasn't able to get any of the `errorsToIgnore` to happen locally, so I'm not sure how to test. I suggest we merge, learn, and go from there.