### PR TITLE
fix: saved queries cloud (Query Library) integration

### DIFF
--- a/SAVED_QUERIES_IMPLEMENTATION.md
+++ b/SAVED_QUERIES_IMPLEMENTATION.md
@@ -1,0 +1,199 @@
+# Saved Queries Feature Implementation
+
+This document summarizes the implementation of the saved queries feature for Grafana Metrics Drilldown, based on the pattern from Logs Drilldown (PR #1702).
+
+## Overview
+
+The saved queries feature allows users to save and reload metric exploration states, including:
+- Metric name
+- Label filters (label matchers)
+- Datasource configuration
+
+**Storage Strategy:**
+- **Primary:** Grafana Query Library (Grafana 12.4.0+ with `queryLibrary` feature flag)
+- **Fallback:** Browser localStorage (for OSS users and older Grafana versions)
+
+## Files Created
+
+### Service Layer (3 files)
+
+1. **`src/services/saveQuery.ts`**
+   - Core CRUD operations for saved queries
+   - Hooks: `useSavedQueries()`, `useHasSavedQueries()`, `useCheckForExistingQuery()`
+   - LocalStorage management functions
+   - Feature detection: `isQueryLibrarySupported()`
+   - Data model: `SavedQuery` and `PrometheusQuery` interfaces
+
+2. **`src/services/narrowSavedQueries.ts`**
+   - Runtime type validation for saved queries
+   - Type guards: `isSavedQuery()`, `narrowSavedQuery()`, `narrowSavedQueries()`
+   - Ensures data integrity when reading from localStorage
+
+3. **`src/services/parsePrometheusQuery.ts`**
+   - Parses PromQL expressions to extract components
+   - Extracts metric name and label matchers from query strings
+   - Filters out special placeholders (`__ignore_usage__`, `${filters:raw}`)
+
+4. **`src/services/variableGetters.ts`**
+   - Helper functions for safely accessing scene variables
+   - `getDataSourceVariable()` - Type-safe datasource variable access
+   - `getDataSourceUid()` - Get datasource UID from scene
+
+### UI Components (4 files)
+
+1. **`src/Components/SavedQueries/SaveQueryButton.tsx`**
+   - Functional component for save button
+   - Switches between Query Library component and fallback modal
+   - Extracts current state (metric, filters, datasource) from MetricScene
+   - Builds PromQL expression using `buildQueryExpression()`
+
+2. **`src/Components/SavedQueries/SaveQueryModal.tsx`**
+   - Fallback modal for saving queries (localStorage mode)
+   - Form with title (required) and description (optional)
+   - Displays PromQL expression preview
+   - Duplicate detection with warning
+   - Analytics tracking on save
+
+3. **`src/Components/SavedQueries/LoadQueryScene.tsx`**
+   - Scene object for load functionality
+   - Manages datasource state changes
+   - Switches between Query Library component and fallback modal
+   - Handles query selection and navigation via `MetricSelectedEvent`
+   - Parses PromQL to reconstruct exploration state
+
+4. **`src/Components/SavedQueries/LoadQueryModal.tsx`**
+   - Fallback modal for loading queries (localStorage mode)
+   - Two-panel layout: query list (left) + details (right)
+   - Shows title, timestamp, description, and PromQL preview
+   - Delete and select actions
+   - Analytics tracking on load/delete
+
+## Files Modified
+
+### Integration Points (2 files)
+
+1. **`src/MetricScene/MetricActionBar.tsx`**
+   - Added `loadQueryScene` to `MetricActionBarState`
+   - Constructor and activation handler to initialize `LoadQueryScene`
+   - Renders `SaveQueryButton` and `LoadQueryScene.Component` in action bar
+
+2. **`src/AppDataTrail/DataTrail.tsx`**
+   - Added `loadQueryScene` to `DataTrailState`
+   - Initialized `LoadQueryScene` in constructor
+   - Renders `LoadQueryScene.Component` in header controls
+
+### Configuration (3 files)
+
+1. **`src/shared/user-preferences/pref-keys.ts`**
+   - Added `SAVED_QUERIES: 'saved-queries'` to `PREF_KEYS`
+
+2. **`src/shared/tracking/interactions.ts`**
+   - Added 6 new analytics events:
+     - `save_query_modal_opened`
+     - `query_saved` (with metadata: has_description, label_matcher_count, storage_type)
+     - `load_query_modal_opened` (with metadata: saved_query_count, storage_type)
+     - `saved_query_loaded` (with metadata: label_matcher_count, storage_type)
+     - `saved_query_deleted` (with metadata: storage_type)
+     - `duplicate_query_warning_shown`
+
+3. **`src/plugin.json`**
+   - Added `"grafana/query-library-context/v1"` to `dependencies.extensions.exposedComponents` (components this app consumes)
+   - Declares the app’s dependency on the Query Library so Grafana can inject it when available (Grafana 12.4+ with `queryLibrary` feature flag)
+
+### Dependencies (1 file)
+
+1. **`package.json`**
+   - Added `uuid@^11.1.0` for generating unique identifiers
+   - Note: `semver` was already present, so no changes needed
+
+## Data Model
+
+### SavedQuery Interface
+```typescript
+interface SavedQuery {
+  uid: string;                    // UUID
+  title: string;                  // User-provided name
+  description: string;            // Optional description
+  timestamp: number;              // Creation time
+  dsUid: string;                  // Datasource UID
+  metric: string;                 // Metric name
+  labelMatchers: LabelMatcher[];  // Label filters [{key, operator, value}]
+  resolution?: 'HIGH' | 'MEDIUM' | 'LOW';  // Optional
+  groupByField?: string;          // Optional group-by label
+}
+```
+
+### Storage Key
+- `grafana-metricsdrilldown-app.savedQueries` (uses plugin ID prefix)
+
+## Key Features
+
+1. **Dual Storage Support**
+   - Automatically detects Query Library availability
+   - Falls back to localStorage for older Grafana versions
+   - Seamless UX switching between modes
+
+2. **Type Safety**
+   - Runtime type validation for localStorage data
+   - TypeScript interfaces for compile-time safety
+   - Helper functions with proper type guards
+
+3. **State Management**
+   - Extracts full exploration state from MetricScene
+   - Reconstructs state when loading saved query
+   - Handles datasource switching correctly
+
+4. **Analytics Tracking**
+   - Comprehensive event tracking for all user actions
+   - Metadata includes storage type for behavior analysis
+   - Tracks duplicate warnings
+
+5. **User Experience**
+   - Duplicate detection prevents accidental overwrites
+   - Displays formatted PromQL expressions
+   - Timestamps for saved queries
+   - Delete functionality with confirmation
+
+## Integration Architecture
+
+### Save Flow
+1. User clicks Save button in MetricActionBar or uses Query Library
+2. SaveQueryButton extracts current state from DataTrail/MetricScene
+3. Builds PromQL expression using `buildQueryExpression()`
+4. Opens SaveQueryModal (fallback) or Query Library modal
+5. User enters title/description
+6. Query saved to localStorage with UUID and timestamp
+7. Analytics event fired
+
+### Load Flow
+1. User clicks Load button in DataTrail header or MetricActionBar
+2. LoadQueryScene shows modal (fallback) or Query Library dropdown
+3. User selects saved query from list
+4. Parser extracts metric and label matchers from PromQL
+5. Navigation triggered via `MetricSelectedEvent` with URL values
+6. DataTrail reconstructs exploration state
+7. Analytics event fired
+
+## Testing Checklist
+
+- [x] TypeScript compilation passes
+- [ ] Save query from metric detail view
+- [ ] Load query from landing page (metrics list)
+- [ ] Load query from metric detail view
+- [ ] Queries persist across browser sessions
+- [ ] Datasource switching works correctly
+- [ ] Duplicate warning appears when saving identical query
+- [ ] Delete query removes from list
+- [ ] Query Library integration (requires Grafana 12.4+)
+- [ ] Fallback to localStorage on older Grafana
+- [ ] Analytics events fire correctly
+
+## Future Enhancements
+
+Potential improvements (not implemented):
+- Query sharing across users (requires backend)
+- Query categories/tags
+- Import/export functionality
+- Query history/versioning
+- Search/filter saved queries
+- Query templates

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -10,7 +10,8 @@
       "exposedComponents": [
         "grafana/add-to-dashboard-form/v1",
         "grafana/alerting/create-alert-from-panel/v1",
-        "grafana/prometheus-query-results/v1"
+        "grafana/prometheus-query-results/v1",
+        "grafana/query-library-context/v1"
       ]
     }
   },

