### PR TITLE
chore(deps): fix CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "e2e:codegen": "playwright codegen",
     "e2e:smoke": "playwright test -c ./e2e/config/playwright.config.smoke.ts -x --trace on",
     "knip": "pnpm dlx knip --config knip.js",
+    "cve-scan": "trivy repo . -f table --scanners vuln",
     "i18n-extract": "i18next-cli extract -c i18next.config.ts",
     "i18n-extract-check": "i18next-cli extract -c i18next.config.ts --ci"
   },
@@ -152,7 +153,8 @@
       "yaml": "^2.8.3",
       "@grafana/data": "^13.0.0",
       "@grafana/i18n": "^13.0.0",
-      "@grafana/schema": "^13.0.0"
+      "@grafana/schema": "^13.0.0",
+      "uuid": "^14.0.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ overrides:
   '@grafana/data': ^13.0.0
   '@grafana/i18n': ^13.0.0
   '@grafana/schema': ^13.0.0
+  uuid: ^14.0.0
 
 importers:
 
@@ -5933,20 +5934,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
-
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
-    hasBin: true
-
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
   uwrap@0.1.2:
@@ -6797,7 +6786,7 @@ snapshots:
       '@grafana/e2e-selectors': 13.1.0-24448182242
       '@playwright/test': 1.59.1
       semver: 7.7.4
-      uuid: 13.0.0
+      uuid: 14.0.0
       yaml: 2.8.3
 
   '@grafana/plugin-ui@0.12.1(@grafana/data@13.0.0(eslint@10.0.2(jiti@2.6.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/e2e-selectors@12.4.0)(@grafana/runtime@12.4.0(@openfeature/web-sdk@1.7.3(@openfeature/core@1.9.2))(@types/react@18.3.28)(eslint@10.0.2(jiti@2.6.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/ui@12.4.0(@types/react@18.3.28)(eslint@10.0.2(jiti@2.6.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.2)':
@@ -6820,7 +6809,7 @@ snapshots:
       react-virtualized-auto-sizer: 1.0.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rxjs: 7.8.2
       sql-formatter-plus: 1.3.6
-      uuid: 11.1.0
+      uuid: 14.0.0
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -6868,7 +6857,7 @@ snapshots:
       react-window: 1.8.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rxjs: 7.8.2
       semver: 7.7.3
-      uuid: 11.1.0
+      uuid: 14.0.0
     transitivePeerDependencies:
       - '@openfeature/web-sdk'
       - dayjs
@@ -6960,7 +6949,7 @@ snapshots:
       react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-virtualized-auto-sizer: 1.0.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rxjs: 7.8.2
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/react'
@@ -7043,7 +7032,7 @@ snapshots:
       tinycolor2: 1.6.0
       tslib: 2.8.1
       uplot: 1.6.32
-      uuid: 11.1.0
+      uuid: 14.0.0
       uwrap: 0.1.2
     transitivePeerDependencies:
       - '@types/react'
@@ -7125,7 +7114,7 @@ snapshots:
       tinycolor2: 1.6.0
       tslib: 2.8.1
       uplot: 1.6.32
-      uuid: 11.1.0
+      uuid: 14.0.0
       uwrap: 0.1.2
     transitivePeerDependencies:
       - '@types/react'
@@ -13052,13 +13041,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@11.1.0: {}
-
-  uuid@13.0.0: {}
-
   uuid@14.0.0: {}
-
-  uuid@9.0.1: {}
 
   uwrap@0.1.2: {}
 


### PR DESCRIPTION
## Summary
- Override transitive `uuid@9.0.1` and `uuid@11.1.0` to `^14.0.0` via pnpm overrides, fixing [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (missing buffer bounds check in v3/v5/v6)
- Add `cve-scan` script (`trivy repo . -f table --scanners vuln`) for local vulnerability scanning

## Test plan
- [x] `pnpm run cve-scan` reports 0 vulnerabilities
- [ ] CI passes (typecheck, lint, tests)