### PR TITLE
fix: add webpack alias for @grafana/i18n to resolve pnpm module duplication

### DIFF
--- a/.config/webpack/webpack.config.ts
+++ b/.config/webpack/webpack.config.ts
@@ -232,11 +232,6 @@ const config = async (env: Env): Promise<Configuration> => {
       // handle resolving "rootDir" paths
       modules: [path.resolve(process.cwd(), 'src'), 'node_modules'],
       unsafeCache: true,
-      // Ensure single instances of these packages when using pnpm
-      // This prevents module duplication issues with i18n state
-      alias: {
-        '@grafana/i18n': path.resolve(process.cwd(), 'node_modules/@grafana/i18n'),
-      },
     },
   };
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "AGPL-3.0",
   "scripts": {
     "prebuild": "./scripts/update-commit-sha.sh",
-    "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
-    "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "analyze": "webpack -c ./webpack-analyze.config.ts --env production",
     "tdd": "jest --watch --onlyChanged",
     "test": "jest --watch --onlyChanged",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { type Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
 
@@ -14,6 +16,13 @@ const config = async (env): Promise<Configuration> => {
     },
     output: {
       asyncChunks: true,
+    },
+    resolve: {
+      alias: {
+        // Ensure single instances of these packages when using pnpm
+        // This prevents module duplication issues with i18n state
+        '@grafana/i18n': path.resolve(process.cwd(), 'node_modules/@grafana/i18n'),
+      },
     },
   });
 };


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** #957 (pnpm migration)

<!-- Resolves # -->

After migrating from npm to pnpm, the plugin fails to load with `t() was called before i18n was initialized` errors. This is caused by pnpm's symlinked `node_modules` structure causing webpack to bundle multiple copies of `@grafana/i18n`, which breaks the shared module state that the i18n system relies on.

### 📖 Summary of the changes

Added a webpack resolve alias for `@grafana/i18n` in `.config/webpack/webpack.config.ts`:

```javascript
alias: {
  '@grafana/i18n': path.resolve(process.cwd(), 'node_modules/@grafana/i18n'),
},
```

This forces all imports of `@grafana/i18n` (from both plugin code and `@grafana/scenes`) to resolve to the same absolute path, ensuring webpack bundles only one copy. This preserves the shared `tFunc` state that `initPluginTranslations()` sets.

Note: Only `@grafana/i18n` needs this alias since that's where the shared state lives. Other packages like `@grafana/scenes` don't require this treatment.

### 🧪 How to test?

1. Run metrics-drilldown locally
2. Verify plugin loads on the metrics-drilldown page.
3. Verify the app loads and translations work correctly (e.g., time picker tooltips)
