### PR TITLE
chore(docker): support appending feature toggles and fix alert rules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ GRAFANA_SCOPES_PORT=3002
 
 # Path to logs-drilldown plugin dist directory (useful for git worktree setups)
 # LOGS_DRILLDOWN_DIST=../logs-drilldown/dist
+
+# Enable feature flags here
+# GF_FEATURE_TOGGLES_ENABLE=queryLibrary

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - '${GRAFANA_PORT:-3001}:3000'
     environment:
       GF_SERVER_ROOT_URL: 'http://localhost:${GRAFANA_PORT:-3001}'
-      GF_FEATURE_TOGGLES_ENABLE: exploreMetricsUseExternalAppPlugin,localizationForPlugins
+      GF_FEATURE_TOGGLES_ENABLE: exploreMetricsUseExternalAppPlugin,localizationForPlugins${GF_FEATURE_TOGGLES_ENABLE:+,${GF_FEATURE_TOGGLES_ENABLE}}
       # prevents a Grafana startup error in case a newer plugin version (set in package.json) is used compared to the latest one published in the catalog
       GF_PLUGINS_PREINSTALL_DISABLED: true
     volumes:
@@ -39,7 +39,7 @@ services:
       - '${GRAFANA_SCOPES_PORT:-3002}:3000'
     environment:
       GF_SERVER_ROOT_URL: 'http://localhost:${GRAFANA_SCOPES_PORT:-3002}'
-      GF_FEATURE_TOGGLES_ENABLE: exploreMetricsUseExternalAppPlugin,grafanaAPIServer,grafanaAPIServerWithExperimentalAPIs,scopeFilters,promQLScope,enableScopesInMetricsExplore,localizationForPlugins
+      GF_FEATURE_TOGGLES_ENABLE: exploreMetricsUseExternalAppPlugin,grafanaAPIServer,grafanaAPIServerWithExperimentalAPIs,scopeFilters,promQLScope,enableScopesInMetricsExplore,localizationForPlugins${GF_FEATURE_TOGGLES_ENABLE:+,${GF_FEATURE_TOGGLES_ENABLE}}
     extra_hosts:
       # This allows us to connect to other services running on the host machine.
       # Linux CI: Uses 172.17.0.1 (default)

--- a/provisioning/alerting/alert-rules-wingman.json
+++ b/provisioning/alerting/alert-rules-wingman.json
@@ -55,8 +55,7 @@
           "noDataState": "NoData",
           "execErrState": "Error",
           "for": "4h",
-          "isPaused": false,
-          "notification_settings": { "receiver": "grafana-default-email" }
+          "isPaused": false
         },
         {
           "uid": "ceedukphd7da8c",
@@ -145,8 +144,7 @@
           "noDataState": "NoData",
           "execErrState": "Error",
           "for": "4h",
-          "isPaused": false,
-          "notification_settings": { "receiver": "grafana-default-email" }
+          "isPaused": false
         }
       ]
     }


### PR DESCRIPTION
### ✨ Description

Allow the local Docker development environment to work with the latest Grafana build by removing hardcoded `notification_settings` from alert rules, and make it  easier to enable additional feature toggles without modifying tracked files.

### 📖 Summary of the changes

- **`docker-compose.yaml`**: Use `${GF_FEATURE_TOGGLES_ENABLE:+,${GF_FEATURE_TOGGLES_ENABLE}}` syntax to allow appending extra feature toggles via the `.env` file. A comma is automatically inserted only when the variable is set.
- **`.env.example`**: Document the new `GF_FEATURE_TOGGLES_ENABLE` option with an example.
- **`provisioning/alerting/alert-rules-wingman.json`**: Remove `notification_settings` referencing `grafana-default-email`, which caused errors with the latest Grafana build.

### 🧪 How to test?

1. Run `docker compose config` with no `GF_FEATURE_TOGGLES_ENABLE` in `.env` — confirm the feature toggles are unchanged from their hardcoded values.
2. Add `GF_FEATURE_TOGGLES_ENABLE=queryLibrary` to `.env`, run `docker compose config` — confirm `,queryLibrary` is appended to both services' toggle lists.
3. Run `docker compose up` and verify Grafana starts without alert rule provisioning errors.
