### PR TITLE
fix: __name__ patch to use in components

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -7,7 +7,6 @@ import React from 'react';
 import { AppContext, defaultTrail } from './AppContext';
 import { ErrorView } from './ErrorView';
 import { Onboarding } from './Onboarding';
-import { patchSceneQueryRunnerFilters } from './patchSceneQueryRunner';
 import { AppRoutes } from './Routes';
 import { useCatchExceptions } from './useCatchExceptions';
 import { useReportAppInitialized } from './useReportAppInitialized';
@@ -18,7 +17,6 @@ import { PluginPropsContext } from '../shared/utils/utils.plugin';
 
 initFaro();
 initOpenFeatureProvider();
-patchSceneQueryRunnerFilters();
 
 const prometheusDatasources = Object.values(config.datasources).filter(isPrometheusDataSource);
 

--- a/src/exposedComponents/EntityMetrics/LazyEntityMetrics.tsx
+++ b/src/exposedComponents/EntityMetrics/LazyEntityMetrics.tsx
@@ -9,6 +9,9 @@ const EntityMetrics = lazy(async () => {
   const { loadResources } = await import('@grafana/scenes');
   await initPluginTranslations('grafana-scenes', [loadResources]);
 
+  const { patchSceneQueryRunnerFilters } = await import('App/patchSceneQueryRunner');
+  patchSceneQueryRunnerFilters();
+
   return import('./EntityMetrics');
 });
 

--- a/src/exposedComponents/LabelBreakdown/LazyLabelBreakdown.tsx
+++ b/src/exposedComponents/LabelBreakdown/LazyLabelBreakdown.tsx
@@ -9,6 +9,9 @@ const LabelBreakdown = lazy(async () => {
   const { loadResources } = await import('@grafana/scenes');
   await initPluginTranslations('grafana-scenes', [loadResources]);
 
+  const { patchSceneQueryRunnerFilters } = await import('App/patchSceneQueryRunner');
+  patchSceneQueryRunnerFilters();
+
   return import('./LabelBreakdown');
 });
 

--- a/src/exposedComponents/MiniBreakdown/LazyMiniBreakdown.tsx
+++ b/src/exposedComponents/MiniBreakdown/LazyMiniBreakdown.tsx
@@ -9,6 +9,9 @@ const MiniBreakdown = lazy(async () => {
   const { loadResources } = await import('@grafana/scenes');
   await initPluginTranslations('grafana-scenes', [loadResources]);
 
+  const { patchSceneQueryRunnerFilters } = await import('App/patchSceneQueryRunner');
+  patchSceneQueryRunnerFilters();
+
   return import('./MiniBreakdown');
 });
 

