### PR TITLE
feat(sourceMetrics): per-metric `customRateInterval` override in KG source metrics component

### DIFF
--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -55,6 +55,7 @@ import { getKgSceneProps, type KgEntityHint } from 'shared/knowledgeGraph/kgAnno
 import { type KgAnnotationToggle } from 'shared/knowledgeGraph/KgAnnotationToggle';
 import { logger } from 'shared/logger/logger';
 
+import { type SourceMetrics } from '../exposedComponents/SourceMetrics/types';
 import { resetYAxisSync } from '../MetricScene/Breakdown/MetricLabelsList/behaviors/syncYAxis';
 import { MetricScene } from '../MetricScene/MetricScene';
 import { type PanelDataRequestPayload } from '../shared/GmdVizPanel/components/addToDashboard/addToDashboard';
@@ -94,6 +95,10 @@ export interface DataTrailState extends SceneObjectState {
   // Knowledge Graph annotations
   kgEntityHint?: KgEntityHint;
   kgAnnotationToggle?: KgAnnotationToggle;
+
+  // Per-metric overrides supplied by KG via the SourceMetrics exposed component.
+  // Looked up by metric name at GmdVizPanel construction sites.
+  sourceMetrics?: SourceMetrics;
 
   // Add to dashboard feature
   isAddToDashboardAvailable: boolean;

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -204,9 +204,14 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
         ? [...baseControls, new SelectNewMetricButton(), new SceneTimePicker({}), new SceneRefreshPicker({})]
         : [...baseControls, new SceneTimePicker({}), new SceneRefreshPicker({})];
 
+      // Resolve KG-supplied per-metric overrides for this metric (issue #1130).
+      const entry = metric ? this.state.sourceMetrics?.find((s) => s.metricName === metric) : undefined;
+
       this.setState({
         metric,
-        topScene: metric ? new MetricScene({ metric }) : new MetricsReducer(),
+        topScene: metric
+          ? new MetricScene({ metric, customRateInterval: entry?.customRateInterval })
+          : new MetricsReducer(),
         controls,
       });
     }

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -118,23 +118,41 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
   });
 
   protected _urlSync = new SceneObjectUrlSyncConfig(this, {
-    keys: ['metric'],
+    keys: ['metric', 'customRateInterval'],
   });
 
   getUrlState(): SceneObjectUrlValues {
+    // Emit the active metric's customRateInterval (issue #1130) so the outbound
+    // "Open in Metrics Drilldown" link carries the KG-supplied override across to standalone.
+    const entry = this.state.metric
+      ? this.state.sourceMetrics?.find((s) => s.metricName === this.state.metric)
+      : undefined;
     return {
       metric: this.state.metric,
+      customRateInterval: entry?.customRateInterval,
     };
   }
 
   updateFromUrl(values: SceneObjectUrlValues) {
     if (this.state.embedded) {
-      // In embedded mode, we want to avoid clearing a metric from the trail state
-      // when the trail has been freshly instantiated and the URL doesn't yet contain the metric.
+      // In embedded mode the React prop is authoritative; skip URL values entirely.
+      // This also preserves a freshly-instantiated metric when the URL does not yet contain it.
       return;
     }
 
-    this.updateStateForNewMetric((values.metric as string) || undefined);
+    const metric = typeof values.metric === 'string' && values.metric ? values.metric : undefined;
+    const customRateInterval =
+      typeof values.customRateInterval === 'string' && values.customRateInterval
+        ? values.customRateInterval
+        : undefined;
+
+    // Standalone hydration of the KG override (issue #1130). Synthesize a single-entry
+    // sourceMetrics array so the GmdVizPanel construction sites find the override via the
+    // same lookup path used in embedded mode.
+    const sourceMetricsOverride =
+      metric && customRateInterval ? [{ metricName: metric, labels: [], customRateInterval }] : undefined;
+
+    this.updateStateForNewMetric(metric, sourceMetricsOverride);
   }
 
   public constructor(state: Partial<DataTrailState>) {
@@ -194,7 +212,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
     this.initConfigPrometheusFunction();
   }
 
