### PR TITLE
chore: add mise.toml and align CI node version

### DIFF
--- a/.github/workflows/bundle-stats-create.yml
+++ b/.github/workflows/bundle-stats-create.yml
@@ -21,13 +21,19 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Get Node.js version from package.json
+        id: node-version
+        run: |
+          NODE_VERSION=$(node -p "require('./package.json').engines.node.replace('>=', '')")
+          echo "version=$NODE_VERSION" >> $GITHUB_OUTPUT
+
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - name: Setup Node.js environment
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '22'
+          node-version: ${{ steps.node-version.outputs.version }}
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -11,12 +11,17 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Get Node.js version from package.json
+        id: node-version
+        run: |
+          NODE_VERSION=$(node -p "require('./package.json').engines.node.replace('>=', '')")
+          echo "version=$NODE_VERSION" >> $GITHUB_OUTPUT
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - name: Setup Node.js environment
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '22'
+          node-version: ${{ steps.node-version.outputs.version }}
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[settings]
+node.corepack = true
+
+[tools]
+node = "24.15.0"


### PR DESCRIPTION
### ✨ Description

Add `mise.toml` for local dev tooling and align CI Node version references.

### 📖 Summary of the changes

- Add `mise.toml` with Node 24.15.0 and corepack enabled
- Update `is-compatible.yml` and `bundle-stats-create.yml` to read Node version from `package.json` engines instead of hardcoding `22`, matching the existing pattern in `bundle-stats-compare.yml`

### 🧪 How to test?

- [ ] Verify CI workflows pass on this PR
- [ ] Run `mise install` locally and confirm correct Node version

