### PR TITLE
fix: add function for building the path async

### DIFF
--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -26,7 +26,7 @@ const ASSISTANT_TARGET_V1 = 'grafana-assistant-app/navigateToDrilldown/v1';
 
 const ADHOC_URL_DELIMITER = '|';
 
-// add an optional getPath function to the PluginExtensionAddedLinkConfig type
+// add an optional buildPathAsync function to the PluginExtensionAddedLinkConfig type
 type PluginExtensionAddedLinkConfigWithPath<Context extends object> = PluginExtensionAddedLinkConfig<Context> & {
   buildPathAsync?: (context: Context) => Promise<string | null>;
 };
@@ -55,7 +55,7 @@ export const linkConfigs: Array<PluginExtensionAddedLinkConfigWithPath<PluginExt
       }
     },
     buildPathAsync: async (context) => {
-      // lazy load the promQL parser to reduce the initial bundle size 
+      // lazy load the promQL parser to reduce the initial bundle size
       const url = await buildDrilldownUrlAsync(context);
       return url;
     },


### PR DESCRIPTION
### ✨ Description

Use an async function to build the path for Grafana assistant.

See this issue for more context: https://github.com/grafana/metrics-drilldown/issues/851

Summary: We use the onClick link function to lazy load the promQL parser and save on bundle size. Grafana assistant does not use the onClick function for navigation so we never parse the query the assistant provides. We only navigate to the root path of Metrics Drilldown.

#### Companion PRs
[Grafana plugin extension PR](https://github.com/grafana/grafana/pull/113887)
Grafana assistant PR

### 🧪 How to test?

1. Build Grafana assistant
2. Ask it to navigate to metrics drilldown with a query
3. Grafana assistant correctly navigates to metrics drilldown with the metric and any additional labels.