-  private updateStateForNewMetric(metric?: string) {
+  private updateStateForNewMetric(metric?: string, sourceMetricsOverride?: SourceMetrics) {
     if (!this.state.topScene || metric !== this.state.metric) {
       // Update controls based on whether a metric is selected
       const baseControls = [new VariableValueSelectors({ layout: 'vertical' }), new SceneControlsSpacer()];
@@ -205,7 +223,9 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
         : [...baseControls, new SceneTimePicker({}), new SceneRefreshPicker({})];
 
       // Resolve KG-supplied per-metric overrides for this metric (issue #1130).
-      const entry = metric ? this.state.sourceMetrics?.find((s) => s.metricName === metric) : undefined;
+      // sourceMetricsOverride lets callers (updateFromUrl in standalone) merge a new array into the same setState.
+      const effectiveSourceMetrics = sourceMetricsOverride ?? this.state.sourceMetrics;
+      const entry = metric ? effectiveSourceMetrics?.find((s) => s.metricName === metric) : undefined;
 
       this.setState({
         metric,
@@ -213,6 +233,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
           ? new MetricScene({ metric, customRateInterval: entry?.customRateInterval })
           : new MetricsReducer(),
         controls,
+        ...(sourceMetricsOverride !== undefined && { sourceMetrics: sourceMetricsOverride }),
       });
     }
   }

--- a/src/MetricScene/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
+++ b/src/MetricScene/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
@@ -31,6 +31,7 @@ import { addCardinalityInfo } from 'shared/GmdVizPanel/types/timeseries/behavior
 import { getTimeseriesQueryRunnerParams } from 'shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams';
 import { addUnspecifiedLabel } from 'shared/GmdVizPanel/types/timeseries/transformations/addUnspecifiedLabel';
 import { trailDS } from 'shared/shared';
+import { getTrailFor } from 'shared/utils/utils';
 
 import { AddToFiltersGraphAction } from './AddToFiltersGraphAction';
 import { getLabelValueFromDataFrame } from './getLabelValueFromDataFrame';
@@ -181,6 +182,7 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
 
   private buildSinglePanel() {
     const { metric, label } = this.state;
+    const entry = getTrailFor(this).state.sourceMetrics?.find((s) => s.metricName === metric.name);
 
     return new GmdVizPanel({
       metric: metric.name,
@@ -194,6 +196,7 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
       queryOptions: {
         groupBy: label,
         data: sceneGraph.getData(this),
+        customRateInterval: entry?.customRateInterval,
       },
     });
   }
@@ -201,6 +204,7 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
   private buildByFrameRepeater() {
     const { metric, label } = this.state;
     const prefMetricConfig = getPreferredConfigForMetric(metric.name);
+    const entry = getTrailFor(this).state.sourceMetrics?.find((s) => s.metricName === metric.name);
 
     return new SceneByFrameRepeater({
       // we set the syncYAxis behavior here to ensure that the EventResetSyncYAxis events that are published by SceneByFrameRepeater can be received
@@ -272,6 +276,7 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
           queryOptions: {
             ...prefMetricConfig?.queryOptions,
             labelMatchers: [{ key: label, operator: '=', value: labelValue }],
+            customRateInterval: entry?.customRateInterval,
           },
         });
 

--- a/src/MetricScene/MetricGraphScene.tsx
+++ b/src/MetricScene/MetricGraphScene.tsx
@@ -47,7 +47,13 @@ interface MetricGraphSceneState extends SceneObjectState {
 }
 
 export class MetricGraphScene extends SceneObjectBase<MetricGraphSceneState> {
-  public constructor({ metric }: { metric: MetricGraphSceneState['metric'] }) {
+  public constructor({
+    metric,
+    customRateInterval,
+  }: {
+    metric: MetricGraphSceneState['metric'];
+    customRateInterval?: string;
+  }) {
     super({
       metric,
       topView: new SceneFlexLayout({
@@ -81,6 +87,7 @@ export class MetricGraphScene extends SceneObjectBase<MetricGraphSceneState> {
               },
               queryOptions: {
                 resolution: QUERY_RESOLUTION.HIGH,
+                customRateInterval,
               },
             }),
           }),

--- a/src/MetricScene/MetricScene.tsx
+++ b/src/MetricScene/MetricScene.tsx
@@ -27,6 +27,8 @@ import { RelatedLogsScene } from './RelatedLogs/RelatedLogsScene';
 interface MetricSceneState extends SceneObjectState {
   body: MetricGraphScene;
   metric: string;
+  // KG-supplied per-metric override (issue #1130). Forwarded to MetricGraphScene and the main GmdVizPanel.
+  customRateInterval?: string;
   actionView?: ActionViewType;
   relatedLogsCount?: number;
   isQueryResultsAvailable?: boolean;
@@ -55,7 +57,7 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
   public constructor(state: MakeOptional<MetricSceneState, 'body'>) {
     super({
       $variables: state.$variables ?? getVariableSet(state.metric),
-      body: state.body ?? new MetricGraphScene({ metric: state.metric }),
+      body: state.body ?? new MetricGraphScene({ metric: state.metric, customRateInterval: state.customRateInterval }),
       ...state,
     });
 

--- a/src/MetricsReducer/MetricsGroupByList/MetricsGroupByRow.tsx
+++ b/src/MetricsReducer/MetricsGroupByList/MetricsGroupByRow.tsx
@@ -29,6 +29,7 @@ import { ConfigurePanelAction } from 'shared/GmdVizPanel/components/ConfigurePan
 import { SelectAction } from 'shared/GmdVizPanel/components/SelectAction';
 import { GmdVizPanel } from 'shared/GmdVizPanel/GmdVizPanel';
 import { VAR_FILTERS } from 'shared/shared';
+import { getTrailFor } from 'shared/utils/utils';
 
 import { GRID_TEMPLATE_COLUMNS, GRID_TEMPLATE_ROWS } from '..//MetricsList/MetricsList';
 import { InlineBanner } from '../../App/InlineBanner';
@@ -112,11 +113,13 @@ export class MetricsGroupByRow extends SceneObjectBase<MetricsGroupByRowState> {
             ),
           }),
         getLayoutChild: (option, colorIndex) => {
+          const metricName = option.value as string;
+          const entry = getTrailFor(this).state.sourceMetrics?.find((s) => s.metricName === metricName);
           return new SceneCSSGridItem({
             body: new WithUsageDataPreviewPanel({
-              metric: option.value as string,
+              metric: metricName,
               vizPanelInGridItem: new GmdVizPanel({
-                metric: option.value as string,
+                metric: metricName,
                 panelOptions: {
                   fixedColorIndex: colorIndex,
                   headerActions: ({ metric }) => [
@@ -126,6 +129,7 @@ export class MetricsGroupByRow extends SceneObjectBase<MetricsGroupByRowState> {
                 },
                 queryOptions: {
                   labelMatchers: [{ key: labelName, operator: '=', value: labelValue }],
+                  customRateInterval: entry?.customRateInterval,
                 },
               }),
             }),

--- a/src/MetricsReducer/MetricsList/MetricsList.tsx
+++ b/src/MetricsReducer/MetricsList/MetricsList.tsx
@@ -22,6 +22,7 @@ import { ShowMoreButton } from 'MetricsReducer/components/ShowMoreButton';
 import { LayoutSwitcher, LayoutType, type LayoutSwitcherState } from 'MetricsReducer/list-controls/LayoutSwitcher';
 import { SelectAction } from 'shared/GmdVizPanel/components/SelectAction';
 import { GmdVizPanel } from 'shared/GmdVizPanel/GmdVizPanel';
+import { getTrailFor } from 'shared/utils/utils';
 
 import { VIZ_PANEL_HEIGHT, WithUsageDataPreviewPanel } from './WithUsageDataPreviewPanel';
 
@@ -77,14 +78,19 @@ export class MetricsList extends SceneObjectBase<MetricsListState> {
             ),
           }),
         getLayoutChild: (option, colorIndex) => {
+          const metricName = option.value as string;
+          const entry = getTrailFor(this).state.sourceMetrics?.find((s) => s.metricName === metricName);
           return new SceneCSSGridItem({
             body: new WithUsageDataPreviewPanel({
-              metric: option.value as string,
+              metric: metricName,
               vizPanelInGridItem: new GmdVizPanel({
-                metric: option.value as string,
+                metric: metricName,
                 panelOptions: {
                   fixedColorIndex: colorIndex,
                   headerActions: ({ metric }) => [new SelectAction({ metric: metric.name, variant: 'secondary' })],
+                },
+                queryOptions: {
+                  customRateInterval: entry?.customRateInterval,
                 },
               }),
             }),

--- a/src/exposedComponents/SourceMetrics/SourceMetrics.tsx
+++ b/src/exposedComponents/SourceMetrics/SourceMetrics.tsx
@@ -13,8 +13,8 @@ import { labelMatcherToAdHocFilter } from 'shared/utils/utils.variables';
 
 import { FilterGroupByAssertsLabelsBehavior } from './behaviors/FilterGroupByAssertsLabelsBehavior';
 import { HistogramPercentilesDefaultBehavior } from './behaviors/HistogramPercentilesDefaultBehavior';
+import { type SourceMetrics } from './types';
 import { parsePromQLQuery } from '../../extensions/links';
-import { type PromQLLabelMatcher } from '../../shared/utils/utils.promql';
 import { toSceneTimeRange } from '../../shared/utils/utils.timerange';
 
 /**
@@ -96,18 +96,6 @@ function getSourceMetricsScenario(props: Pick<SourceMetricsProps, 'query' | 'sou
   return { scenario: 'missing_metric_information', sourceMetrics: undefined, fallbackQuery: undefined };
 }
 
-type SourceMetrics = Array<{
-  metricName: string;
-  labels: PromQLLabelMatcher[];
-  // KG-supplied per-metric overrides. Mirror of asserts-app-plugin's AssertionSourceMetric.
-  // Consumed in issue #1058: skips name-suffix heuristic and /api/v1/metadata fallback.
-  metricType?: 'counter' | 'gauge' | 'histogram' | 'summary';
-  // Consumed in issue #1130: replaces $__rate_interval inside rate(metric[X]).
-  customRateInterval?: string;
-  // Consumed in issue #1131: replaces default gauge aggregation (e.g. max_over_time).
-  customFunction?: string;
-}>;
-
 export interface SourceMetricsProps {
   query: string;
   initialStart: string | number;
@@ -179,6 +167,7 @@ const KnowledgeGraphSourceMetrics = (props: SourceMetricsProps) => {
     metric,
     initialDS: props.dataSource.uid,
     initialFilters,
+    sourceMetrics: props.sourceMetrics,
     $timeRange: toSceneTimeRange(props.initialStart, props.initialEnd),
     embedded: true,
     $behaviors: [new FilterGroupByAssertsLabelsBehavior({ metric }), new HistogramPercentilesDefaultBehavior()],

--- a/src/exposedComponents/SourceMetrics/SourceMetrics.tsx
+++ b/src/exposedComponents/SourceMetrics/SourceMetrics.tsx
@@ -99,6 +99,13 @@ function getSourceMetricsScenario(props: Pick<SourceMetricsProps, 'query' | 'sou
 type SourceMetrics = Array<{
   metricName: string;
   labels: PromQLLabelMatcher[];
+  // KG-supplied per-metric overrides. Mirror of asserts-app-plugin's AssertionSourceMetric.
+  // Consumed in issue #1058: skips name-suffix heuristic and /api/v1/metadata fallback.
+  metricType?: 'counter' | 'gauge' | 'histogram' | 'summary';
+  // Consumed in issue #1130: replaces $__rate_interval inside rate(metric[X]).
+  customRateInterval?: string;
+  // Consumed in issue #1131: replaces default gauge aggregation (e.g. max_over_time).
+  customFunction?: string;
 }>;
 
 export interface SourceMetricsProps {

--- a/src/exposedComponents/SourceMetrics/types.ts
+++ b/src/exposedComponents/SourceMetrics/types.ts
@@ -1,0 +1,15 @@
+import { type PromQLLabelMatcher } from '../../shared/utils/utils.promql';
+
+// KG-supplied per-metric overrides for Metrics Drilldown.
+// Mirror of asserts-app-plugin's AssertionSourceMetric.
+// Extracted to a leaf module so DataTrail can import the type without a runtime cycle through utils.trail.
+export type SourceMetrics = Array<{
+  metricName: string;
+  labels: PromQLLabelMatcher[];
+  // Consumed in issue #1058: skips name-suffix heuristic and /api/v1/metadata fallback.
+  metricType?: 'counter' | 'gauge' | 'histogram' | 'summary';
+  // Consumed in issue #1130: replaces $__rate_interval inside rate(metric[X]).
+  customRateInterval?: string;
+  // Consumed in issue #1131: replaces default gauge aggregation (e.g. max_over_time).
+  customFunction?: string;
+}>;

--- a/src/shared/GmdVizPanel/GmdVizPanel.tsx
+++ b/src/shared/GmdVizPanel/GmdVizPanel.tsx
@@ -75,6 +75,9 @@ export type QueryConfig = {
   groupBy?: string;
   queries?: QueryDefs;
   data?: SceneDataProvider;
+  // KG-supplied per-metric override (issue #1130). Replaces $__rate_interval inside rate(metric[X]).
+  // Prometheus duration string, e.g. '5m', '1h'.
+  customRateInterval?: string;
 };
 
 export type QueryOptions = {
@@ -83,6 +86,7 @@ export type QueryOptions = {
   groupBy?: string;
   queries?: QueryDefs;
   data?: QueryConfig['data'];
+  customRateInterval?: QueryConfig['customRateInterval'];
 };
 
 /* GmdVizPanelState */

--- a/src/shared/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm.tsx
+++ b/src/shared/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm.tsx
@@ -74,8 +74,10 @@ export class ConfigurePanelForm extends SceneObjectBase<ConfigurePanelFormState>
 
   private async buildBody() {
     const { metric } = this.state;
+    const trail = getTrailFor(this);
     const prefConfig = getPreferredConfigForMetric(metric.name);
-    const presets = await getConfigPresetsForMetric(metric.name, getTrailFor(this));
+    const presets = await getConfigPresetsForMetric(metric.name, trail);
+    const entry = trail.state.sourceMetrics?.find((s) => s.metricName === metric.name);
 
     // if not found in the user preferences, we use the first preset
     // it always works because the presets are organized to always have the default one as the first element (see GmdVizPanel/config/presets)
@@ -109,7 +111,11 @@ export class ConfigurePanelForm extends SceneObjectBase<ConfigurePanelFormState>
                 fixedColorIndex: colorIndex,
                 headerActions: () => [],
               },
-              queryOptions: option.queryOptions,
+              queryOptions: {
+                ...option.queryOptions,
+                // KG override wins over preset/user-pref values (issue #1130).
+                ...(entry?.customRateInterval !== undefined && { customRateInterval: entry.customRateInterval }),
+              },
             }),
           }),
         });

--- a/src/shared/GmdVizPanel/types/heatmap/__tests__/getHeatmapQueryRunnerParams.test.ts
+++ b/src/shared/GmdVizPanel/types/heatmap/__tests__/getHeatmapQueryRunnerParams.test.ts
@@ -23,4 +23,25 @@ describe('getHeatmapQueryRunnerParams(options)', () => {
       },
     ]);
   });
+
+  test('applies customRateInterval override to heatmap rate window', () => {
+    const result = getHeatmapQueryRunnerParams({
+      metric: { name: 'grafana_database_all_migrations_duration_seconds', type: 'classic-histogram' },
+      queryConfig: {
+        resolution: QUERY_RESOLUTION.MEDIUM,
+        labelMatchers: [{ key: 'success', operator: '=', value: 'true' }],
+        addIgnoreUsageFilter: true,
+        customRateInterval: '5m',
+      },
+    });
+
+    expect(result.queries).toStrictEqual([
+      {
+        refId: 'grafana_database_all_migrations_duration_seconds-heatmap',
+        expr: 'sum by (le) (rate(grafana_database_all_migrations_duration_seconds{success="true", __ignore_usage__="", ${filters:raw}}[5m]))',
+        format: 'heatmap',
+        fromExploreMetrics: true,
+      },
+    ]);
+  });
 });

