### PR TITLE
fix: update related metrics select button to secondary variant

### DIFF
--- a/src/MetricsReducer/MetricsList/MetricsList.tsx
+++ b/src/MetricsReducer/MetricsList/MetricsList.tsx
@@ -84,7 +84,7 @@ export class MetricsList extends SceneObjectBase<MetricsListState> {
                 metric: option.value as string,
                 panelOptions: {
                   fixedColorIndex: colorIndex,
-                  headerActions: ({ metric }) => [new SelectAction({ metric: metric.name })],
+                  headerActions: ({ metric }) => [new SelectAction({ metric: metric.name, variant: 'secondary' })],
                 },
               }),
             }),


### PR DESCRIPTION
### ✨ Description

fixes: https://github.com/orgs/grafana/projects/516/views/30?pane=issue&itemId=158437952&issue=grafana%7Cmetrics-drilldown%7C1086

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->
update related metrics select button to be secondary variant, matching the breakdown tab's button styling

#### pre-changes
<img width="1180" height="1222" alt="image" src="https://github.com/user-attachments/assets/be8528cb-80a1-47c9-8e6d-e8fc78218835" />

#### post-changes
<img width="1180" height="1222" alt="image" src="https://github.com/user-attachments/assets/83acfe51-7562-4428-9b95-f8ea755bfc73" />
