### PR TITLE
fix: filter Safari extension errors that crash the app

### DIFF
--- a/src/App/useCatchExceptions.test.ts
+++ b/src/App/useCatchExceptions.test.ts
@@ -108,6 +108,7 @@ describe('useCatchExceptions', () => {
         message: 'Browser extension error: Failed to execute appendChild on Node',
       }),
       expect.objectContaining({
+        errorType: 'browser-extension',
         filename: 'chrome-extension://some-extension-id/something.html',
         lineno: '13',
         colno: '35',
@@ -139,6 +140,7 @@ describe('useCatchExceptions', () => {
         message: `Browser extension error: ${safariMessage}`,
       }),
       expect.objectContaining({
+        errorType: 'browser-extension',
         filename: 'https://grafana.example.com/public/plugins/grafana-metricsdrilldown-app/686.js',
         lineno: '1',
         colno: '1881',

--- a/src/App/useCatchExceptions.test.ts
+++ b/src/App/useCatchExceptions.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { act } from 'react';
 
-import { ensureErrorObject, useCatchExceptions } from './useCatchExceptions';
+import { ensureErrorObject, isSafariExtensionError, useCatchExceptions } from './useCatchExceptions';
 import { errorsToIgnore } from '../shared/logger/faro/faro';
 import { logger } from '../shared/logger/logger';
 
@@ -47,6 +47,20 @@ describe('ensureErrorObject', () => {
 
     expect(result).toBeInstanceOf(Error);
     expect(result.message).toBe('default message');
+  });
+});
+
+describe('isSafariExtensionError', () => {
+  it('returns true for Safari extension background page errors', () => {
+    expect(
+      isSafariExtensionError(
+        "Looks like there is an error in the background page. You might want to inspect your background page for more details: undefined is not an object (evaluating 'window.fixinatorInputs.has')"
+      )
+    ).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isSafariExtensionError('Cannot read property of undefined')).toBe(false);
   });
 });
 
@@ -97,6 +111,37 @@ describe('useCatchExceptions', () => {
         filename: 'chrome-extension://some-extension-id/something.html',
         lineno: '13',
         colno: '35',
+      })
+    );
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it('filters Safari-attributed browser extension errors and logs them', () => {
+    const { result } = renderHook(() => useCatchExceptions());
+
+    const safariMessage =
+      "Looks like there is an error in the background page. You might want to inspect your background page for more details: undefined is not an object (evaluating 'window.fixinatorInputs.has')";
+
+    const safariExtensionError = new ErrorEvent('error', {
+      message: safariMessage,
+      filename: 'https://grafana.example.com/public/plugins/grafana-metricsdrilldown-app/686.js',
+      lineno: 1,
+      colno: 1881,
+      error: new TypeError("undefined is not an object (evaluating 'window.fixinatorInputs.has')"),
+    });
+
+    act(() => {
+      window.dispatchEvent(safariExtensionError);
+    });
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: `Browser extension error: ${safariMessage}`,
+      }),
+      expect.objectContaining({
+        filename: 'https://grafana.example.com/public/plugins/grafana-metricsdrilldown-app/686.js',
+        lineno: '1',
+        colno: '1881',
       })
     );
     expect(result.current[0]).toBeUndefined();

--- a/src/App/useCatchExceptions.ts
+++ b/src/App/useCatchExceptions.ts
@@ -27,12 +27,30 @@ export function ensureErrorObject(error: any, defaultMessage: string): Error {
   return new Error(defaultMessage);
 }
 
+// Safari wraps extension background-script errors with this prefix and
+// attributes them to the page's own scripts, so the filename-based
+// extension:// check below never matches.
+const SAFARI_EXTENSION_ERROR_PREFIX = 'Looks like there is an error in the background page';
+
+export function isSafariExtensionError(message: string): boolean {
+  return message.startsWith(SAFARI_EXTENSION_ERROR_PREFIX);
+}
+
 /**
  * Determines if an error should be treated as an application-breaking error.
  * Filters out known non-critical errors like browser extension errors and ResizeObserver warnings.
  */
 function shouldTreatAsApplicationError(errorEvent: ErrorEvent): boolean {
   if (shouldIgnoreError(errorEvent.message)) {
+    return false;
+  }
+
+  if (isSafariExtensionError(errorEvent.message)) {
+    logger.error(new Error(`Browser extension error: ${errorEvent.message}`, { cause: 'browser-extension' }), {
+      filename: errorEvent.filename,
+      lineno: errorEvent.lineno?.toString(),
+      colno: errorEvent.colno?.toString(),
+    });
     return false;
   }
 

--- a/src/App/useCatchExceptions.ts
+++ b/src/App/useCatchExceptions.ts
@@ -46,7 +46,8 @@ function shouldTreatAsApplicationError(errorEvent: ErrorEvent): boolean {
   }
 
   if (isSafariExtensionError(errorEvent.message)) {
-    logger.error(new Error(`Browser extension error: ${errorEvent.message}`, { cause: 'browser-extension' }), {
+    logger.error(new Error(`Browser extension error: ${errorEvent.message}`, { cause: errorEvent.error }), {
+      errorType: 'browser-extension',
       filename: errorEvent.filename,
       lineno: errorEvent.lineno?.toString(),
       colno: errorEvent.colno?.toString(),
@@ -59,7 +60,8 @@ function shouldTreatAsApplicationError(errorEvent: ErrorEvent): boolean {
     const extensionUrl = new URL(errorEvent.filename);
 
     if (extensionUrl.protocol.endsWith('extension:')) {
-      logger.error(new Error(`Browser extension error: ${errorEvent.message}`, { cause: 'browser-extension' }), {
+      logger.error(new Error(`Browser extension error: ${errorEvent.message}`, { cause: errorEvent.error }), {
+        errorType: 'browser-extension',
         extensionName: extensionUrl.hostname,
         filename: errorEvent.filename,
         lineno: errorEvent.lineno?.toString(),


### PR DESCRIPTION
## Summary
- Fixes #1137 — Safari on macOS crashes with a fatal error when a browser extension (e.g. Fixinator) injects globals that fail to initialize
- Safari attributes extension background-script errors to the page's own scripts rather than `extension://` URLs, so the existing filename-based extension detection in `shouldTreatAsApplicationError()` never matches
- Adds detection for Safari's `"Looks like there is an error in the background page"` error prefix, which Safari universally uses to wrap extension errors — this catches all Safari extension errors, not just the specific Fixinator case

## Test plan
- [x] Unit tests for `isSafariExtensionError()` helper
- [x] Integration test dispatching a Safari-style extension ErrorEvent and verifying it's filtered
- [x] All existing tests pass (19/19)
- [x] TypeScript type check passes
- [x] Manual verification: app loads correctly in Chromium (Playwright screenshot)
- [ ] Ideally test in WebKit/Safari with the Fixinator extension installed (could not reproduce locally due to missing system deps)