--- a/src/shared/savedQueries/LoadQueryScene.tsx
+++ b/src/shared/savedQueries/LoadQueryScene.tsx
@@ -142,7 +142,24 @@ export class LoadQueryScene extends SceneObjectBase<LoadQuerySceneState> {
         </>
       );
     } else if (isLoadingExposedComponent || !OpenQueryLibraryComponent) {
-      return null;
+      // Fall back to local UI when Query Library is supported but the exposed component is not available
+      return (
+        <>
+          <ToolbarButton
+            icon="folder-open"
+            variant="canvas"
+            disabled={!hasSavedQueries}
+            onClick={model.toggleOpen}
+            className={styles.button}
+            tooltip={
+              hasSavedQueries
+                ? t('metrics.metrics-drilldown.load-query.button-tooltip', 'Load saved query')
+                : t('metrics.metrics-drilldown.load-query.button-no-query-tooltip', 'No saved queries to load')
+            }
+          />
+          {isOpen && <LoadQueryModal sceneRef={model} onClose={model.toggleClosed} />}
+        </>
+      );
     }
 
     return (

--- a/src/shared/savedQueries/SaveQueryButton.tsx
+++ b/src/shared/savedQueries/SaveQueryButton.tsx
@@ -93,7 +93,19 @@ export function SaveQueryButton({ sceneRef }: Props) {
       </>
     );
   } else if (isLoadingExposedComponent || !OpenQueryLibraryComponent) {
-    return null;
+    // Fall back to local UI when Query Library is supported but the exposed component is not available
+    return (
+      <>
+        <ToolbarButton
+          variant="canvas"
+          icon="save"
+          disabled={!promql}
+          onClick={() => setSaving(true)}
+          tooltip={t('metrics.metrics-drilldown.save-query.button-tooltip', 'Save query')}
+        />
+        {saving && <SaveQueryModal dsUid={dsUid} query={promql} onClose={() => setSaving(false)} />}
+      </>
+    );
   }
 
   return (


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/metrics-drilldown/pull/1064
Resolves <!-- Paste Github issue that is resolved by this pull request -->

Fixes saved queries “save to cloud” (Query Library) behavior so users can save and load queries via the Grafana Query Library when it’s available, and always see Save/Load buttons (using local storage when the cloud component isn’t available).

**Before:** With “save to cloud” enabled (Query Library supported), the Load button was missing on the metric select page and both Save and Load were missing on the metric breakdown action bar, because the app never declared the Query Library dependency and the cloud component was never injected.

**After:** The app declares its dependency on the Query Library in `plugin.json`, so Grafana injects the cloud component when available (Grafana 12.4+ with `queryLibrary` feature flag). When the component is still loading or not available, the app shows the local Save/Load UI so the buttons are always visible and users can at least use localStorage.

### 📖 Summary of the changes

- **`src/plugin.json`**  
  - Added `"grafana/query-library-context/v1"` to `dependencies.extensions.exposedComponents`.  
  - This declares that the app consumes the Query Library component so Grafana can resolve and inject it when the feature is available. Without this, `usePluginComponent('grafana/query-library-context/v1')` always received `undefined`.

- **`src/shared/savedQueries/LoadQueryScene.tsx`**  
  - When Query Library is supported but the exposed component is unavailable (`isLoadingExposedComponent || !OpenQueryLibraryComponent`), the component now renders the **local** Load button and modal instead of returning `null`.  
  - Ensures the Load button is always visible on the metric select page and in the action bar.

- **`src/shared/savedQueries/SaveQueryButton.tsx`**  
  - Same fallback: when Query Library is supported but the cloud component is unavailable, render the local Save button and modal instead of `null`.  
  - Ensures the Save button is always visible on both the metric list and the metric breakdown action bar.

- **`SAVED_QUERIES_IMPLEMENTATION.md`**  
  - Updated to state that the Query Library ID was added to `dependencies.extensions.exposedComponents` (consumed components), not to the app’s own exposed components list.

### 🧪 How to test?

1. **Environment:** Grafana 12.4+ with the `queryLibrary` feature flag enabled (e.g. in config or env).
2. **Restart Grafana** (or fully reload the app) so the updated `plugin.json` is loaded.
3. **Metric select page (Drilldown > Metrics > All metrics):**
   - Confirm the **Load saved query** button appears to the right of the save control.
   - Confirm the **Save** control is visible (e.g. floppy icon).
   - Use Save and confirm the Query Library flow is used when the component is available (e.g. “Save in Saved Queries” / cloud). Use Load and confirm saved queries from the library can be loaded.
4. **Metric breakdown (after selecting a metric):**
   - In the action bar (above Breakdown / Related metrics / etc.), confirm **Save** and **Load** buttons are visible.
   - Save the current metric + filters and load a saved query; confirm cloud save/load when the Query Library is available.
5. **Fallback (optional):** In an environment where the Query Library is not available (e.g. feature flag off or older Grafana), confirm Save and Load buttons still appear and work via the local (localStorage) modals.