### PR TITLE
fix: type InlineBanner error prop as unknown to prevent crash

### DIFF
--- a/src/App/InlineBanner.tsx
+++ b/src/App/InlineBanner.tsx
@@ -9,7 +9,7 @@ type InlineBannerProps = {
   severity: AlertVariant;
   title: string;
   message?: string | React.ReactNode;
-  error?: Error;
+  error?: unknown;
   errorContext?: ErrorContext;
   children?: React.ReactNode;
 };

--- a/src/MetricScene/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
+++ b/src/MetricScene/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
@@ -238,7 +238,7 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
             <InlineBanner
               severity="error"
               title={t('breakdown.label-values-list.error-title', 'Error while loading metrics!')}
-              error={data.errors![0] as Error}
+              error={data.errors?.[0]}
             />
           ),
         }),

--- a/src/MetricScene/QueryResults/QueryResultsScene.tsx
+++ b/src/MetricScene/QueryResults/QueryResultsScene.tsx
@@ -112,7 +112,7 @@ export class QueryResultsScene extends SceneObjectBase<QueryResultsSceneState> {
           <InlineBanner
             severity="error"
             title={t('query-results.error-title', 'Query failed')}
-            error={data.errors[0] as Error}
+            error={data.errors?.[0]}
           />
         )}
         {!InstantQueryResults && (


### PR DESCRIPTION
## Summary
- Changes `InlineBanner`'s `error` prop type from `Error` to `unknown`, aligning the type with its internal `ensureErrorObject` implementation which already handles arbitrary types defensively
- Replaces unsafe `data.errors![0] as Error` with `data.errors?.[0]` in `MetricLabelValuesList` — this was the crash reported by Josh Hunt when adding a label filter on dev (React 19 + Firefox)
- Applies the same optional chaining cleanup in `QueryResultsScene`

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 531 tests pass
- [ ] Verify on dev with React 19 feature flag that adding a label filter no longer crashes
- [ ] Verify error banners still render correctly when queries actually fail