### PR TITLE
chore(extensions): use group type from grafana data

### DIFF
--- a/src/extensions/links.ts
+++ b/src/extensions/links.ts
@@ -15,11 +15,6 @@ import { ROUTES } from 'shared/constants/routes';
 import { parseMatcher } from './parseMatcher';
 import { processLabelMatcher, type ParsedPromQLQuery, type PromQLLabelMatcher } from '../shared/utils/utils.promql';
 
-// TODO: Remove this once @grafana/data exports the group field type (https://github.com/grafana/grafana/pull/116481)
-type PluginExtensionAddedLinkConfigWithGroup<T extends object = object> = PluginExtensionAddedLinkConfig<T> & {
-  group?: { name: string; icon: string };
-};
-
 const PRODUCT_NAME = 'Grafana Metrics Drilldown';
 const title = `Open in ${PRODUCT_NAME}`;
 const description = `Open current query in the ${PRODUCT_NAME} view`;
@@ -30,7 +25,7 @@ const ASSISTANT_TARGET_V1 = 'grafana-assistant-app/navigateToDrilldown/v1';
 
 const ADHOC_URL_DELIMITER = '|';
 
-export const linkConfigs: Array<PluginExtensionAddedLinkConfigWithGroup<PluginExtensionPanelContext>> = [
+export const linkConfigs: Array<PluginExtensionAddedLinkConfig<PluginExtensionPanelContext>> = [
   {
     title,
     description,


### PR DESCRIPTION
### ✨ Description

Resolves #1124

This PR removes the temporary local type used for plugin extension links with groups.

### 📖 Summary of the changes

- Removed the temporary `PluginExtensionAddedLinkConfigWithGroup` type from `src/extensions/links.ts`
- Updated `linkConfigs` to use `PluginExtensionAddedLinkConfig<PluginExtensionPanelContext>` directly

### 🧪 How to test?

**Passed tests:**

- `pnpm run typecheck`
- `pnpm run lint`

Happy to make changes if needed.