### PR TITLE
chore: add `openFeature` context

### DIFF
--- a/src/shared/featureFlags/openFeature.ts
+++ b/src/shared/featureFlags/openFeature.ts
@@ -94,8 +94,8 @@ export function initOpenFeatureProvider(): Promise<void> {
       timeoutMs: 10_000, // Timeout after 10 seconds
     }),
     {
-      targetingKey: config.namespace,
-      namespace: config.namespace,
+      targetingKey: config.namespace, // Dimension of uniqueness, to ensure flags are evaluated consistently for a given stack
+      namespace: config.namespace, // Required by the multi-tenant feature flag service
       ...config.openFeatureContext,
     }
   );


### PR DESCRIPTION
### ✨ Description

This is a follow-up to #886. It adds additional [context](https://docs.google.com/document/d/1EfBDuzO0KaGT2GYay6bNaqwZ4c_imjZQ3VeEpEMVBXE/edit?tab=t.nii621u9xkdh#heading=h.mt7zyatuc30z) from `@grafana/runtime` that can be used in our feature flag [targeting rules](https://gofeatureflag.org/docs/configure_flag/target-with-flags).

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

Adds `config.openFeatureContext` to our feature flag [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context).

### 🧪 How to test?

No need to test anything at this point. We can leverage some of the `openFeatureContext` in an upcoming feature flag configuration. All CI should pass, though.