--- a/src/exposedComponents/SourceMetrics/LazySourceMetrics.tsx
+++ b/src/exposedComponents/SourceMetrics/LazySourceMetrics.tsx
@@ -9,6 +9,9 @@ const LabelBreakdown = lazy(async () => {
   const { loadResources } = await import('@grafana/scenes');
   await initPluginTranslations('grafana-scenes', [loadResources]);
 
+  const { patchSceneQueryRunnerFilters } = await import('App/patchSceneQueryRunner');
+  patchSceneQueryRunnerFilters();
+
   return import('./SourceMetrics');
 });
 

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -49,7 +49,7 @@ const LazyApp = lazy(async () => {
   // The patch is also applied inside each LazyExposedComponent (Entity/Label/Mini/SourceMetrics),
   // because exposed components mount in host Grafana surfaces without going through LazyApp.
   // The patch is idempotent (Symbol.for guard in patchSceneQueryRunner.ts), so multiple
-  // lazy boundaries calling it is safe. Kept dynamic to avoid pulling @grafana/scenes
+  // lazy boundaries calling it are safe. Kept dynamic to avoid pulling @grafana/scenes
   // and the logger graph into the entry chunk (see bundle-stats history in extensions/links.ts).
   const { patchSceneQueryRunnerFilters } = await import('App/patchSceneQueryRunner');
   patchSceneQueryRunnerFilters();

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -4,7 +4,6 @@ import { LoadingPlaceholder } from '@grafana/ui';
 import { compare } from 'compare-versions';
 import React, { lazy, Suspense } from 'react';
 
-import { patchSceneQueryRunnerFilters } from 'App/patchSceneQueryRunner';
 import { entityMetricsConfig } from 'exposedComponents/EntityMetrics/config';
 import { labelBreakdownConfig } from 'exposedComponents/LabelBreakdown/config';
 import { miniBreakdownConfig } from 'exposedComponents/MiniBreakdown/config';
@@ -14,7 +13,7 @@ import { linkConfigs } from 'extensions/links';
 
 import pluginJson from './plugin.json';
 
-patchSceneQueryRunnerFilters();
+
 
 const LazyApp = lazy(async () => {
   
@@ -45,6 +44,9 @@ const LazyApp = lazy(async () => {
   } else {
     logger.warn('WASM not supported, outlier detection will not work');
   }
+
+  const { patchSceneQueryRunnerFilters } = await import('App/patchSceneQueryRunner');
+  patchSceneQueryRunnerFilters();
 
   return import('./App/App');
 });

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -13,10 +13,7 @@ import { linkConfigs } from 'extensions/links';
 
 import pluginJson from './plugin.json';
 
-
-
 const LazyApp = lazy(async () => {
-  
   const { initPluginTranslations } = await import('@grafana/i18n');
 
   // Initialize i18n for scenes library

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -4,6 +4,7 @@ import { LoadingPlaceholder } from '@grafana/ui';
 import { compare } from 'compare-versions';
 import React, { lazy, Suspense } from 'react';
 
+import { patchSceneQueryRunnerFilters } from 'App/patchSceneQueryRunner';
 import { entityMetricsConfig } from 'exposedComponents/EntityMetrics/config';
 import { labelBreakdownConfig } from 'exposedComponents/LabelBreakdown/config';
 import { miniBreakdownConfig } from 'exposedComponents/MiniBreakdown/config';
@@ -13,7 +14,10 @@ import { linkConfigs } from 'extensions/links';
 
 import pluginJson from './plugin.json';
 
+patchSceneQueryRunnerFilters();
+
 const LazyApp = lazy(async () => {
+  
   const { initPluginTranslations } = await import('@grafana/i18n');
 
   // Initialize i18n for scenes library

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -45,6 +45,12 @@ const LazyApp = lazy(async () => {
     logger.warn('WASM not supported, outlier detection will not work');
   }
 
+  // TODO: remove once the upstream @grafana/scenes regression is fixed.
+  // The patch is also applied inside each LazyExposedComponent (Entity/Label/Mini/SourceMetrics),
+  // because exposed components mount in host Grafana surfaces without going through LazyApp.
+  // The patch is idempotent (Symbol.for guard in patchSceneQueryRunner.ts), so multiple
+  // lazy boundaries calling it is safe. Kept dynamic to avoid pulling @grafana/scenes
+  // and the logger graph into the entry chunk (see bundle-stats history in extensions/links.ts).
   const { patchSceneQueryRunnerFilters } = await import('App/patchSceneQueryRunner');
   patchSceneQueryRunnerFilters();
 


### PR DESCRIPTION
### ✨ Description

The fix for the Scenes regression where adhocVariableFilters do not respect expressionBuilder and therefore do not remove the __name__ filter needed to be added to plugin components.

**Related issue(s):** 
https://github.com/grafana/metrics-drilldown/pull/1205

<!-- General summary of what the PR aims to do -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

### 📖 Summary of the changes

<!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->
1. Add patch to plugin components
2. Add todo to remove patch once scenes is fixed

### 🧪 How to test?

<!-- Steps required to test the PR or a pointer to the relevant automated tests -->
1. Build KG app and metrics drilldown
2. Use graft for both
3. navigate to the source metrics tab in the KG RCA workbench.
4. [OR use this link after grafting both plugins to ops](https://ops.grafana-ops.net/a/grafana-asserts-app/assertions?start=now-1h&end=now&we%5B0%5D%5Bn%5D=cloudsql-proxy-mysql-exporter&we%5B0%5D%5Btp%5D=Service&we%5B0%5D%5Bsc%5D%5Bns%5D=synthetic-monitoring-prod-ap-south-0&we%5B0%5D%5Bsc%5D%5Benv%5D=prod-ap-south-0&we%5B1%5D%5Bn%5D=cloudsql-proxy-mysql-exporter&we%5B1%5D%5Btp%5D=Service&we%5B1%5D%5Bsc%5D%5Bns%5D=machine-learning&we%5B1%5D%5Bsc%5D%5Benv%5D=prod-ap-southeast-0&we%5B2%5D%5Bn%5D=cloudsql-proxy-mysql-exporter&we%5B2%5D%5Btp%5D=Service&we%5B2%5D%5Bsc%5D%5Bns%5D=onboarding&we%5B2%5D%5Bsc%5D%5Benv%5D=prod-ap-southeast-0&we%5B3%5D%5Bn%5D=cloudsql-proxy-mysql-exporter&we%5B3%5D%5Btp%5D=Service&we%5B3%5D%5Bsc%5D%5Bns%5D=stackstate&we%5B3%5D%5Bsc%5D%5Benv%5D=prod-ap-southeast-0&we%5B4%5D%5Bn%5D=grafana-ruler&we%5B4%5D%5Btp%5D=Service&we%5B4%5D%5Bsc%5D%5Bns%5D=grafana-ruler&we%5B4%5D%5Bsc%5D%5Benv%5D=prod-ap-southeast-0&we%5B5%5D%5Bn%5D=grafana-ruler&we%5B5%5D%5Btp%5D=Service&we%5B5%5D%5Bsc%5D%5Bns%5D=grafana-ruler&we%5B5%5D%5Bsc%5D%5Benv%5D=prod-ap-southeast-1&we%5B6%5D%5Bn%5D=querier-burst&we%5B6%5D%5Btp%5D=Service&we%5B6%5D%5Bsc%5D%5Bns%5D=loki-prod-028&we%5B6%5D%5Bsc%5D%5Benv%5D=prod-ap-south-1&we%5B7%5D%5Bn%5D=querier&we%5B7%5D%5Btp%5D=Service&we%5B7%5D%5Bsc%5D%5Bns%5D=loki-prod-028&we%5B7%5D%5Bsc%5D%5Benv%5D=prod-ap-south-1&we%5B8%5D%5Bn%5D=querier&we%5B8%5D%5Btp%5D=Service&we%5B8%5D%5Bsc%5D%5Bns%5D=loki-prod-020&we%5B8%5D%5Bsc%5D%5Benv%5D=prod-ap-southeast-1&we%5B9%5D%5Bn%5D=policy-api&we%5B9%5D%5Btp%5D=Service&we%5B9%5D%5Bsc%5D%5Bns%5D=tempo-prod-19&we%5B9%5D%5Bsc%5D%5Benv%5D=prod-ap-south-1&we%5B10%5D%5Bn%5D=compactor&we%5B10%5D%5Btp%5D=Service&we%5B10%5D%5Bsc%5D%5Bns%5D=loki-prod-028&we%5B10%5D%5Bsc%5D%5Benv%5D=prod-ap-south-1&we%5B11%5D%5Bn%5D=parallel-querier-burst&we%5B11%5D%5Btp%5D=Service&we%5B11%5D%5Bsc%5D%5Bns%5D=loki-prod-014&we%5B11%5D%5Bsc%5D%5Benv%5D=prod-ap-south-0&we%5B12%5D%5Bn%5D=querier&we%5B12%5D%5Btp%5D=Service&we%5B12%5D%5Bsc%5D%5Bns%5D=loki-prod-030&we%5B12%5D%5Bsc%5D%5Benv%5D=prod-ap-northeast-0&we%5B13%5D%5Bn%5D=parallel-querier-burst&we%5B13%5D%5Btp%5D=Service&we%5B13%5D%5Bsc%5D%5Bns%5D=loki-prod-028&we%5B13%5D%5Bsc%5D%5Benv%5D=prod-ap-south-1&we%5B14%5D%5Bn%5D=index-gateway&we%5B14%5D%5Btp%5D=Service&we%5B14%5D%5Bsc%5D%5Bns%5D=loki-prod-028&we%5B14%5D%5Bsc%5D%5Benv%5D=prod-ap-south-1&we%5B15%5D%5Bn%5D=hggateway&we%5B15%5D%5Btp%5D=Service&we%5B15%5D%5Bsc%5D%5Bns%5D=hosted-grafana&we%5B15%5D%5Bsc%5D%5Benv%5D=prod-ap-south-1&we%5B16%5D%5Bn%5D=faro-collector&we%5B16%5D%5Btp%5D=Service&we%5B16%5D%5Bsc%5D%5Bns%5D=faro&we%5B16%5D%5Bsc%5D%5Benv%5D=prod-ap-southeast-1&we%5B17%5D%5Bn%5D=logs-gateway&we%5B17%5D%5Btp%5D=Service&we%5B17%5D%5Bsc%5D%5Bns%5D=insight-logs&we%5B17%5D%5Bsc%5D%5Benv%5D=prod-ap-south-1&we%5B18%5D%5Bn%5D=cortex-gw-internal&we%5B18%5D%5Btp%5D=Service&we%5B18%5D%5Bsc%5D%5Bns%5D=loki-prod-028&we%5B18%5D%5Bsc%5D%5Benv%5D=prod-ap-south-1&we%5B19%5D%5Bn%5D=cortex-gw-internal&we%5B19%5D%5Btp%5D=Service&we%5B19%5D%5Bsc%5D%5Bns%5D=loki-prod-014&we%5B19%5D%5Bsc%5D%5Benv%5D=prod-ap-south-0&view=BY_ENTITY&ed%5Bn%5D=querier&ed%5Btp%5D=Service&ed%5Bsc%5D%5Bns%5D=loki-prod-020&ed%5Bsc%5D%5Benv%5D=prod-ap-southeast-1&ed%5Btab%5D=metricsView&ed%5BadditionalLabels%5D%5B__grafana_origin%5D=plugin%2Fgrafana-asserts-app&ed%5BadditionalLabels%5D%5Balertname%5D=ErrorRatioBreach&ed%5BadditionalLabels%5D%5Basserts_alert_category%5D=error&ed%5BadditionalLabels%5D%5Basserts_entity_name%5D=querier&ed%5BadditionalLabels%5D%5Basserts_entity_type%5D=Service&ed%5BadditionalLabels%5D%5Basserts_env%5D=prod-ap-southeast-1&ed%5BadditionalLabels%5D%5Basserts_error_type%5D=server_errors&ed%5BadditionalLabels%5D%5Basserts_request_type%5D=inbound&ed%5BadditionalLabels%5D%5Basserts_severity%5D=critical&ed%5BadditionalLabels%5D%5Basserts_source%5D=loki_memcache&ed%5BadditionalLabels%5D%5Basserts_threshold_level%5D=automatic&ed%5BadditionalLabels%5D%5Bcontainer%5D=querier&ed%5BadditionalLabels%5D%5Bjob%5D=loki-prod-020%2Fquerier&ed%5BadditionalLabels%5D%5Bns%5D=loki-prod-020&ed%5BadditionalLabels%5D%5Bprovider%5D=aws&ed%5BadditionalLabels%5D%5Bteam%5D=asserts&ed%5BadditionalLabels%5D%5Btenant%5D=27821&ed%5BalertName%5D=ErrorRatioBreach&ed%5Bstart%5D=now-1h&ed%5Bend%5D=now&gmd-filters-prefix=loki&gmd-var-metrics-reducer-sort-by=alphabetical&from=now-1h&to=now&timezone=utc&gmd-var-ds=grafanacloud-prom&gmd-var-metrics_filters=asserts_request_type%7C%3D%7Cinbound&gmd-var-metrics_filters=asserts_env%7C%3D%7Cprod-ap-southeast-1&gmd-var-metrics_filters=namespace%7C%3D%7Cloki-prod-020&gmd-var-metrics_filters=job%7C%3D%7Cloki-prod-020%2Fquerier&gmd-var-metrics_filters=__name__%7C%21~%7Casserts.%2A__gfp__GRAFANA_ALERTS.%2A__gfp__ALERTS.%2A&gmd-var-metrics_filters=asserts_metric_error%7C%3D~%7C.%2B&gmd-var-metrics_filters=asserts_error_type%7C%3D%7Cserver_errors&gmd-var-filters=asserts_request_type%7C%3D%7Cinbound&gmd-var-filters=asserts_env%7C%3D%7Cprod-ap-southeast-1&gmd-var-filters=namespace%7C%3D%7Cloki-prod-020&gmd-var-filters=job%7C%3D%7Cloki-prod-020%2Fquerier&gmd-var-filters=__name__%7C%21~%7Casserts.%2A__gfp__GRAFANA_ALERTS.%2A__gfp__ALERTS.%2A&gmd-var-filters=asserts_metric_error%7C%3D~%7C.%2B&gmd-var-filters=asserts_error_type%7C%3D%7Cserver_errors&gmd-var-labelsWingman=%28none%29&gmd-layout=grid&gmd-filters-rule=&gmd-filters-suffix=&gmd-search_txt=&gmd-filters-recent=&gmd-var-other_metric_filters=filters-prefix,prefix%7C%3D%7Cloki)
