### PR TITLE
chore: skip attestation for forks

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,10 +7,6 @@ on:
       - main
   pull_request:
 
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
   ci-cd:
     name: GMD
@@ -29,7 +25,7 @@ jobs:
     with:
       branch: ${{ github.event_name == 'push' && github.ref_name || github.ref }}
       environment: ${{ (github.event_name == 'push' && github.ref_name == 'main') && 'dev,ops' || 'none' }}
-      attestation: true
+      attestation: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       grafana-cloud-deployment-type: provisioned
       auto-merge-environments: dev,ops
       argo-workflow-slack-channel: '#proj-metricsdrilldown-cd'


### PR DESCRIPTION
### What
​Skip attestation step in combined ci/cd file for forks. 

### Why
`actions/attest-build-provenance` needs `id-token: write`, which GitHub force-downgrades to read-only on fork PRs. That's why `Build attestation` fails on every fork PR (e.g. #1231), blocking external contributions.
Attestation produces a [SLSA Build Provenance](https://slsa.dev) bundle (Sigstore-signed digest of the plugin `.zip`) so consumers can `gh attestation verify` a published plugin. It's only meaningful for *published* artifacts — PR builds aren't published anywhere (no GCS, no catalog, no Argo). Skipping them costs nothing.
After this change, attestation still runs on push-to-main (`dev,ops` deploy) and in `publish.yml` (prod release). Every published plugin keeps its provenance. Line 32 now matches the condition already used on line 31 for `environment`.

## Verify
- This PR: `Build attestation` is skipped (not failed).
- Next push to `main`: `Build attestation` runs and posts a new entry on the [Attestations page](https://github.com/grafana/metrics-drilldown/attestations).