### PR TITLE
ci: bump shared workflows to `4.3.0`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,9 +7,9 @@ on:
       - main
 
 permissions:
-  contents: 'write'
-  id-token: 'write'
-  attestations: 'write'
+  contents: "write"
+  id-token: "write"
+  attestations: "write"
 
 jobs:
   CD:
@@ -23,6 +23,6 @@ jobs:
       # Use argo workflows, auto merge to dev in deployment tools
       grafana-cloud-deployment-type: provisioned
       auto-merge-environments: dev,ops
-      argo-workflow-slack-channel: '#proj-metricsdrilldown-cd'
+      argo-workflow-slack-channel: "#proj-metricsdrilldown-cd"
       # Add the git head ref sha to the plugin version as suffix (`+abcdef`). This is required for CD builds.
       plugin-version-suffix: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ on:
       - main
 
 permissions:
-  contents: 'read'
-  id-token: 'write'
+  contents: "read"
+  id-token: "write"
 
 jobs:
   CI:
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v4.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v4.3.0
     with:
       run-playwright: false
       run-playwright-docker: true

--- a/.github/workflows/playwright-published.yml
+++ b/.github/workflows/playwright-published.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 permissions:
-  contents: 'read'
+  contents: "read"
 
 jobs:
   build:
@@ -27,8 +27,8 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -57,10 +57,10 @@ jobs:
           echo "plugin-name=$name" >> $GITHUB_OUTPUT
 
       - name: Sign and package
-        uses: grafana/plugin-ci-workflows/actions/internal/plugins/package@ci-cd-workflows/v4.2.0
+        uses: grafana/plugin-ci-workflows/actions/internal/plugins/package@ci-cd-workflows/v4.3.0
         with:
           output-folder: dist-artifacts
-          universal: 'true'
+          universal: "true"
           dist-folder: dist
           access-policy-token: ${{ fromJSON(steps.get-secrets.outputs.secrets).access_policy_token }}
 
@@ -73,7 +73,7 @@ jobs:
 
   playwright:
     needs: build
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@ci-cd-workflows/v4.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@ci-cd-workflows/v4.3.0
     with:
       id: ${{ needs.build.outputs.plugin-name }}
       version: ${{ needs.build.outputs.plugin-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-grafana-dev-image:
-        description: 'Bypass grafana-dev image for e2e tests'
+        description: "Bypass grafana-dev image for e2e tests"
         required: false
         type: boolean
         default: false
@@ -26,9 +26,9 @@ on:
       - main
 
 permissions:
-  contents: 'write'
-  id-token: 'write'
-  attestations: 'write'
+  contents: "write"
+  id-token: "write"
+  attestations: "write"
 
 jobs:
   CD:
@@ -40,9 +40,9 @@ jobs:
         (github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'npm version')) ||
         (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
       )
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v4.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v4.3.0
     with:
-      environment: 'prod' # publishing to 'prod' will also deploy to 'ops' and 'dev'
+      environment: "prod" # publishing to 'prod' will also deploy to 'ops' and 'dev'
       attestation: true # this guarantees that the plugin was built from the source code provided in the release
       run-playwright: false
       run-playwright-docker: true
@@ -51,4 +51,4 @@ jobs:
       playwright-report-path: e2e/test-reports/
       playwright-docker-compose-file: docker-compose.yaml
       playwright-grafana-url: http://localhost:3001
-      argo-workflow-slack-channel: '#proj-metricsdrilldown-cd'
+      argo-workflow-slack-channel: "#proj-metricsdrilldown-cd"

--- a/.github/workflows/version-bump-changelog.yml
+++ b/.github/workflows/version-bump-changelog.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Semver type of new version (major / minor / patch)'
+        description: "Semver type of new version (major / minor / patch)"
         required: true
         type: choice
         options:
@@ -12,7 +12,7 @@ on:
           - minor
           - major
       generate-changelog:
-        description: 'Generate changelog'
+        description: "Generate changelog"
         required: false
         type: boolean
         default: true
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Version bump
-        uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@ci-cd-workflows/v4.2.0
+        uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@ci-cd-workflows/v4.3.0
         with:
           generate-changelog: ${{ inputs.generate-changelog }}
           version: ${{ inputs.version }}


### PR DESCRIPTION
### ✨ Description

Version `4.3.0` contains a fix (https://github.com/grafana/plugin-ci-workflows/pull/404) that will help us overcome failing CD in circumstances like https://github.com/grafana/metrics-drilldown/commit/208aeb767ca093679310fa5a38bc7951a250c701, where `@grafana-plugins-platform-bot[bot]` is the commit author.

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

This PR upgrades all plugin shared workflows to version `4.3.0`.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

- [x] All CI should pass
