### PR TITLE
fix(ci): bump plugin-ci-workflows to v7.3.1

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,7 +18,7 @@ jobs:
         github.event_name == 'push' &&
         contains(github.event.head_commit.message, 'pnpm version')
       )
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.1.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.3.1
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         (github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'pnpm version')) ||
         (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
       )
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.1.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.3.1
     with:
       environment: 'prod' # publishing to 'prod' will also deploy to 'ops' and 'dev'
       attestation: true # this guarantees that the plugin was built from the source code provided in the release

--- a/.github/workflows/version-bump-changelog.yml
+++ b/.github/workflows/version-bump-changelog.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Version bump
-        uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@ci-cd-workflows/v7.1.0
+        uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@ci-cd-workflows/v7.3.1
         with:
           generate-changelog: ${{ inputs.generate-changelog }}
           version: ${{ inputs.version }}


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/metrics-drilldown/actions/runs/25170235350/job/73789701624

Bumps `grafana/plugin-ci-workflows` from `v7.1.0` to `v7.3.1` to fix a docs publish authentication failure. The generated GitHub token lacked access to clone `grafana/website`, which was resolved upstream in v7.3.0/v7.3.1.

### 📖 Summary of the changes

- Updated `plugin-ci-workflows` version from `v7.1.0` to `v7.3.1` in all three workflow files:
  - `.github/workflows/publish.yml`
  - `.github/workflows/ci-cd.yml`
  - `.github/workflows/version-bump-changelog.yml`

### 🧪 How to test?

- Merge and verify the "Publish docs" step passes in the next CI/CD run on `main`.