### PR TITLE
fix(cve): override fast-uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,8 @@
       "@grafana/i18n": "^13.0.0",
       "@grafana/schema": "^13.0.0",
       "uuid": "^14.0.0",
-      "postcss": "^8.5.10"
+      "postcss": "^8.5.10",
+      "fast-uri": "^3.1.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,7 @@ overrides:
   '@grafana/schema': ^13.0.0
   uuid: ^14.0.0
   postcss: ^8.5.10
+  fast-uri: ^3.1.2
 
 importers:
 
@@ -3447,8 +3448,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -8966,7 +8967,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10159,7 +10160,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:


### PR DESCRIPTION
**Related issue(s):**
- [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — fast-uri path traversal via percent-encoded dot segments (high)
- [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — fast-uri host confusion via percent-encoded authority delimiters (high)

Resolves both high-severity `pnpm audit` findings by overriding `fast-uri` to `>=3.1.2`.

### 📖 Summary of the changes

Added `"fast-uri": "^3.1.2"` to `pnpm.overrides` in `package.json`. This forces all transitive copies of `fast-uri` (pulled in via `copy-webpack-plugin > schema-utils > ajv`) to a patched version, resolving both CVEs. No runtime code changes.

### 🧪 How to test?

```bash
pnpm audit   # should report 0 vulnerabilities
```