--- a/src/shared/GmdVizPanel/types/heatmap/getHeatmapQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/heatmap/getHeatmapQueryRunnerParams.ts
@@ -14,7 +14,8 @@ export function getHeatmapQueryRunnerParams(options: GetQueryRunnerParamsOptions
     addExtremeValuesFiltering: queryConfig.addExtremeValuesFiltering,
   });
 
-  const query = promql.sum({ expr: promql.rate({ expr: expression }), by: ['le'] });
+  const interval = queryConfig.customRateInterval ?? '$__rate_interval';
+  const query = promql.sum({ expr: promql.rate({ expr: expression, interval }), by: ['le'] });
 
   return {
     maxDataPoints: queryConfig.resolution === QUERY_RESOLUTION.HIGH ? 500 : 250,

--- a/src/shared/GmdVizPanel/types/percentiles/__tests__/getPercentilesQueryRunnerParams.test.ts
+++ b/src/shared/GmdVizPanel/types/percentiles/__tests__/getPercentilesQueryRunnerParams.test.ts
@@ -142,4 +142,70 @@ describe('getPercentilesQueryRunnerParams(options)', () => {
       },
     ]);
   });
+
+  test('applies customRateInterval override to counter quantile queries', () => {
+    const result = getPercentilesQueryRunnerParams({
+      metric: { name: 'go_gc_heap_frees_bytes_total', type: 'counter' },
+      queryConfig: {
+        resolution: QUERY_RESOLUTION.MEDIUM,
+        labelMatchers: [{ key: 'job', operator: '!=', value: 'prometheus' }],
+        addIgnoreUsageFilter: true,
+        queries: [{ fn: 'quantile', params: { percentiles: [99] } }],
+        customRateInterval: '5m',
+      },
+    });
+
+    expect(result.queries).toStrictEqual([
+      {
+        refId: 'go_gc_heap_frees_bytes_total-p99-quantile(rate)',
+        expr: 'quantile(0.99, rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters:raw}}[5m]))',
+        legendFormat: '99th Percentile',
+        fromExploreMetrics: true,
+      },
+    ]);
+  });
+
+  test('applies customRateInterval override to native histogram quantile queries', () => {
+    const result = getPercentilesQueryRunnerParams({
+      metric: { name: 'grafana_database_all_migrations_duration_seconds', type: 'native-histogram' },
+      queryConfig: {
+        resolution: QUERY_RESOLUTION.MEDIUM,
+        labelMatchers: [{ key: 'success', operator: '=', value: 'true' }],
+        addIgnoreUsageFilter: true,
+        queries: [{ fn: 'histogram_quantile', params: { percentiles: [50] } }],
+        customRateInterval: '1h',
+      },
+    });
+
+    expect(result.queries).toStrictEqual([
+      {
+        refId: 'grafana_database_all_migrations_duration_seconds-p50-histogram_quantile',
+        expr: 'histogram_quantile(0.5,sum(rate(grafana_database_all_migrations_duration_seconds{success="true", __ignore_usage__="", ${filters:raw}}[1h])))',
+        legendFormat: '50th Percentile',
+        fromExploreMetrics: true,
+      },
+    ]);
+  });
+
+  test('applies customRateInterval override to classic histogram quantile queries', () => {
+    const result = getPercentilesQueryRunnerParams({
+      metric: { name: 'go_gc_heap_allocs_by_size_bytes_bucket', type: 'classic-histogram' },
+      queryConfig: {
+        resolution: QUERY_RESOLUTION.HIGH,
+        labelMatchers: [{ key: 'success', operator: '=', value: 'true' }],
+        addIgnoreUsageFilter: true,
+        queries: [{ fn: 'histogram_quantile', params: { percentiles: [75] } }],
+        customRateInterval: '5m',
+      },
+    });
+
+    expect(result.queries).toStrictEqual([
+      {
+        refId: 'go_gc_heap_allocs_by_size_bytes_bucket-p75-histogram_quantile',
+        expr: 'histogram_quantile(0.75,sum by (le) (rate(go_gc_heap_allocs_by_size_bytes_bucket{success="true", __ignore_usage__="", ${filters:raw}}[5m])))',
+        legendFormat: '75th Percentile',
+        fromExploreMetrics: true,
+      },
+    ]);
+  });
 });

