### PR TITLE
chore: update pnpm version to 10.28.2

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -23,10 +23,10 @@ A comprehensive guide for contributors to the Grafana Metrics Drilldown plugin -
 - **Node.js**: 22+ required
 - **Docker**: For local Grafana development server
 - **Git**: For version control
-- **pnpm**: 10.28.1+ required - Install via corepack (recommended) or see [pnpm installation guide](https://pnpm.io/installation) for other methods:
+- **pnpm**: 10.28.2+ required - Install via corepack (recommended) or see [pnpm installation guide](https://pnpm.io/installation) for other methods:
   ```bash
   corepack enable
-  corepack prepare pnpm@10.28.1 --activate
+  corepack prepare pnpm@10.28.2 --activate
   ```
 
 ### Initial Setup

--- a/e2e/docker/Dockerfile.playwright
+++ b/e2e/docker/Dockerfile.playwright
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/playwright:v1.58.0@sha256:35c7d48b4ccaf3aca5018f5f1bf7f50
 WORKDIR /app
 
 # Enable pnpm via corepack and install dependencies
-RUN corepack enable && corepack prepare pnpm@10.28.1 --activate && \
+RUN corepack enable && corepack prepare pnpm@10.28.2 --activate && \
   pnpm install "@playwright/test@1.58.0" "dotenv@^16.3.1" "@grafana/plugin-e2e" "@grafana/i18n@^12.3.0"
 
 ENV TZ=Europe/Madrid


### PR DESCRIPTION
`pnpm` - in the package.json file - was updated to version `10.28.2` previously. This PR brings the `pnpm` version up to `10.28.2` across the codebase.