### PR TITLE
docs: Update menu title and weight in _index.md

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -5,6 +5,7 @@ labels:
     - enterprise
     - oss
 title: Grafana Metrics Drilldown
+menuTitle: Metrics Drilldown
 aliases:
   - ../explore-metrics/ # /docs/grafana/latest/explore/explore-metrics/
 canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/metrics/
@@ -30,7 +31,7 @@ cards:
       href: ./drill-down-metrics/
       description: Drill down into your metrics without writing a PromQL query.
       height: 24
-weight: 200
+weight: 50
 ---
 
 # Grafana Metrics Drilldown


### PR DESCRIPTION
This fixes the order the Drilldown apps display in the docs to Metrics, Logs, Traces, and Profiles. 

Modifies the menuTitle to be Metrics Drilldown, which matches the other Drilldown apps in the docs table of contents.