--- a/src/shared/GmdVizPanel/types/percentiles/getPercentilesQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/percentiles/getPercentilesQueryRunnerParams.ts
@@ -49,10 +49,11 @@ function buildHistogramQueries({
 
   const queries: SceneDataQuery[] = [];
 
+  const interval = queryConfig.customRateInterval ?? '$__rate_interval';
   const newExpr =
     metric.type === 'native-histogram'
-      ? promql.sum({ expr: promql.rate({ expr }) })
-      : promql.sum({ expr: promql.rate({ expr }), by: ['le'] });
+      ? promql.sum({ expr: promql.rate({ expr, interval }) })
+      : promql.sum({ expr: promql.rate({ expr, interval }), by: ['le'] });
 
   for (const { fn, params } of queryDefs) {
     const entry = PROMQL_FUNCTIONS.get(fn);
@@ -94,7 +95,8 @@ function buildNonHistogramQueries({
     : [{ fn: 'quantile', params: { percentiles: [99, 90, 50] } }];
 
   const queries: SceneDataQuery[] = [];
-  const newExpr = isRateQuery ? promql.rate({ expr }) : expr;
+  const interval = queryConfig.customRateInterval ?? '$__rate_interval';
+  const newExpr = isRateQuery ? promql.rate({ expr, interval }) : expr;
 
   for (const { fn, params } of queryDefs) {
     const entry = PROMQL_FUNCTIONS.get(fn);

--- a/src/shared/GmdVizPanel/types/stat/__tests__/getStatQueryRunnerParams.test.ts
+++ b/src/shared/GmdVizPanel/types/stat/__tests__/getStatQueryRunnerParams.test.ts
@@ -67,4 +67,26 @@ describe('getStatQueryRunnerParams(options)', () => {
       },
     ]);
   });
+
+  test('applies customRateInterval override to counter rate window', () => {
+    const result = getStatQueryRunnerParams({
+      metric: { name: 'go_gc_heap_frees_bytes_total', type: 'counter' },
+      queryConfig: {
+        resolution: QUERY_RESOLUTION.MEDIUM,
+        labelMatchers: [{ key: 'job', operator: '!=', value: 'prometheus' }],
+        addIgnoreUsageFilter: true,
+        queries: [],
+        customRateInterval: '5m',
+      },
+    });
+
+    expect(result.queries).toStrictEqual([
+      {
+        refId: 'go_gc_heap_frees_bytes_total-sum(rate)',
+        expr: 'sum(rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters:raw}}[5m]))',
+        legendFormat: 'sum(rate)',
+        fromExploreMetrics: true,
+      },
+    ]);
+  });
 });

--- a/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
@@ -20,7 +20,8 @@ export function getStatQueryRunnerParams(options: GetQueryRunnerParamsOptions): 
     addExtremeValuesFiltering: queryConfig.addExtremeValuesFiltering,
   });
 
