### PR TITLE
feat: add Knowledge Graph annotation overlays

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -129,6 +129,16 @@ export default [
     },
   },
   {
+    // eslint-plugin-import crashes on ESLint 10 when fixing import/order in this file
+    // (sourceCode.getTokenOrCommentAfter is not a function). Safe to remove once
+    // eslint-plugin-import is updated with ESLint 10 compatibility.
+    name: 'metrics-drilldown/data-trail-import-order-workaround',
+    files: ['src/AppDataTrail/DataTrail.tsx'],
+    rules: {
+      'import/order': 'off',
+    },
+  },
+  {
     name: 'metrics-drilldown/jest-config',
     files: ['jest.config.js'],
     rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -131,7 +131,9 @@ export default [
   {
     // eslint-plugin-import crashes on ESLint 10 when fixing import/order in this file
     // (sourceCode.getTokenOrCommentAfter is not a function). This is a pre-existing issue
-    // on main hidden by eslint cache. Safe to remove once eslint-plugin-import supports ESLint 10.
+    // on main hidden by eslint cache.
+    // TODO: migrate from eslint-plugin-import to eslint-plugin-import-x (ESLint 10 compatible fork)
+    // and remove this workaround. eslint-plugin-import@2.32.0 is the last release with no fix planned.
     name: 'metrics-drilldown/data-trail-import-order-workaround',
     files: ['src/AppDataTrail/DataTrail.tsx'],
     rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -129,6 +129,16 @@ export default [
     },
   },
   {
+    // eslint-plugin-import crashes on ESLint 10 when fixing import/order in this file
+    // (sourceCode.getTokenOrCommentAfter is not a function). This is a pre-existing issue
+    // on main hidden by eslint cache. Safe to remove once eslint-plugin-import supports ESLint 10.
+    name: 'metrics-drilldown/data-trail-import-order-workaround',
+    files: ['src/AppDataTrail/DataTrail.tsx'],
+    rules: {
+      'import/order': 'off',
+    },
+  },
+  {
     name: 'metrics-drilldown/jest-config',
     files: ['jest.config.js'],
     rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -129,16 +129,6 @@ export default [
     },
   },
   {
-    // eslint-plugin-import crashes on ESLint 10 when fixing import/order in this file
-    // (sourceCode.getTokenOrCommentAfter is not a function). Safe to remove once
-    // eslint-plugin-import is updated with ESLint 10 compatibility.
-    name: 'metrics-drilldown/data-trail-import-order-workaround',
-    files: ['src/AppDataTrail/DataTrail.tsx'],
-    rules: {
-      'import/order': 'off',
-    },
-  },
-  {
     name: 'metrics-drilldown/jest-config',
     files: ['jest.config.js'],
     rules: {

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -61,6 +61,9 @@ import { buildFilterExpression } from '../shared/utils/utils.queries';
 import { getAppBackgroundColor } from '../shared/utils/utils.styles';
 import { limitAdhocProviders } from '../shared/utils/utils.trail';
 import { isAdHocFiltersVariable } from '../shared/utils/utils.variables';
+import { KgAnnotationToggle } from 'shared/knowledgeGraph/KgAnnotationToggle';
+import { getKgSceneProps } from 'shared/knowledgeGraph/kgAnnotations';
+
 import { PluginInfo } from './header/PluginInfo/PluginInfo';
 import { SelectNewMetricButton } from './header/SelectNewMetricButton';
 import { MetricDatasourceHelper } from './MetricDatasourceHelper/MetricDatasourceHelper';
@@ -87,6 +90,9 @@ export interface DataTrailState extends SceneObjectState {
   urlNamespace?: string; // optional namespace for url params, to avoid conflicts with other plugins in embedded mode
 
   drawer: SceneDrawer;
+
+  // Knowledge Graph annotations
+  kgAnnotationToggle?: KgAnnotationToggle;
 
   // Add to dashboard feature
   isAddToDashboardAvailable: boolean;
@@ -126,6 +132,8 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
   }
 
   public constructor(state: Partial<DataTrailState>) {
+    const kg = getKgSceneProps();
+
     super({
       $timeRange: state.$timeRange ?? new SceneTimeRange({}),
       $variables: state.$variables ?? getVariableSet(state.initialDS, state.metric, state.initialFilters),
@@ -142,6 +150,13 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
       isAddToDashboardAvailable: false,
       isAddToDashboardModalOpen: false,
       ...state,
+      ...(kg
+        ? {
+            $data: state.$data ?? kg.$data,
+            $behaviors: [...(state.$behaviors ?? []), ...kg.behaviors],
+            kgAnnotationToggle: state.kgAnnotationToggle ?? kg.controls,
+          }
+        : {}),
     });
 
     this.addActivationHandler(this.onActivate.bind(this));
@@ -375,8 +390,16 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
   };
 
   static readonly Component = ({ model }: SceneComponentProps<DataTrail>) => {
-    const { controls, topScene, embedded, embeddedMini, drawer, isAddToDashboardModalOpen, addToDashboardPanelData } =
-      model.useState();
+    const {
+      controls,
+      topScene,
+      embedded,
+      embeddedMini,
+      drawer,
+      isAddToDashboardModalOpen,
+      addToDashboardPanelData,
+      kgAnnotationToggle,
+    } = model.useState();
 
     const chromeHeaderHeight = useChromeHeaderHeight() ?? 0;
     const headerHeight = embedded ? 0 : chromeHeaderHeight;
@@ -432,6 +455,9 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
                   {controls.map((control) => (
                     <control.Component key={control.state.key} model={control} />
                   ))}
+                  {kgAnnotationToggle && (
+                    <kgAnnotationToggle.Component model={kgAnnotationToggle} />
+                  )}
                   <Stack direction="row" gap={0.5}>
                     <PluginInfo getPrometheusBuildInfo={model.getPrometheusBuildInfo} />
                   </Stack>

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -50,7 +50,7 @@ import { EventApplyPanelConfig } from 'shared/GmdVizPanel/components/ConfigurePa
 import { EventCancelConfigurePanel } from 'shared/GmdVizPanel/components/ConfigurePanelForm/EventCancelConfigurePanel';
 import { EventConfigurePanel } from 'shared/GmdVizPanel/components/EventConfigurePanel';
 import { GmdVizPanel } from 'shared/GmdVizPanel/GmdVizPanel';
-import { KgAnnotationToggle } from 'shared/knowledgeGraph/KgAnnotationToggle';
+import { type KgAnnotationToggle } from 'shared/knowledgeGraph/KgAnnotationToggle';
 import { getKgSceneProps } from 'shared/knowledgeGraph/kgAnnotations';
 import { logger } from 'shared/logger/logger';
 

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -52,6 +52,7 @@ import { EventConfigurePanel } from 'shared/GmdVizPanel/components/EventConfigur
 import { GmdVizPanel } from 'shared/GmdVizPanel/GmdVizPanel';
 import { type KgAnnotationToggle } from 'shared/knowledgeGraph/KgAnnotationToggle';
 import { getKgSceneProps, type KgEntityHint } from 'shared/knowledgeGraph/kgAnnotations';
+import { evaluateFeatureFlag } from 'shared/featureFlags/openFeature';
 import { logger } from 'shared/logger/logger';
 
 import { resetYAxisSync } from '../MetricScene/Breakdown/MetricLabelsList/behaviors/syncYAxis';
@@ -133,8 +134,6 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
   }
 
   public constructor(state: Partial<DataTrailState>) {
-    const kg = getKgSceneProps(state.kgEntityHint);
-
     super({
       $timeRange: state.$timeRange ?? new SceneTimeRange({}),
       $variables: state.$variables ?? getVariableSet(state.initialDS, state.metric, state.initialFilters),
@@ -151,13 +150,6 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
       isAddToDashboardAvailable: false,
       isAddToDashboardModalOpen: false,
       ...state,
-      ...(kg
-        ? {
-            $data: state.$data ?? kg.$data,
-            $behaviors: [...(state.$behaviors ?? []), ...kg.behaviors],
-            kgAnnotationToggle: state.kgAnnotationToggle ?? kg.controls,
-          }
-        : {}),
     });
 
     this.addActivationHandler(this.onActivate.bind(this));
@@ -165,6 +157,19 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
 
   private onActivate() {
     registerRuntimeDataSources([new LabelsDataSource()]);
+
+    evaluateFeatureFlag('kgAnnotationsInMetricsDrilldown').then((enabled) => {
+      if (enabled) {
+        const kg = getKgSceneProps(this.state.kgEntityHint);
+        if (kg) {
+          this.setState({
+            $data: this.state.$data ?? kg.$data,
+            $behaviors: [...(this.state.$behaviors ?? []), ...kg.behaviors],
+            kgAnnotationToggle: this.state.kgAnnotationToggle ?? kg.controls,
+          });
+        }
+      }
+    });
 
     // Delays init() to ensure proper initialization order and avoid race conditions.
     // The variable dependency handler (onReferencedVariableValueChanged) calls reset()

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -51,7 +51,7 @@ import { EventCancelConfigurePanel } from 'shared/GmdVizPanel/components/Configu
 import { EventConfigurePanel } from 'shared/GmdVizPanel/components/EventConfigurePanel';
 import { GmdVizPanel } from 'shared/GmdVizPanel/GmdVizPanel';
 import { type KgAnnotationToggle } from 'shared/knowledgeGraph/KgAnnotationToggle';
-import { getKgSceneProps } from 'shared/knowledgeGraph/kgAnnotations';
+import { getKgSceneProps, type KgEntityHint } from 'shared/knowledgeGraph/kgAnnotations';
 import { logger } from 'shared/logger/logger';
 
 import { resetYAxisSync } from '../MetricScene/Breakdown/MetricLabelsList/behaviors/syncYAxis';
@@ -92,6 +92,7 @@ export interface DataTrailState extends SceneObjectState {
   drawer: SceneDrawer;
 
   // Knowledge Graph annotations
+  kgEntityHint?: KgEntityHint;
   kgAnnotationToggle?: KgAnnotationToggle;
 
   // Add to dashboard feature
@@ -132,7 +133,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
   }
 
   public constructor(state: Partial<DataTrailState>) {
-    const kg = getKgSceneProps();
+    const kg = getKgSceneProps(state.kgEntityHint);
 
     super({
       $timeRange: state.$timeRange ?? new SceneTimeRange({}),

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -50,6 +50,8 @@ import { EventApplyPanelConfig } from 'shared/GmdVizPanel/components/ConfigurePa
 import { EventCancelConfigurePanel } from 'shared/GmdVizPanel/components/ConfigurePanelForm/EventCancelConfigurePanel';
 import { EventConfigurePanel } from 'shared/GmdVizPanel/components/EventConfigurePanel';
 import { GmdVizPanel } from 'shared/GmdVizPanel/GmdVizPanel';
+import { KgAnnotationToggle } from 'shared/knowledgeGraph/KgAnnotationToggle';
+import { getKgSceneProps } from 'shared/knowledgeGraph/kgAnnotations';
 import { logger } from 'shared/logger/logger';
 
 import { resetYAxisSync } from '../MetricScene/Breakdown/MetricLabelsList/behaviors/syncYAxis';
@@ -61,8 +63,6 @@ import { buildFilterExpression } from '../shared/utils/utils.queries';
 import { getAppBackgroundColor } from '../shared/utils/utils.styles';
 import { limitAdhocProviders } from '../shared/utils/utils.trail';
 import { isAdHocFiltersVariable } from '../shared/utils/utils.variables';
-import { KgAnnotationToggle } from 'shared/knowledgeGraph/KgAnnotationToggle';
-import { getKgSceneProps } from 'shared/knowledgeGraph/kgAnnotations';
 
 import { PluginInfo } from './header/PluginInfo/PluginInfo';
 import { SelectNewMetricButton } from './header/SelectNewMetricButton';

--- a/src/exposedComponents/EntityMetrics/EntityMetrics.tsx
+++ b/src/exposedComponents/EntityMetrics/EntityMetrics.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef } from 'react';
 import { ErrorView } from 'App/ErrorView';
 import { Trail } from 'App/Routes';
 import { useCatchExceptions } from 'App/useCatchExceptions';
+import { type KgEntityHint } from 'shared/knowledgeGraph/kgAnnotations';
 import { reportExploreMetrics } from 'shared/tracking/interactions';
 import { newMetricsTrail } from 'shared/utils/utils';
 
@@ -14,10 +15,11 @@ export interface EntityMetricsProps {
   initialStart: string | number;
   initialEnd: string | number;
   dataSource: DataSourceApi;
-  entityType?: string; // Optional for UI customization
+  entityType?: string;
+  entityName?: string;
 }
 
-const EntityMetrics = ({ labels, initialStart, initialEnd, dataSource }: EntityMetricsProps) => {
+const EntityMetrics = ({ labels, initialStart, initialEnd, dataSource, entityType, entityName }: EntityMetricsProps) => {
   const [error] = useCatchExceptions();
   const initRef = useRef(false);
 
@@ -37,9 +39,21 @@ const EntityMetrics = ({ labels, initialStart, initialEnd, dataSource }: EntityM
       value: String(value),
     }));
 
+  // When entity type and name are provided, use direct KG entity queries
+  // instead of the label-resolution fallback
+  let kgEntityHint: KgEntityHint | undefined;
+  if (entityType && entityName) {
+    kgEntityHint = {
+      entityType,
+      entityName,
+      scope: labels.namespace ? { namespace: labels.namespace } : undefined,
+    };
+  }
+
   const trail = newMetricsTrail({
     initialDS: dataSource.uid,
     initialFilters,
+    kgEntityHint,
     $timeRange: toSceneTimeRange(initialStart, initialEnd),
     embedded: true,
   });

--- a/src/locales/en-US/grafana-metricsdrilldown-app.json
+++ b/src/locales/en-US/grafana-metricsdrilldown-app.json
@@ -96,6 +96,12 @@
     "unknown-error": "Unknown error!"
   },
   "kg-annotations": {
+    "layer": {
+      "name": "Insights - {{severityLabel}}"
+    },
+    "query": {
+      "name": "KG Assertions - {{severityLabel}}"
+    },
     "severity": {
       "critical": "Critical",
       "info": "Info",

--- a/src/locales/en-US/grafana-metricsdrilldown-app.json
+++ b/src/locales/en-US/grafana-metricsdrilldown-app.json
@@ -102,7 +102,10 @@
       "warning": "Warning"
     },
     "toggle": {
-      "label": "Insights"
+      "description": "Overlay health states (critical, warning, info) from the Knowledge Graph on timeseries panels.",
+      "disabled-tooltip": "Add label filters to match entities.",
+      "label": "Insights",
+      "learn-more": "Learn more"
     }
   },
   "labels-datasource": {

--- a/src/locales/en-US/grafana-metricsdrilldown-app.json
+++ b/src/locales/en-US/grafana-metricsdrilldown-app.json
@@ -95,6 +95,16 @@
   "inline-banner": {
     "unknown-error": "Unknown error!"
   },
+  "kg-annotations": {
+    "severity": {
+      "critical": "Critical",
+      "info": "Info",
+      "warning": "Warning"
+    },
+    "toggle": {
+      "label": "Insights"
+    }
+  },
   "labels-datasource": {
     "none-option": "(none)",
     "test-success": "OK"

--- a/src/shared/GmdVizPanel/types/percentiles/buildPercentilesPanel.ts
+++ b/src/shared/GmdVizPanel/types/percentiles/buildPercentilesPanel.ts
@@ -32,6 +32,7 @@ export function buildPercentilesPanel(options: BuildVizPanelOptions) {
     .setShowMenuAlways(Boolean(panelConfig.menu))
     .setData($data)
     .setUnit(unit)
+    .setOption('annotations', { multiLane: true })
     .setOption('legend', panelConfig.legend || { showLegend: true, placement: 'bottom' as LegendPlacement })
     .setOption('tooltip', { mode: TooltipDisplayMode.Multi, sort: SortOrder.Descending })
     .setCustomFieldConfig('fillOpacity', 9)

--- a/src/shared/GmdVizPanel/types/timeseries/buildTimeseriesPanel.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/buildTimeseriesPanel.ts
@@ -38,6 +38,7 @@ export function buildTimeseriesPanel(options: BuildVizPanelOptions): VizPanel {
     .setShowMenuAlways(Boolean(panelConfig.menu))
     .setData($data)
     .setUnit(unit)
+    .setOption('annotations', { multiLane: true })
     .setOption('legend', panelConfig.legend || { showLegend: true, placement: 'bottom' as LegendPlacement })
     .setCustomFieldConfig('fillOpacity', 9)
     .setBehaviors([
@@ -99,6 +100,7 @@ function buildGroupByPanel(options: Required<BuildVizPanelOptions>): VizPanel {
     .setShowMenuAlways(Boolean(panelConfig.menu))
     .setData($data)
     .setUnit(unit)
+    .setOption('annotations', { multiLane: true })
     .setOption('legend', panelConfig.legend || { showLegend: true, placement: 'right' as LegendPlacement })
     .setOption('tooltip', { mode: TooltipDisplayMode.Multi, sort: SortOrder.Descending })
     .setOverrides((b) => {

--- a/src/shared/featureFlags/openFeature.ts
+++ b/src/shared/featureFlags/openFeature.ts
@@ -11,6 +11,11 @@ import { logger } from '../logger/logger';
  * See {@link https://github.com/grafana/deployment_tools/blob/master/ksonnet/environments/hosted-grafana/waves/feature-toggles/goff/drilldown/metrics/flag-definitions.libsonnet | Metrics Drilldown GoFF flag definitions} for the source of truth.
  */
 const goffFeatureFlags = {
+  kgAnnotationsInMetricsDrilldown: {
+    valueType: 'boolean',
+    values: [true, false] as const,
+    defaultValue: false,
+  },
   'drilldown.metrics.default_open_sidebar': {
     valueType: 'string',
     values: [
@@ -41,7 +46,7 @@ const goffFeatureFlags = {
     defaultValue: 'excluded',
     trackingKey: 'experiment_grafana_assistant_quick_search_tab_test',
   },
-} as const satisfies Record<`drilldown.metrics.${string}`, FeatureFlag>;
+} as const satisfies Record<string, FeatureFlag>;
 
 /**
  * This discriminated union captures the different types of feature flags that can be evaluated.
@@ -155,7 +160,6 @@ export async function evaluateFeatureFlag<T extends keyof typeof goffFeatureFlag
     switch (flagDef.valueType) {
       case 'boolean':
         const booleanValue = client.getBooleanValue(flagName, flagDef.defaultValue);
-        // @ts-expect-error - this can be removed once we add a boolean-type flag to `goffFeatureFlags`
         return booleanValue as FlagValue<T>;
       case 'number':
         const numberValue = client.getNumberValue(flagName, flagDef.defaultValue);

--- a/src/shared/featureToggles/knowledgeGraphAnnotations.ts
+++ b/src/shared/featureToggles/knowledgeGraphAnnotations.ts
@@ -1,0 +1,7 @@
+import { config } from '@grafana/runtime';
+
+const FEATURE_TOGGLE_NAME = 'kgAnnotationsInMetricsDrilldown';
+
+export function isKnowledgeGraphAnnotationsEnabled(): boolean {
+  return Boolean(FEATURE_TOGGLE_NAME in config.featureToggles && config.featureToggles[FEATURE_TOGGLE_NAME]);
+}

--- a/src/shared/featureToggles/knowledgeGraphAnnotations.ts
+++ b/src/shared/featureToggles/knowledgeGraphAnnotations.ts
@@ -1,7 +1,0 @@
-import { config } from '@grafana/runtime';
-
-const FEATURE_TOGGLE_NAME = 'kgAnnotationsInMetricsDrilldown';
-
-export function isKnowledgeGraphAnnotationsEnabled(): boolean {
-  return Boolean(FEATURE_TOGGLE_NAME in config.featureToggles && config.featureToggles[FEATURE_TOGGLE_NAME]);
-}

--- a/src/shared/knowledgeGraph/KgAnnotationToggle.tsx
+++ b/src/shared/knowledgeGraph/KgAnnotationToggle.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-
-import { ControlsLabel, SceneDataLayerSet, SceneObjectBase, SceneObjectRef, SceneObjectState } from '@grafana/scenes';
+import { t } from '@grafana/i18n';
+import { ControlsLabel, SceneObjectBase, type SceneDataLayerSet, type SceneObjectRef, type SceneObjectState } from '@grafana/scenes';
 import { InlineSwitch } from '@grafana/ui';
+import React from 'react';
 
 export const KG_INSIGHTS_DESCRIPTION =
   'Overlay health states (critical, warning, info) from the Knowledge Graph on timeseries panels';
@@ -12,7 +12,7 @@ export interface KgAnnotationToggleState extends SceneObjectState {
 }
 
 export class KgAnnotationToggle extends SceneObjectBase<KgAnnotationToggleState> {
-  static Component = KgAnnotationToggleRenderer;
+  static readonly Component = KgAnnotationToggleRenderer;
 
   public toggleEnabled = () => {
     const next = !this.state.isEnabled;
@@ -29,7 +29,7 @@ export class KgAnnotationToggle extends SceneObjectBase<KgAnnotationToggleState>
   };
 }
 
-function KgAnnotationToggleRenderer({ model }: { model: KgAnnotationToggle }) {
+function KgAnnotationToggleRenderer({ model }: Readonly<{ model: KgAnnotationToggle }>) {
   const { isEnabled, layerSetRef } = model.useState();
   const { layers } = layerSetRef.resolve().useState();
 
@@ -39,7 +39,7 @@ function KgAnnotationToggleRenderer({ model }: { model: KgAnnotationToggle }) {
 
   return (
     <div style={{ display: 'flex', alignSelf: 'flex-end' }}>
-      <ControlsLabel label="Insights" description={KG_INSIGHTS_DESCRIPTION} />
+      <ControlsLabel label={t('kg-annotations.toggle.label', 'Insights')} description={KG_INSIGHTS_DESCRIPTION} />
       <InlineSwitch value={isEnabled} onChange={model.toggleEnabled} />
     </div>
   );

--- a/src/shared/knowledgeGraph/KgAnnotationToggle.tsx
+++ b/src/shared/knowledgeGraph/KgAnnotationToggle.tsx
@@ -1,10 +1,7 @@
 import { t } from '@grafana/i18n';
-import { ControlsLabel, SceneObjectBase, type SceneDataLayerSet, type SceneObjectRef, type SceneObjectState } from '@grafana/scenes';
-import { InlineSwitch } from '@grafana/ui';
+import { SceneObjectBase, type SceneDataLayerSet, type SceneObjectRef, type SceneObjectState } from '@grafana/scenes';
+import { InlineLabel, InlineSwitch, TextLink } from '@grafana/ui';
 import React from 'react';
-
-export const KG_INSIGHTS_DESCRIPTION =
-  'Overlay health states (critical, warning, info) from the Knowledge Graph on timeseries panels';
 
 export interface KgAnnotationToggleState extends SceneObjectState {
   isEnabled: boolean;
@@ -32,15 +29,31 @@ export class KgAnnotationToggle extends SceneObjectBase<KgAnnotationToggleState>
 function KgAnnotationToggleRenderer({ model }: Readonly<{ model: KgAnnotationToggle }>) {
   const { isEnabled, layerSetRef } = model.useState();
   const { layers } = layerSetRef.resolve().useState();
+  const hasLayers = layers.length > 0;
 
-  if (layers.length === 0) {
-    return null;
-  }
+  const description = t(
+    'kg-annotations.toggle.description',
+    'Overlay health states (critical, warning, info) from the Knowledge Graph on timeseries panels.'
+  );
+
+  const tooltipContent = hasLayers ? (
+    description
+  ) : (
+    <span>
+      {description}{' '}
+      {t('kg-annotations.toggle.disabled-tooltip', 'Add label filters to match entities.')}{' '}
+      <TextLink external href="https://grafana.com/docs/grafana-cloud/knowledge-graph/introduction/">
+        {t('kg-annotations.toggle.learn-more', 'Learn more')}
+      </TextLink>
+    </span>
+  );
 
   return (
     <div style={{ display: 'flex', alignSelf: 'flex-end' }}>
-      <ControlsLabel label={t('kg-annotations.toggle.label', 'Insights')} description={KG_INSIGHTS_DESCRIPTION} />
-      <InlineSwitch value={isEnabled} onChange={model.toggleEnabled} />
+      <InlineLabel tooltip={tooltipContent} interactive={!hasLayers} width="auto" transparent>
+        {t('kg-annotations.toggle.label', 'Insights')}
+      </InlineLabel>
+      <InlineSwitch value={isEnabled} onChange={model.toggleEnabled} disabled={!hasLayers} />
     </div>
   );
 }

--- a/src/shared/knowledgeGraph/KgAnnotationToggle.tsx
+++ b/src/shared/knowledgeGraph/KgAnnotationToggle.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import { ControlsLabel, SceneDataLayerSet, SceneObjectBase, SceneObjectRef, SceneObjectState } from '@grafana/scenes';
+import { InlineSwitch } from '@grafana/ui';
+
+export const KG_INSIGHTS_DESCRIPTION =
+  'Overlay health states (critical, warning, info) from the Knowledge Graph on timeseries panels';
+
+export interface KgAnnotationToggleState extends SceneObjectState {
+  isEnabled: boolean;
+  layerSetRef: SceneObjectRef<SceneDataLayerSet>;
+}
+
+export class KgAnnotationToggle extends SceneObjectBase<KgAnnotationToggleState> {
+  static Component = KgAnnotationToggleRenderer;
+
+  public toggleEnabled = () => {
+    const next = !this.state.isEnabled;
+    this.setState({ isEnabled: next });
+    for (const layer of this.state.layerSetRef.resolve().state.layers) {
+      layer.setState({ isEnabled: next });
+    }
+  };
+
+  public syncLayerEnabledState = () => {
+    for (const layer of this.state.layerSetRef.resolve().state.layers) {
+      layer.setState({ isEnabled: this.state.isEnabled });
+    }
+  };
+}
+
+function KgAnnotationToggleRenderer({ model }: { model: KgAnnotationToggle }) {
+  const { isEnabled, layerSetRef } = model.useState();
+  const { layers } = layerSetRef.resolve().useState();
+
+  if (layers.length === 0) {
+    return null;
+  }
+
+  return (
+    <div style={{ display: 'flex', alignSelf: 'flex-end' }}>
+      <ControlsLabel label="Insights" description={KG_INSIGHTS_DESCRIPTION} />
+      <InlineSwitch value={isEnabled} onChange={model.toggleEnabled} />
+    </div>
+  );
+}

--- a/src/shared/knowledgeGraph/kgAnnotations.test.ts
+++ b/src/shared/knowledgeGraph/kgAnnotations.test.ts
@@ -5,7 +5,6 @@ import { getKgSceneProps, isKgAnnotationsAvailable } from 'shared/knowledgeGraph
 import { KgAnnotationToggle } from 'shared/knowledgeGraph/KgAnnotationToggle';
 
 const originalDatasources = config.datasources;
-const originalFeatureToggles = { ...config.featureToggles };
 
 const KG_DATASOURCE = {
   uid: 'grafanacloud-knowledgegraph',
@@ -22,27 +21,16 @@ const KG_DATASOURCE = {
 
 afterEach(() => {
   config.datasources = originalDatasources;
-  config.featureToggles = { ...originalFeatureToggles };
 });
 
 describe('isKgAnnotationsAvailable', () => {
-  it('returns false when feature flag is off', () => {
-    config.featureToggles = { ...originalFeatureToggles };
-    delete (config.featureToggles as Record<string, unknown>).kgAnnotationsInMetricsDrilldown;
-    config.datasources = { knowledgegraph: KG_DATASOURCE };
-
-    expect(isKgAnnotationsAvailable()).toBe(false);
-  });
-
   it('returns false when KG datasource is missing', () => {
-    (config.featureToggles as Record<string, unknown>).kgAnnotationsInMetricsDrilldown = true;
     config.datasources = {};
 
     expect(isKgAnnotationsAvailable()).toBe(false);
   });
 
-  it('returns true when both flag and datasource are present', () => {
-    (config.featureToggles as Record<string, unknown>).kgAnnotationsInMetricsDrilldown = true;
+  it('returns true when KG datasource is present', () => {
     config.datasources = { knowledgegraph: KG_DATASOURCE };
 
     expect(isKgAnnotationsAvailable()).toBe(true);
@@ -50,15 +38,13 @@ describe('isKgAnnotationsAvailable', () => {
 });
 
 describe('getKgSceneProps', () => {
-  it('returns undefined when not available', () => {
-    config.featureToggles = { ...originalFeatureToggles };
-    delete (config.featureToggles as Record<string, unknown>).kgAnnotationsInMetricsDrilldown;
+  it('returns undefined when KG datasource is missing', () => {
+    config.datasources = {};
 
     expect(getKgSceneProps()).toBeUndefined();
   });
 
-  it('returns proper structure when available', () => {
-    (config.featureToggles as Record<string, unknown>).kgAnnotationsInMetricsDrilldown = true;
+  it('returns proper structure when KG datasource is present', () => {
     config.datasources = { knowledgegraph: KG_DATASOURCE };
 
     const props = getKgSceneProps();

--- a/src/shared/knowledgeGraph/kgAnnotations.test.ts
+++ b/src/shared/knowledgeGraph/kgAnnotations.test.ts
@@ -35,6 +35,12 @@ describe('isKgAnnotationsAvailable', () => {
 
     expect(isKgAnnotationsAvailable()).toBe(true);
   });
+
+  it('returns false when uid matches but type does not', () => {
+    config.datasources = { knowledgegraph: { ...KG_DATASOURCE, type: 'some-other-datasource' } };
+
+    expect(isKgAnnotationsAvailable()).toBe(false);
+  });
 });
 
 describe('getKgSceneProps', () => {

--- a/src/shared/knowledgeGraph/kgAnnotations.test.ts
+++ b/src/shared/knowledgeGraph/kgAnnotations.test.ts
@@ -1,0 +1,98 @@
+import { config } from '@grafana/runtime';
+import { SceneDataLayerSet, SceneObjectRef } from '@grafana/scenes';
+
+import { isKgAnnotationsAvailable, getKgSceneProps } from './kgAnnotations';
+import { KgAnnotationToggle } from './KgAnnotationToggle';
+
+const originalDatasources = config.datasources;
+const originalFeatureToggles = { ...config.featureToggles };
+
+const KG_DATASOURCE = {
+  uid: 'grafanacloud-knowledgegraph',
+  type: 'grafana-knowledgegraph-datasource',
+  name: 'Knowledge Graph',
+  meta: {} as any,
+  id: 1,
+  access: 'proxy' as const,
+  readOnly: false,
+  jsonData: {},
+  url: '',
+  isDefault: false,
+};
+
+afterEach(() => {
+  config.datasources = originalDatasources;
+  config.featureToggles = { ...originalFeatureToggles };
+});
+
+describe('isKgAnnotationsAvailable', () => {
+  it('returns false when feature flag is off', () => {
+    config.featureToggles = { ...originalFeatureToggles };
+    delete (config.featureToggles as Record<string, unknown>).kgAnnotationsInMetricsDrilldown;
+    config.datasources = { knowledgegraph: KG_DATASOURCE };
+
+    expect(isKgAnnotationsAvailable()).toBe(false);
+  });
+
+  it('returns false when KG datasource is missing', () => {
+    (config.featureToggles as Record<string, unknown>).kgAnnotationsInMetricsDrilldown = true;
+    config.datasources = {};
+
+    expect(isKgAnnotationsAvailable()).toBe(false);
+  });
+
+  it('returns true when both flag and datasource are present', () => {
+    (config.featureToggles as Record<string, unknown>).kgAnnotationsInMetricsDrilldown = true;
+    config.datasources = { knowledgegraph: KG_DATASOURCE };
+
+    expect(isKgAnnotationsAvailable()).toBe(true);
+  });
+});
+
+describe('getKgSceneProps', () => {
+  it('returns undefined when not available', () => {
+    config.featureToggles = { ...originalFeatureToggles };
+    delete (config.featureToggles as Record<string, unknown>).kgAnnotationsInMetricsDrilldown;
+
+    expect(getKgSceneProps()).toBeUndefined();
+  });
+
+  it('returns proper structure when available', () => {
+    (config.featureToggles as Record<string, unknown>).kgAnnotationsInMetricsDrilldown = true;
+    config.datasources = { knowledgegraph: KG_DATASOURCE };
+
+    const props = getKgSceneProps();
+    expect(props).toBeDefined();
+    expect(props!.$data).toBeInstanceOf(SceneDataLayerSet);
+    expect(props!.behaviors).toHaveLength(1);
+    expect(props!.controls).toBeInstanceOf(KgAnnotationToggle);
+  });
+});
+
+describe('KgAnnotationToggle', () => {
+  it('toggles enabled state and propagates to layers', () => {
+    const layerSet = new SceneDataLayerSet({ name: 'test', layers: [] });
+    const toggle = new KgAnnotationToggle({
+      isEnabled: true,
+      layerSetRef: new SceneObjectRef(layerSet),
+    });
+
+    expect(toggle.state.isEnabled).toBe(true);
+    toggle.toggleEnabled();
+    expect(toggle.state.isEnabled).toBe(false);
+    toggle.toggleEnabled();
+    expect(toggle.state.isEnabled).toBe(true);
+  });
+
+  it('syncLayerEnabledState syncs current toggle state to layers', () => {
+    const layerSet = new SceneDataLayerSet({ name: 'test', layers: [] });
+    const toggle = new KgAnnotationToggle({
+      isEnabled: false,
+      layerSetRef: new SceneObjectRef(layerSet),
+    });
+
+    toggle.syncLayerEnabledState();
+    // With empty layers, this should not throw
+    expect(toggle.state.isEnabled).toBe(false);
+  });
+});

--- a/src/shared/knowledgeGraph/kgAnnotations.test.ts
+++ b/src/shared/knowledgeGraph/kgAnnotations.test.ts
@@ -1,8 +1,8 @@
 import { config } from '@grafana/runtime';
 import { SceneDataLayerSet, SceneObjectRef } from '@grafana/scenes';
 
-import { isKgAnnotationsAvailable, getKgSceneProps } from './kgAnnotations';
-import { KgAnnotationToggle } from './KgAnnotationToggle';
+import { getKgSceneProps, isKgAnnotationsAvailable } from 'shared/knowledgeGraph/kgAnnotations';
+import { KgAnnotationToggle } from 'shared/knowledgeGraph/KgAnnotationToggle';
 
 const originalDatasources = config.datasources;
 const originalFeatureToggles = { ...config.featureToggles };

--- a/src/shared/knowledgeGraph/kgAnnotations.test.ts
+++ b/src/shared/knowledgeGraph/kgAnnotations.test.ts
@@ -1,5 +1,5 @@
 import { config } from '@grafana/runtime';
-import { SceneDataLayerSet, SceneObjectRef } from '@grafana/scenes';
+import { dataLayers, SceneDataLayerSet, SceneObjectRef } from '@grafana/scenes';
 
 import { getKgSceneProps, isKgAnnotationsAvailable } from 'shared/knowledgeGraph/kgAnnotations';
 import { KgAnnotationToggle } from 'shared/knowledgeGraph/KgAnnotationToggle';
@@ -61,30 +61,42 @@ describe('getKgSceneProps', () => {
   });
 });
 
+function makeLayerSet(isEnabled: boolean) {
+  const layer = new dataLayers.AnnotationsDataLayer({ name: 'test-layer', isEnabled, query: {} as any });
+  const layerSet = new SceneDataLayerSet({ name: 'test', layers: [layer] });
+  return { layer, layerSet };
+}
+
 describe('KgAnnotationToggle', () => {
   it('toggles enabled state and propagates to layers', () => {
-    const layerSet = new SceneDataLayerSet({ name: 'test', layers: [] });
+    const { layer, layerSet } = makeLayerSet(true);
     const toggle = new KgAnnotationToggle({
       isEnabled: true,
       layerSetRef: new SceneObjectRef(layerSet),
     });
 
-    expect(toggle.state.isEnabled).toBe(true);
     toggle.toggleEnabled();
     expect(toggle.state.isEnabled).toBe(false);
+    expect(layer.state.isEnabled).toBe(false);
+
     toggle.toggleEnabled();
     expect(toggle.state.isEnabled).toBe(true);
+    expect(layer.state.isEnabled).toBe(true);
   });
 
   it('syncLayerEnabledState syncs current toggle state to layers', () => {
-    const layerSet = new SceneDataLayerSet({ name: 'test', layers: [] });
+    const { layer, layerSet } = makeLayerSet(true);
     const toggle = new KgAnnotationToggle({
       isEnabled: false,
       layerSetRef: new SceneObjectRef(layerSet),
     });
 
     toggle.syncLayerEnabledState();
-    // With empty layers, this should not throw
-    expect(toggle.state.isEnabled).toBe(false);
+    expect(layer.state.isEnabled).toBe(false);
   });
+
+  // KgAnnotationBehavior reactive tests (filter/datasource subscriptions, layer creation, dedup)
+  // are not covered here. The behavior relies on sceneGraph.lookupVariable which requires a
+  // fully mounted scene tree with AdHocFiltersVariable and a datasource variable wired up.
+  // This needs a dedicated integration-style test with scene activation -- deferred to a follow-up.
 });

--- a/src/shared/knowledgeGraph/kgAnnotations.ts
+++ b/src/shared/knowledgeGraph/kgAnnotations.ts
@@ -119,8 +119,11 @@ export class KgAnnotationBehavior extends SceneObjectBase<KgAnnotationBehaviorSt
 
     const datasourceUid = (dsVar?.getValue() as string) || '';
     const lookupKey = `${datasourceUid}::${JSON.stringify(labels)}`;
+    const hasLabels = Object.keys(labels).length > 0;
 
-    if (lookupKey === this.currentLookupKey) {
+    // Only deduplicate when we have labels — always allow the clear path to run
+    // so that stale annotation data is removed when filters are emptied
+    if (lookupKey === this.currentLookupKey && hasLabels) {
       return;
     }
     this.currentLookupKey = lookupKey;
@@ -128,7 +131,7 @@ export class KgAnnotationBehavior extends SceneObjectBase<KgAnnotationBehaviorSt
     const layerSet = this.state.layerSet.resolve();
     const toggle = this.state.toggle.resolve();
 
-    if (Object.keys(labels).length > 0 && datasourceUid) {
+    if (hasLabels && datasourceUid) {
       const layers = createAnnotationLayers(labels, datasourceUid);
       layerSet.setState({ layers });
       toggle.syncLayerEnabledState();

--- a/src/shared/knowledgeGraph/kgAnnotations.ts
+++ b/src/shared/knowledgeGraph/kgAnnotations.ts
@@ -45,14 +45,14 @@ function createFromLabelsAnnotationLayers(labels: Record<string, string>, dataso
   return getSeverities().map(
     (s) =>
       new dataLayers.AnnotationsDataLayer({
-        name: `Insights - ${s.label}`,
+        name: t('kg-annotations.layer.name', 'Insights - {{severityLabel}}', { severityLabel: s.label }),
         isEnabled: true,
         isHidden: true,
         query: {
           datasource: { type: KG_DATASOURCE_TYPE, uid: KG_DATASOURCE_UID },
           enable: true,
           iconColor: s.color,
-          name: `KG Assertions - ${s.label}`,
+          name: t('kg-annotations.query.name', 'KG Assertions - {{severityLabel}}', { severityLabel: s.label }),
           target: {
             refId: `kgAnnotations-${s.value}`,
             queryType: 'annotations',
@@ -73,14 +73,14 @@ function createDirectAnnotationLayers(entity: KgEntityHint) {
   return getSeverities().map(
     (s) =>
       new dataLayers.AnnotationsDataLayer({
-        name: `Insights - ${s.label}`,
+        name: t('kg-annotations.layer.name', 'Insights - {{severityLabel}}', { severityLabel: s.label }),
         isEnabled: true,
         isHidden: true,
         query: {
           datasource: { type: KG_DATASOURCE_TYPE, uid: KG_DATASOURCE_UID },
           enable: true,
           iconColor: s.color,
-          name: `KG Assertions - ${s.label}`,
+          name: t('kg-annotations.query.name', 'KG Assertions - {{severityLabel}}', { severityLabel: s.label }),
           target: {
             refId: `kgAnnotations-${s.value}`,
             queryType: 'annotations',

--- a/src/shared/knowledgeGraph/kgAnnotations.ts
+++ b/src/shared/knowledgeGraph/kgAnnotations.ts
@@ -30,7 +30,7 @@ interface KgSceneProps {
 }
 
 export function isKgAnnotationsAvailable(): boolean {
-  return Object.values(config.datasources).some((d) => d.uid === KG_DATASOURCE_UID);
+  return Object.values(config.datasources).some((d) => d.uid === KG_DATASOURCE_UID && d.type === KG_DATASOURCE_TYPE);
 }
 
 function getSeverities() {

--- a/src/shared/knowledgeGraph/kgAnnotations.ts
+++ b/src/shared/knowledgeGraph/kgAnnotations.ts
@@ -11,7 +11,6 @@ import {
 } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
 
-import { isKnowledgeGraphAnnotationsEnabled } from 'shared/featureToggles/knowledgeGraphAnnotations';
 import { KgAnnotationToggle } from 'shared/knowledgeGraph/KgAnnotationToggle';
 import { VAR_DATASOURCE, VAR_FILTERS } from 'shared/shared';
 
@@ -31,9 +30,6 @@ interface KgSceneProps {
 }
 
 export function isKgAnnotationsAvailable(): boolean {
-  if (!isKnowledgeGraphAnnotationsEnabled()) {
-    return false;
-  }
   return Object.values(config.datasources).some((d) => d.uid === KG_DATASOURCE_UID);
 }
 

--- a/src/shared/knowledgeGraph/kgAnnotations.ts
+++ b/src/shared/knowledgeGraph/kgAnnotations.ts
@@ -1,19 +1,19 @@
+import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import {
-  AdHocFiltersVariable,
   dataLayers,
   SceneDataLayerSet,
+  sceneGraph,
   SceneObjectBase,
   SceneObjectRef,
-  SceneObjectState,
-  sceneGraph,
+  type AdHocFiltersVariable,
+  type SceneObjectState,
 } from '@grafana/scenes';
-import { DataQuery } from '@grafana/schema';
+import { type DataQuery } from '@grafana/schema';
 
+import { isKnowledgeGraphAnnotationsEnabled } from 'shared/featureToggles/knowledgeGraphAnnotations';
+import { KgAnnotationToggle } from 'shared/knowledgeGraph/KgAnnotationToggle';
 import { VAR_DATASOURCE, VAR_FILTERS } from 'shared/shared';
-
-import { isKnowledgeGraphAnnotationsEnabled } from '../featureToggles/knowledgeGraphAnnotations';
-import { KgAnnotationToggle } from './KgAnnotationToggle';
 
 const KG_DATASOURCE_TYPE = 'grafana-knowledgegraph-datasource';
 const KG_DATASOURCE_UID = 'grafanacloud-knowledgegraph';
@@ -33,10 +33,10 @@ export function isKgAnnotationsAvailable(): boolean {
 
 function createAnnotationLayers(labels: Record<string, string>, datasourceUid: string) {
   const severities = [
-    { value: 'critical', color: 'red', label: 'Critical' },
-    { value: 'warning', color: 'orange', label: 'Warning' },
-    { value: 'info', color: 'blue', label: 'Info' },
-  ] as const;
+    { value: 'critical', color: 'red', label: t('kg-annotations.severity.critical', 'Critical') },
+    { value: 'warning', color: 'orange', label: t('kg-annotations.severity.warning', 'Warning') },
+    { value: 'info', color: 'blue', label: t('kg-annotations.severity.info', 'Info') },
+  ];
 
   return severities.map(
     (s) =>

--- a/src/shared/knowledgeGraph/kgAnnotations.ts
+++ b/src/shared/knowledgeGraph/kgAnnotations.ts
@@ -1,0 +1,163 @@
+import { config } from '@grafana/runtime';
+import {
+  AdHocFiltersVariable,
+  dataLayers,
+  SceneDataLayerSet,
+  SceneObjectBase,
+  SceneObjectRef,
+  SceneObjectState,
+  sceneGraph,
+} from '@grafana/scenes';
+import { DataQuery } from '@grafana/schema';
+
+import { VAR_DATASOURCE, VAR_FILTERS } from 'shared/shared';
+
+import { isKnowledgeGraphAnnotationsEnabled } from '../featureToggles/knowledgeGraphAnnotations';
+import { KgAnnotationToggle } from './KgAnnotationToggle';
+
+const KG_DATASOURCE_TYPE = 'grafana-knowledgegraph-datasource';
+const KG_DATASOURCE_UID = 'grafanacloud-knowledgegraph';
+
+interface KgSceneProps {
+  $data: SceneDataLayerSet;
+  behaviors: KgAnnotationBehavior[];
+  controls: KgAnnotationToggle;
+}
+
+export function isKgAnnotationsAvailable(): boolean {
+  if (!isKnowledgeGraphAnnotationsEnabled()) {
+    return false;
+  }
+  return Object.values(config.datasources).some((d) => d.uid === KG_DATASOURCE_UID);
+}
+
+function createAnnotationLayers(labels: Record<string, string>, datasourceUid: string) {
+  const severities = [
+    { value: 'critical', color: 'red', label: 'Critical' },
+    { value: 'warning', color: 'orange', label: 'Warning' },
+    { value: 'info', color: 'blue', label: 'Info' },
+  ] as const;
+
+  return severities.map(
+    (s) =>
+      new dataLayers.AnnotationsDataLayer({
+        name: `Insights - ${s.label}`,
+        isEnabled: true,
+        isHidden: true,
+        query: {
+          datasource: { type: KG_DATASOURCE_TYPE, uid: KG_DATASOURCE_UID },
+          enable: true,
+          iconColor: s.color,
+          name: `KG Assertions - ${s.label}`,
+          target: {
+            refId: `kgAnnotations-${s.value}`,
+            queryType: 'annotations',
+            queryMode: 'fromLabels',
+            severityFilter: [s.value],
+            fromLabelsQuery: {
+              telemetryType: 'metric',
+              datasourceUid,
+              labels,
+            },
+          } as unknown as DataQuery,
+        },
+      })
+  );
+}
+
+interface KgAnnotationBehaviorState extends SceneObjectState {
+  layerSet: SceneObjectRef<SceneDataLayerSet>;
+  toggle: SceneObjectRef<KgAnnotationToggle>;
+}
+
+export class KgAnnotationBehavior extends SceneObjectBase<KgAnnotationBehaviorState> {
+  private currentLookupKey: string | undefined;
+
+  constructor(state: KgAnnotationBehaviorState) {
+    super(state);
+    this.addActivationHandler(this._onActivate);
+  }
+
+  private _onActivate = () => {
+    const filtersVar = sceneGraph.lookupVariable(VAR_FILTERS, this) as AdHocFiltersVariable | undefined;
+    if (!filtersVar) {
+      return;
+    }
+
+    const dsVar = sceneGraph.lookupVariable(VAR_DATASOURCE, this);
+
+    this.onFiltersChanged(filtersVar, dsVar);
+
+    const subs = [
+      filtersVar.subscribeToState(() => {
+        this.onFiltersChanged(filtersVar, dsVar);
+      }),
+    ];
+
+    if (dsVar) {
+      subs.push(
+        dsVar.subscribeToState(() => {
+          this.onFiltersChanged(filtersVar, dsVar);
+        })
+      );
+    }
+
+    return () => {
+      subs.forEach((s) => s.unsubscribe());
+    };
+  };
+
+  private onFiltersChanged(
+    filtersVar: AdHocFiltersVariable,
+    dsVar: ReturnType<typeof sceneGraph.lookupVariable> | undefined
+  ) {
+    const filters = filtersVar.state.filters.filter((f) => f.operator === '=');
+    const labels: Record<string, string> = {};
+    for (const f of filters) {
+      labels[f.key] = f.value;
+    }
+
+    const datasourceUid = (dsVar?.getValue() as string) || '';
+    const lookupKey = `${datasourceUid}::${JSON.stringify(labels)}`;
+
+    if (lookupKey === this.currentLookupKey) {
+      return;
+    }
+    this.currentLookupKey = lookupKey;
+
+    const layerSet = this.state.layerSet.resolve();
+    const toggle = this.state.toggle.resolve();
+
+    if (Object.keys(labels).length > 0 && datasourceUid) {
+      const layers = createAnnotationLayers(labels, datasourceUid);
+      layerSet.setState({ layers });
+      toggle.syncLayerEnabledState();
+    } else {
+      layerSet.setState({ layers: [] });
+    }
+  }
+}
+
+export function getKgSceneProps(): KgSceneProps | undefined {
+  if (!isKgAnnotationsAvailable()) {
+    return undefined;
+  }
+
+  const layerSet = new SceneDataLayerSet({ name: 'Insights', layers: [] });
+
+  const toggle = new KgAnnotationToggle({
+    isEnabled: true,
+    layerSetRef: new SceneObjectRef(layerSet),
+  });
+
+  const behavior = new KgAnnotationBehavior({
+    layerSet: new SceneObjectRef(layerSet),
+    toggle: new SceneObjectRef(toggle),
+  });
+
+  return {
+    $data: layerSet,
+    behaviors: [behavior],
+    controls: toggle,
+  };
+}

--- a/src/shared/knowledgeGraph/kgAnnotations.ts
+++ b/src/shared/knowledgeGraph/kgAnnotations.ts
@@ -18,6 +18,12 @@ import { VAR_DATASOURCE, VAR_FILTERS } from 'shared/shared';
 const KG_DATASOURCE_TYPE = 'grafana-knowledgegraph-datasource';
 const KG_DATASOURCE_UID = 'grafanacloud-knowledgegraph';
 
+export interface KgEntityHint {
+  entityType: string;
+  entityName: string;
+  scope?: { env?: string; site?: string; namespace?: string };
+}
+
 interface KgSceneProps {
   $data: SceneDataLayerSet;
   behaviors: KgAnnotationBehavior[];
@@ -31,14 +37,16 @@ export function isKgAnnotationsAvailable(): boolean {
   return Object.values(config.datasources).some((d) => d.uid === KG_DATASOURCE_UID);
 }
 
-function createAnnotationLayers(labels: Record<string, string>, datasourceUid: string) {
-  const severities = [
+function getSeverities() {
+  return [
     { value: 'critical', color: 'red', label: t('kg-annotations.severity.critical', 'Critical') },
     { value: 'warning', color: 'orange', label: t('kg-annotations.severity.warning', 'Warning') },
     { value: 'info', color: 'blue', label: t('kg-annotations.severity.info', 'Info') },
   ];
+}
 
-  return severities.map(
+function createFromLabelsAnnotationLayers(labels: Record<string, string>, datasourceUid: string) {
+  return getSeverities().map(
     (s) =>
       new dataLayers.AnnotationsDataLayer({
         name: `Insights - ${s.label}`,
@@ -58,6 +66,49 @@ function createAnnotationLayers(labels: Record<string, string>, datasourceUid: s
               telemetryType: 'metric',
               datasourceUid,
               labels,
+            },
+          } as unknown as DataQuery,
+        },
+      })
+  );
+}
+
+function createDirectAnnotationLayers(entity: KgEntityHint) {
+  return getSeverities().map(
+    (s) =>
+      new dataLayers.AnnotationsDataLayer({
+        name: `Insights - ${s.label}`,
+        isEnabled: true,
+        isHidden: true,
+        query: {
+          datasource: { type: KG_DATASOURCE_TYPE, uid: KG_DATASOURCE_UID },
+          enable: true,
+          iconColor: s.color,
+          name: `KG Assertions - ${s.label}`,
+          target: {
+            refId: `kgAnnotations-${s.value}`,
+            queryType: 'annotations',
+            queryMode: 'advanced',
+            severityFilter: [s.value],
+            advancedQuery: {
+              filterCriteria: [
+                {
+                  entityType: entity.entityType,
+                  propertyMatchers: [{ name: 'name', value: entity.entityName, op: 'EQUALS' }],
+                  havingAssertion: true,
+                },
+              ],
+              ...(entity.scope
+                ? {
+                    scopeCriteria: {
+                      nameAndValues: {
+                        ...(entity.scope.env ? { env: [entity.scope.env] } : {}),
+                        ...(entity.scope.site ? { site: [entity.scope.site] } : {}),
+                        ...(entity.scope.namespace ? { namespace: [entity.scope.namespace] } : {}),
+                      },
+                    },
+                  }
+                : {}),
             },
           } as unknown as DataQuery,
         },
@@ -132,7 +183,7 @@ export class KgAnnotationBehavior extends SceneObjectBase<KgAnnotationBehaviorSt
     const toggle = this.state.toggle.resolve();
 
     if (hasLabels && datasourceUid) {
-      const layers = createAnnotationLayers(labels, datasourceUid);
+      const layers = createFromLabelsAnnotationLayers(labels, datasourceUid);
       layerSet.setState({ layers });
       toggle.syncLayerEnabledState();
     } else {
@@ -141,7 +192,7 @@ export class KgAnnotationBehavior extends SceneObjectBase<KgAnnotationBehaviorSt
   }
 }
 
-export function getKgSceneProps(): KgSceneProps | undefined {
+export function getKgSceneProps(entity?: KgEntityHint): KgSceneProps | undefined {
   if (!isKgAnnotationsAvailable()) {
     return undefined;
   }
@@ -153,6 +204,18 @@ export function getKgSceneProps(): KgSceneProps | undefined {
     layerSetRef: new SceneObjectRef(layerSet),
   });
 
+  if (entity) {
+    // Direct entity query — layers are created upfront, no filter subscription needed
+    const layers = createDirectAnnotationLayers(entity);
+    layerSet.setState({ layers });
+    return {
+      $data: layerSet,
+      behaviors: [],
+      controls: toggle,
+    };
+  }
+
+  // Fallback — watch filters and resolve entities via fromLabels
   const behavior = new KgAnnotationBehavior({
     layerSet: new SceneObjectRef(layerSet),
     toggle: new SceneObjectRef(toggle),

--- a/src/shared/knowledgeGraph/kgAnnotations.ts
+++ b/src/shared/knowledgeGraph/kgAnnotations.ts
@@ -94,7 +94,7 @@ function createDirectAnnotationLayers(entity: KgEntityHint) {
               filterCriteria: [
                 {
                   entityType: entity.entityType,
-                  propertyMatchers: [{ name: 'name', value: entity.entityName, op: 'EQUALS' }],
+                  propertyMatchers: [{ name: 'name', value: entity.entityName, op: '=' }],
                   havingAssertion: true,
                 },
               ],


### PR DESCRIPTION
Closes https://github.com/grafana/asserts-app-plugin/issues/2920

https://github.com/user-attachments/assets/05ec1ad8-f8d9-4f0c-a529-a8f6e27ebb00

<img width="381" height="133" alt="Screenshot 2026-04-02 at 11 11 07 AM" src="https://github.com/user-attachments/assets/6440eceb-92c8-4252-9532-d5d1d14c799c" />
<img width="1472" height="823" alt="Screenshot 2026-04-01 at 5 58 38 PM" src="https://github.com/user-attachments/assets/67374b5b-5ffc-4a09-baae-de6a28b88e5b" />


## Summary
- Adds Knowledge Graph health-state annotations (critical, warning, info) as overlays on timeseries and percentile panels
- Gated behind the `kgAnnotationsInMetricsDrilldown` feature toggle and requires the KG datasource to be provisioned
- Includes an "Insights" toggle control in the header and a reactive behavior that updates annotation layers when filters or datasource change
- Enables multi-lane annotation display on all timeseries/percentile panels

## Test plan
- [ ] Verify annotations do not appear when feature toggle is disabled
- [ ] Verify annotations do not appear when KG datasource is not provisioned
- [ ] Enable toggle and confirm critical/warning/info annotations render on timeseries panels
- [ ] Toggle "Insights" switch off and confirm annotations hide
- [ ] Change filters and verify annotation layers update reactively
- [ ] Confirm no regressions on percentile panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)