### PR TITLE
fix(OpenFeature): gracefully degrade when OFREP endpoint is unavailable

### DIFF
--- a/src/shared/featureFlags/openFeature.ts
+++ b/src/shared/featureFlags/openFeature.ts
@@ -108,7 +108,11 @@ export function initOpenFeatureProvider(): Promise<void> {
       namespace: config.namespace, // Required by the multi-tenant feature flag service
       ...config.openFeatureContext,
     }
-  );
+  ).catch((error) => {
+    // OpenFeature initialization may fail in environments without the feature flag service.
+    // This is expected and the app will continue to work with default flag values.
+    logger.warn('OpenFeature provider initialization failed, using default flag values', error);
+  });
 }
 
 /**


### PR DESCRIPTION
### ✨ Description

This PR fixes #897

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->

In Grafana instances where Grafana's multi-tenant [OFREP](https://github.com/open-feature/protocol) endpoint isn't available, let's gracefully degrade, logging a warning instead of living with an unhandled promise rejection. When this happens, the OpenFeature client falls back to default flag values.

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->

I'm not sure yet how to test this, but I will look into a recipe for local testing.