-  const expr = isRateQuery ? promql.rate({ expr: expression, interval: '$__rate_interval' }) : expression;
+  const interval = queryConfig.customRateInterval ?? '$__rate_interval';
+  const expr = isRateQuery ? promql.rate({ expr: expression, interval }) : expression;
 
   return {
     isRateQuery,

--- a/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
@@ -66,6 +66,41 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
         },
       ]);
     });
+
+    test('applies customRateInterval override to counter rate window', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'go_gc_heap_frees_bytes_total', type: 'counter' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [{ key: 'job', operator: '!=', value: 'prometheus' }],
+          addIgnoreUsageFilter: true,
+          customRateInterval: '5m',
+        },
+      });
+
+      expect(result.queries).toStrictEqual([
+        {
+          refId: 'go_gc_heap_frees_bytes_total-sum(rate)',
+          expr: 'sum(rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters:raw}}[5m]))',
+          legendFormat: 'sum(rate)',
+          fromExploreMetrics: true,
+        },
+      ]);
+    });
+
+    test('ignores customRateInterval for gauge metrics (no rate wrap)', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'go_goroutines', type: 'gauge' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [],
+          addIgnoreUsageFilter: true,
+          customRateInterval: '5m',
+        },
+      });
+
+      expect(result.queries[0].expr).toBe('avg(go_goroutines{__ignore_usage__="", ${filters:raw}})');
+    });
   });
 
   describe('with group by label', () => {
@@ -109,6 +144,28 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
         {
           refId: 'go_gc_heap_frees_bytes_total-by-instance',
           expr: 'sum by (instance) (rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters:raw}}[$__rate_interval]))',
+          legendFormat: '{{instance}}',
+          fromExploreMetrics: true,
+        },
+      ]);
+    });
+
+    test('applies customRateInterval override to grouped counter rate window', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'go_gc_heap_frees_bytes_total', type: 'counter' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [{ key: 'job', operator: '!=', value: 'prometheus' }],
+          addIgnoreUsageFilter: true,
+          groupBy: 'instance',
+          customRateInterval: '1h',
+        },
+      });
+
+      expect(result.queries).toStrictEqual([
+        {
+          refId: 'go_gc_heap_frees_bytes_total-by-instance',
+          expr: 'sum by (instance) (rate(go_gc_heap_frees_bytes_total{job!="prometheus", __ignore_usage__="", ${filters:raw}}[1h]))',
           legendFormat: '{{instance}}',
           fromExploreMetrics: true,
         },

--- a/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
@@ -21,7 +21,8 @@ export function getTimeseriesQueryRunnerParams(options: GetQueryRunnerParamsOpti
   });
 
   const isRateQuery = metric.type === 'counter';
-  const expr = isRateQuery ? promql.rate({ expr: expression, interval: '$__rate_interval' }) : expression;
+  const interval = queryConfig.customRateInterval ?? '$__rate_interval';
+  const expr = isRateQuery ? promql.rate({ expr: expression, interval }) : expression;
 
   return {
     isRateQuery,


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/metrics-drilldown/issues/1130
Resolves #1130

[KG companion PR](https://github.com/grafana/asserts-app-plugin/pull/3278)

Allow KG to override `$__rate_interval` per source metric so insights derived from recording rules query at the rule's evaluation window (5m, 1h) instead of Grafana's panel-resolution-driven interval. The override flows from KG via the existing `<SourceMetrics />` exposed component and survives the embedded-to-standalone handoff via URL sync.

### 📖 Summary of the changes

- `SourceMetrics` entry type extended with three optional fields (`metricType`, `customRateInterval`, `customFunction`). Mirrors the asserts-app `AssertionSourceMetric` extension. Only `customRateInterval` is consumed in this PR; the other two are declared-only and land in their own follow-ups (#1058, #1131).
- Type extracted to `exposedComponents/SourceMetrics/types.ts` to break a `DataTrail` <-> `SourceMetrics` import cycle.
- `DataTrailState.sourceMetrics` holds the array. `SourceMetrics.tsx` passes the KG prop into `newMetricsTrail`.
- Six `GmdVizPanel` construction sites look up the active metric's entry by name and forward `customRateInterval` into `queryOptions`: `MetricGraphScene` (via a new constructor arg threaded through `MetricScene`), `MetricLabelValuesList` (single panel + per-frame Breakdown), `MetricsList`, `MetricsGroupByRow`, `ConfigurePanelForm`.
- `QueryConfig` gains `customRateInterval`. Four query builders read it with fallback to `$__rate_interval`: timeseries, stat, percentiles (histogram + non-histogram paths), heatmap.
- `DataTrail._urlSync` adds `customRateInterval`. `getUrlState` derives the value from the active metric's entry so the outbound `Open in Metrics Drilldown` link carries it. `updateFromUrl` in standalone synthesizes a single-entry `sourceMetrics` array so the same lookup path handles deep links and shared URLs. Embedded mode skips URL hydration; the React prop is authoritative.
- Per-builder tests added for the override-set case. Existing test snapshots unchanged because the absent-override path produces byte-identical PromQL.

### 🧪 How to test?

1. Pair with the asserts-app-plugin branch that extends `AssertionSourceMetric` ([linked here](https://github.com/grafana/asserts-app-plugin/pull/3278)).

Add this to KG EntityDetails.container.tsx

```
  // Temporary end-to-end smoke for metrics-drilldown issue #1130: force a 5m
  // customRateInterval on every KG source metric. useMemo keeps the array reference
  // stable so React.memo on EmbeddedMetricsDrilldown is not invalidated each render.
  const sourceMetricsWithOverride = useMemo(
    () => sourceMetrics?.map((s) => ({ ...s, customRateInterval: '5m' })),
    [sourceMetrics]
  );

...

                 {metricsQuery && (
                    <EmbeddedMetricsDrilldown
                      query={metricsQuery}
                      dataSource={metricsDataSource}
                      initialStart={drawerStart}
                      initialEnd={drawerEnd}
                      onTimeRangeChange={handleTimeRangeChange}
                      sourceMetrics={sourceMetricsWithOverride}
                      isLoadingSourceMetrics={isLoadingSourceMetrics}
                    />
                  )} 
```

2. In RCA Workbench, open a metric-bearing insight (e.g. `LatencyP99ErrorBuildup`).
3. In the embedded panel, inspect the rendered query (panel menu, Inspect, Query). Confirm `rate(metric[5m])` instead of `rate(metric[$__rate_interval])`.
4. Check the host URL contains `gmd-customRateInterval=5m`.
5. Click the `Metrics Drilldown` button. Standalone URL should contain `customRateInterval=5m` (no `gmd-` prefix). Standalone panel renders with `[5m]`.
6. Navigate to a different metric in `MetricsReducer` (multi-metric scenario) and confirm the URL drops the override when no entry matches, then restores it on back-navigation.
7. `yarn test` for the four updated query-builder suites and `DataTrail.test.tsx`.**


