### PR TITLE
feat: add create alert event for tracking

### DIFF
--- a/src/shared/GmdVizPanel/components/CreateAlertAction.tsx
+++ b/src/shared/GmdVizPanel/components/CreateAlertAction.tsx
@@ -12,6 +12,8 @@ import { type Panel } from '@grafana/schema';
 import { Button, useStyles2 } from '@grafana/ui';
 import React, { useState } from 'react';
 
+import { reportExploreMetrics } from 'shared/tracking/interactions';
+
 import { getPanelData, type PanelDataRequestPayload } from './addToDashboard/addToDashboard';
 
 // NOTE: Until a new version of @grafana/data is released that includes
@@ -49,6 +51,8 @@ export class CreateAlertAction extends SceneObjectBase<CreateAlertActionState> {
       // Transform VizPanel into Panel schema with interpolated variables
       // as expected by the alerting component API.
       const data = getPanelData(vizPanel);
+      const metric = vizPanel.state.title ?? '';
+      reportExploreMetrics('create_alert_clicked', { metric });
       setPanelData(data);
       setShowModal(true);
     };

--- a/src/shared/tracking/interactions.ts
+++ b/src/shared/tracking/interactions.ts
@@ -185,6 +185,8 @@ type Interactions = {
   add_to_dashboard_modal_opened: {};
   // User confirms to add to dashboard and builds a panel
   add_to_dashboard_build_panel: { expr: string };
+  // User clicks the "Create Alert" button, opening the alert creation flow
+  create_alert_clicked: { metric: string };
   // User asks a question in the Quick Search input
   quick_search_assistant_question_asked: { question: string };
   // User enters assistant mode in the Quick Search input (e.g., by typing '?', clicking the AI button, or using the Tab+Enter keyboard flow)


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** <!-- Paste a GitHub issue URL or another pull request URL -->
Resolves <!-- Paste Github issue that is resolved by this pull request -->

Add a create alert event to track in the [KPI dashboard](https://ops.grafana-ops.net/d/adkmlvq4wpjpcb/metrics-drilldown-kpi?orgId=1&from=now-90d&to=now&timezone=browser)

### 📖 Summary of the changes

Add event and track metric selected.

### 🧪 How to test?

Tests and build should pass.
