### PR TITLE
build(pnpm): upgrade from v10 to v11

### DIFF
--- a/.github/workflows/bundle-stats-create.yml
+++ b/.github/workflows/bundle-stats-create.yml
@@ -28,7 +28,7 @@ jobs:
           echo "version=$NODE_VERSION" >> $GITHUB_OUTPUT
 
       - name: Install pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js environment
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -17,7 +17,7 @@ jobs:
           NODE_VERSION=$(node -p "require('./package.json').engines.node.replace('>=', '')")
           echo "version=$NODE_VERSION" >> $GITHUB_OUTPUT
       - name: Install pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node.js environment
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "i18n-extract": "i18next-cli extract -c i18next.config.ts",
     "i18n-extract-check": "i18next-cli extract -c i18next.config.ts --ci"
   },
-  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
+  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
   "engines": {
     "node": ">=22"
   },
@@ -129,34 +129,5 @@
   },
   "peerDependencies": {
     "lodash": "^4.18.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "@remix-run/router": "^1.23.2",
-      "react-router": "^6.30.2",
-      "dompurify": "^3.4.0",
-      "lodash": "^4.18.0",
-      "minimatch@^3": "~3.1.4",
-      "minimatch@^9": "~10.2.0",
-      "minimatch@^10": "^10.2.3",
-      "serialize-javascript": "^7.0.5",
-      "immutable": "^5.1.5",
-      "flatted": "^3.4.0",
-      "undici": "^7.24.0",
-      "picomatch@^2": "~4.0.0",
-      "picomatch@^4": "^4.0.4",
-      "protobufjs@^7": "^7.5.6",
-      "protobufjs@^8": "^8.0.2",
-      "protocol-buffers-schema": "^3.6.1",
-      "brace-expansion@^1": "^5.0.0",
-      "brace-expansion@^5": "^5.0.5",
-      "yaml": "^2.8.3",
-      "@grafana/data": "^13.0.0",
-      "@grafana/i18n": "^13.0.0",
-      "@grafana/schema": "^13.0.0",
-      "uuid": "^14.0.0",
-      "postcss": "^8.5.10",
-      "fast-uri": "^3.1.2"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "i18n-extract": "i18next-cli extract -c i18next.config.ts",
     "i18n-extract-check": "i18next-cli extract -c i18next.config.ts --ci"
   },
-  "packageManager": "pnpm@11.2.2+sha512.36e6621fad506178936455e70247b8808ef4ec25797a9f437a93281a020484e2607f6a469a22e982987c3dbb8866e3071514ab10a4a1749e06edcd1ec118436f",
+  "packageManager": "pnpm@11.3.0+sha512.2c403d6594527287672b1f7056343a1f7c3634036a67ffabfcc2b3d7595d843768f8787148d1b57cf7956c90606bbd192857c363af19e96d2d0ec9ec5741d215",
   "engines": {
     "node": ">=22"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "i18n-extract": "i18next-cli extract -c i18next.config.ts",
     "i18n-extract-check": "i18next-cli extract -c i18next.config.ts --ci"
   },
-  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
+  "packageManager": "pnpm@11.2.2+sha512.36e6621fad506178936455e70247b8808ef4ec25797a9f437a93281a020484e2607f6a469a22e982987c3dbb8866e3071514ab10a4a1749e06edcd1ec118436f",
   "engines": {
     "node": ">=22"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,12 +1,37 @@
 packages:
   - '.'
 
-ignoredBuiltDependencies:
-  - core-js
+allowBuilds:
+  core-js: false
+  '@parcel/watcher': true
+  '@swc/core': true
+  esbuild: true
+  protobufjs: true
+  unrs-resolver: true
 
-onlyBuiltDependencies:
-  - '@parcel/watcher'
-  - '@swc/core'
-  - esbuild
-  - protobufjs
-  - unrs-resolver
+overrides:
+  '@remix-run/router': ^1.23.2
+  react-router: ^6.30.2
+  dompurify: ^3.4.0
+  lodash: ^4.18.0
+  minimatch@^3: ~3.1.4
+  minimatch@^9: ~10.2.0
+  minimatch@^10: ^10.2.3
+  serialize-javascript: ^7.0.5
+  immutable: ^5.1.5
+  flatted: ^3.4.0
+  undici: ^7.24.0
+  picomatch@^2: ~4.0.0
+  picomatch@^4: ^4.0.4
+  protobufjs@^7: ^7.5.6
+  protobufjs@^8: ^8.0.2
+  protocol-buffers-schema: ^3.6.1
+  brace-expansion@^1: ^5.0.0
+  brace-expansion@^5: ^5.0.5
+  yaml: ^2.8.3
+  '@grafana/data': ^13.0.0
+  '@grafana/i18n': ^13.0.0
+  '@grafana/schema': ^13.0.0
+  uuid: ^14.0.0
+  postcss: ^8.5.10
+  fast-uri: ^3.1.2


### PR DESCRIPTION
### ✨ Description

Upgrade pnpm from v10.33.2 to v11.1.3.

pnpm 11 is a major version with a redesigned configuration system. The `pnpm` key in `package.json` is silently ignored in v11, so overrides and build dependency settings must be migrated to `pnpm-workspace.yaml`. The `pnpm/action-setup` GitHub Action also needs v6 for pnpm 11 support.

### 📖 Summary of the changes

- **`package.json`**: Removed the `pnpm` key (overrides block), bumped `packageManager` to `pnpm@11.1.3`
- **`pnpm-workspace.yaml`**: Added `overrides` block (moved from `package.json`), replaced `ignoredBuiltDependencies`/`onlyBuiltDependencies` with the new `allowBuilds` map
- **`.github/workflows/bundle-stats-create.yml`**, **`.github/workflows/is-compatible.yml`**: Bumped `pnpm/action-setup` from v5 to v6.0.8 (v5 does not support pnpm 11)

Notable new pnpm 11 defaults to be aware of:
- `minimumReleaseAge: 1440` — newly-published packages are quarantined for 24h before resolution
- `strictDepBuilds: true` — build scripts blocked unless explicitly allowed via `allowBuilds`
- `verifyDepsBeforeRun: install` — auto-runs install if deps are stale before script execution

### 🧪 How to test?

- `pnpm install`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`
- Verify security overrides are applied: `pnpm why protobufjs`, `pnpm why dompurify`, `pnpm why postcss`, `pnpm why serialize-javascript` - all resolve to at least the override floor versions
- **Note:** The shared CI workflow (`grafana/plugin-ci-workflows@v7.3.1`) uses `pnpm/action-setup` internally and the PR to update that to v6 is [here](https://github.com/grafana/plugin-ci-workflows/pull/738). The main CI job will fail until that has been updated.