### PR TITLE
fix(deps): resolve pnpm audit CVEs (protobufjs, dompurify, protocol-buffers-schema)

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "overrides": {
       "@remix-run/router": "^1.23.2",
       "react-router": "^6.30.2",
-      "dompurify": "^3.3.2",
+      "dompurify": "^3.4.0",
       "lodash": "^4.18.0",
       "minimatch@^3": "~3.1.4",
       "minimatch@^9": "~10.2.0",
@@ -144,6 +144,9 @@
       "undici": "^7.24.0",
       "picomatch@^2": "~2.3.2",
       "picomatch@^4": "^4.0.4",
+      "protobufjs@^7": "^7.5.5",
+      "protobufjs@^8": "^8.0.1",
+      "protocol-buffers-schema": "^3.6.1",
       "brace-expansion@^1": "^1.1.13",
       "brace-expansion@^5": "^5.0.5",
       "yaml": "^2.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@remix-run/router': ^1.23.2
   react-router: ^6.30.2
-  dompurify: ^3.3.2
+  dompurify: ^3.4.0
   lodash: ^4.18.0
   minimatch@^3: ~3.1.4
   minimatch@^9: ~10.2.0
@@ -18,6 +18,9 @@ overrides:
   undici: ^7.24.0
   picomatch@^2: ~2.3.2
   picomatch@^4: ^4.0.4
+  protobufjs@^7: ^7.5.5
+  protobufjs@^8: ^8.0.1
+  protocol-buffers-schema: ^3.6.1
   brace-expansion@^1: ^1.1.13
   brace-expansion@^5: ^5.0.5
   yaml: ^2.8.3
@@ -3075,9 +3078,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.3.2:
-    resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
-    engines: {node: '>=20'}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
@@ -4833,16 +4835,16 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
-  protobufjs@8.0.0:
-    resolution: {integrity: sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==}
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
     engines: {node: '>=12.0.0'}
 
-  protocol-buffers-schema@3.6.0:
-    resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -6665,7 +6667,7 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-scale-chromatic: 3.1.0
       date-fns: 4.1.0
-      dompurify: 3.3.2
+      dompurify: 3.4.0
       eventemitter3: 5.0.1
       fast_array_intersect: 1.1.0
       history: 4.10.1
@@ -7700,7 +7702,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.202.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
   '@opentelemetry/otlp-transformer@0.212.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -7711,7 +7713,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.212.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
-      protobufjs: 8.0.0
+      protobufjs: 8.0.1
 
   '@opentelemetry/resources@2.0.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -9591,7 +9593,7 @@ snapshots:
       '@babel/runtime': 7.28.6
       csstype: 3.2.3
 
-  dompurify@3.3.2:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -11759,7 +11761,7 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -11774,7 +11776,7 @@ snapshots:
       '@types/node': 24.12.0
       long: 5.3.2
 
-  protobufjs@8.0.0:
+  protobufjs@8.0.1:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -11789,7 +11791,7 @@ snapshots:
       '@types/node': 24.12.0
       long: 5.3.2
 
-  protocol-buffers-schema@3.6.0: {}
+  protocol-buffers-schema@3.6.1: {}
 
   punycode@2.3.1: {}
 
@@ -12250,7 +12252,7 @@ snapshots:
 
   resolve-protobuf-schema@2.1.0:
     dependencies:
-      protocol-buffers-schema: 3.6.0
+      protocol-buffers-schema: 3.6.1
 
   resolve@1.22.11:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves all 4 vulnerabilities reported by `pnpm audit` via `pnpm.overrides` in `package.json`. All are in transitive deps — no top-level Grafana packages bumped.

| Severity | Package | From | To | Advisory |
| --- | --- | --- | --- | --- |
| Critical | `protobufjs` (7.x path) | 7.5.4 | ^7.5.5 | [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg) |
| Critical | `protobufjs` (8.x path) | 8.0.0 | ^8.0.1 | [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg) |
| Moderate | `dompurify` | 3.3.2 | ^3.4.0 | [GHSA-39q2-94rc-95cp](https://github.com/advisories/GHSA-39q2-94rc-95cp) |
| Moderate | `protocol-buffers-schema` | 3.6.0 | ^3.6.1 | [GHSA-j452-xhg8-qg39](https://github.com/advisories/GHSA-j452-xhg8-qg39) |

Two major versions of `protobufjs` coexist in the tree (pulled via different paths through `@opentelemetry/otlp-transformer`), so the override uses pnpm's versioned-override syntax (`protobufjs@^7`, `protobufjs@^8`) — same pattern already in use for `minimatch@^N`.

Follows the established CVE-remediation pattern (see #1177, #1172, #1166, #1151).

## Test plan

- [x] `pnpm audit` → `No known vulnerabilities found`
- [x] `pnpm install` succeeds; lockfile shows `protobufjs@7.5.5`, `protobufjs@8.0.1`, `dompurify@3.4.0`, `protocol-buffers-schema@3.6.1`
- [x] `pnpm typecheck` passes
- [x] `pnpm test:ci` passes (55 suites, 520 tests)
- [x] `pnpm build` (production webpack) succeeds