### PR TITLE
chore: make tree filters GA, remove feature toggle

### DIFF
--- a/src/MetricsReducer/SideBar/SideBar.tsx
+++ b/src/MetricsReducer/SideBar/SideBar.tsx
@@ -115,6 +115,7 @@ export class SideBar extends SceneObjectBase<SideBarState> {
           ),
           icon: 'A_',
           computeGroups: computeMetricPrefixGroups,
+          hierarchical: true,
           active: Boolean(sectionValues.get('filters-prefix')?.length),
         }),
         new MetricsFilterSection({

--- a/src/MetricsReducer/SideBar/SideBar.tsx
+++ b/src/MetricsReducer/SideBar/SideBar.tsx
@@ -178,16 +178,6 @@ export class SideBar extends SceneObjectBase<SideBarState> {
       });
     }
 
-    // Enable hierarchical prefix filtering if the experiment flag is set to treatment
-    evaluateFeatureFlag('drilldown.metrics.hierarchical_prefix_filtering').then((flagValue) => {
-      if (flagValue === 'treatment') {
-        const prefixSection = this.state.sections.find((s) => s.state.key === 'filters-prefix');
-        if (prefixSection instanceof MetricsFilterSection) {
-          prefixSection.setState({ hierarchical: true });
-        }
-      }
-    });
-
     return () => {
       cleanupOtherMetricsVar();
     };

--- a/src/shared/featureFlags/openFeature.ts
+++ b/src/shared/featureFlags/openFeature.ts
@@ -26,16 +26,6 @@ const goffFeatureFlags = {
     defaultValue: 'excluded',
     trackingKey: 'experiment_default_open_sidebar',
   },
-  'drilldown.metrics.hierarchical_prefix_filtering': {
-    valueType: 'string',
-    values: [
-      'treatment', // Hierarchical prefix filtering is enabled
-      'control', // Hierarchical prefix filtering is disabled (default behavior)
-      'excluded', // The user is excluded from the experiment (default filtering behavior is used)
-    ],
-    defaultValue: 'excluded',
-    trackingKey: 'experiment_hierarchical_prefix_filtering',
-  },
   'drilldown.metrics.grafana_assistant_quick_search_tab_test': {
     valueType: 'string',
     values: [

--- a/src/shared/featureFlags/tracking.ts
+++ b/src/shared/featureFlags/tracking.ts
@@ -6,7 +6,6 @@ import type { EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeatu
 
 export const TRACKED_FLAG_VALUES: Record<FlagTrackingKey, unknown> = {
   experiment_default_open_sidebar: null,
-  experiment_hierarchical_prefix_filtering: null,
   experiment_grafana_assistant_quick_search_tab_test: null,
 };
 

--- a/src/shared/tracking/interactions.ts
+++ b/src/shared/tracking/interactions.ts
@@ -230,11 +230,6 @@ function getExperimentPayloads<E extends keyof AllEvents>(event: E): Record<stri
     Object.assign(payloads, getTrackedFlagPayload('experiment_default_open_sidebar', true));
   }
 
-  // Enrich only the metric_selected event to measure impact on metric selection behavior
-  if (event === 'metric_selected') {
-    Object.assign(payloads, getTrackedFlagPayload('experiment_hierarchical_prefix_filtering', true));
-  }
-
   // Enrich assistant events to measure impact of the assistant quick search experiment
   if (event === 'quick_search_assistant_question_asked' || event === 'quick_search_assistant_mode_entered') {
     Object.assign(payloads, getTrackedFlagPayload('experiment_grafana_assistant_quick_search_tab_test', true));


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** 
Resolves https://github.com/grafana/metrics-drilldown/issues/1221
Related https://github.com/grafana/metrics-drilldown/issues/422

Prefix filters use tree filters where users can select a prefix + one level. This feature was behind a feature toggle and rolled out to 50% of prod users.

Testing in Odin showed with 95% confidence that using tree filters (treatment) improved metric selection times compare to single prefix selection (control).

<img width="815" height="689" alt="Screenshot 2026-05-11 at 11 31 39 AM" src="https://github.com/user-attachments/assets/4305df29-1b83-454d-ae08-69153bb920f9" />

### 📖 Summary of the changes

- Remove feature toggle
- default to using tree filters in the side bar prefix filter
- remove rudderstack enrichment of the metric select event

### 🧪 How to test?

All tests pass.
Tree filters are default in the sidebar prefix filter.
