### PR TITLE
fix: add entry in CODEOWNERS for the docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @grafana/observability-metrics
-/docs/sources/ @grafana/docs-metrics
+/docs/sources/ @grafana/docs-metrics @grafana/observability-metrics


### PR DESCRIPTION
### ✨ Description

Adds `@grafana/observability-metrics` team back to be a joint code owner of the `/docs/sources` dir.

### 🧪 How to test?

`@grafana/observability-metrics` team can approve docs PRs
