### PR TITLE
ci: grant pull-requests write permission for PR labeling

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   validate-pr-title:


### PR DESCRIPTION
The PR title validation workflow was failing on fork PRs with "Resource not accessible by integration" when attempting to add labels. This was missed when switching to pull_request_target in #1030.