### PR TITLE
fix: resolve CVE-2026-3449 (@tootallnate/once)

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
       "minimatch@^9": "~9.0.7",
       "minimatch@^10": ">=10.2.3",
       "serialize-javascript": ">=7.0.3",
-      "immutable": ">=5.1.5"
+      "immutable": ">=5.1.5",
+      "@tootallnate/once": ">=3.0.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   minimatch@^10: '>=10.2.3'
   serialize-javascript: '>=7.0.3'
   immutable: '>=5.1.5'
+  '@tootallnate/once': '>=3.0.1'
 
 importers:
 
@@ -1878,8 +1879,8 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@tootallnate/once@2.0.0':
-    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+  '@tootallnate/once@3.0.1':
+    resolution: {integrity: sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==}
     engines: {node: '>= 10'}
 
   '@tsconfig/node10@1.0.12':
@@ -8686,7 +8687,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@tootallnate/once@2.0.0': {}
+  '@tootallnate/once@3.0.1': {}
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -10970,7 +10971,7 @@ snapshots:
 
   http-proxy-agent@5.0.0:
     dependencies:
-      '@tootallnate/once': 2.0.0
+      '@tootallnate/once': 3.0.1
       agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- Adds a `pnpm.overrides` entry to force `@tootallnate/once` to `>=3.0.1`
- Regenerates `pnpm-lock.yaml` so the transitive dep resolves to `3.0.1` (was `2.0.0`)
- Follows the pattern established in #1122 for fixing transitive CVEs via overrides

## CVE

**CVE-2026-3449** — Incorrect Control Flow Scoping in `@tootallnate/once` (<3.0.1): a Promise hangs indefinitely when an `AbortSignal` is aborted, potentially causing stalled requests or blocked workers.

## Test plan

- [x] `pnpm-lock.yaml` no longer contains `@tootallnate/once@2.0.0`
- [x] `pnpm-lock.yaml` resolves `@tootallnate/once@3.0.1`
- [ ] Unit tests pass (`pnpm run test`)
- [ ] Linting passes (`pnpm run lint`)