### PR TITLE
fix(provisioning): use Docker service name for Prometheus datasource URL

### DIFF
--- a/provisioning/datasources/default.yaml
+++ b/provisioning/datasources/default.yaml
@@ -26,7 +26,7 @@ datasources:
     type: prometheus
     isDefault: true
     access: proxy
-    url: http://host.docker.internal:9099
+    url: http://prometheus-gmd:9090
     basicAuth: true #username: admin, password: admin
     basicAuthUser: admin
     jsonData:


### PR DESCRIPTION
## Summary
- On Linux, `host.docker.internal` resolves to `172.17.0.1` (the `docker0` bridge gateway), which cannot route traffic to published ports of sibling containers — causing all Prometheus API calls to timeout with 500 errors and the drilldown page to show "No metrics found"
- Changed the provisioned Prometheus datasource URL from `http://host.docker.internal:9099` to `http://prometheus-gmd:9090`, using the Docker service name and internal port directly over the compose network

## Test plan
- [ ] `pnpm run server` + open `http://localhost:3001/a/grafana-metricsdrilldown-app/drilldown` — metrics should load
- [ ] Verify on macOS/Windows that the change works the same (Prometheus is in the same compose stack on all platforms)
- [ ] Run e2e tests: `pnpm run e2e`