### PR TITLE
feat(sorter): add fetchFiringAlertMetrics data layer for firing alert rules

### DIFF
--- a/e2e/tests/metrics-reducer/firing-alert-metrics.spec.ts
+++ b/e2e/tests/metrics-reducer/firing-alert-metrics.spec.ts
@@ -1,3 +1,4 @@
+import { GRAFANA_RULER_RULES_URL } from '../../../src/MetricsReducer/list-controls/MetricsSorter/fetchers/shared';
 import { expect, test } from '../../fixtures';
 
 test.describe('Firing alert metrics - Ruler API integration', () => {
@@ -7,7 +8,7 @@ test.describe('Firing alert metrics - Ruler API integration', () => {
 
   test('Ruler endpoint returns a successful response with provisioned alert rules', async ({ page }) => {
     const response = await page.request.get(
-      '/api/prometheus/grafana/api/v1/rules?limit_alerts=0'
+      `${GRAFANA_RULER_RULES_URL}?limit_alerts=0`
     );
 
     expect(response.ok()).toBe(true);
@@ -37,7 +38,7 @@ test.describe('Firing alert metrics - Ruler API integration', () => {
 
   test('Ruler endpoint with state=firing filter returns empty groups when no alerts are firing', async ({ page }) => {
     const response = await page.request.get(
-      '/api/prometheus/grafana/api/v1/rules?state=firing&limit_alerts=0'
+      `${GRAFANA_RULER_RULES_URL}?state=firing&limit_alerts=0`
     );
 
     expect(response.ok()).toBe(true);

--- a/e2e/tests/metrics-reducer/firing-alert-metrics.spec.ts
+++ b/e2e/tests/metrics-reducer/firing-alert-metrics.spec.ts
@@ -22,7 +22,11 @@ test.describe('Firing alert metrics - Ruler API integration', () => {
     const group = body.data.groups.find(
       (g: { name: string }) => g.name === 'test-evaluation-group-00'
     );
-    expect(group).toBeDefined();
+
+    if (!group) {
+      throw new Error('Expected group "test-evaluation-group-00" not found in ruler response');
+    }
+
     expect(group.rules.length).toBe(2);
 
     const ruleNames = group.rules.map((r: { name: string }) => r.name);

--- a/e2e/tests/metrics-reducer/firing-alert-metrics.spec.ts
+++ b/e2e/tests/metrics-reducer/firing-alert-metrics.spec.ts
@@ -47,6 +47,13 @@ test.describe('Firing alert metrics - Ruler API integration', () => {
 
     expect(body.status).toBe('success');
     expect(Array.isArray(body.data.groups)).toBe(true);
-    expect(body.data.groups).toHaveLength(0);
+
+    // Older Grafana versions (≤12.0.x) return group shells with empty rules arrays
+    // instead of omitting groups entirely, so assert no rules rather than no groups
+    const totalRules = body.data.groups.reduce(
+      (sum: number, g: { rules: unknown[] }) => sum + g.rules.length,
+      0
+    );
+    expect(totalRules).toBe(0);
   });
 });

--- a/e2e/tests/metrics-reducer/firing-alert-metrics.spec.ts
+++ b/e2e/tests/metrics-reducer/firing-alert-metrics.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '../../fixtures';
+
+test.describe('Firing alert metrics - Ruler API integration', () => {
+  test.beforeEach(async ({ metricsReducerView }) => {
+    await metricsReducerView.goto();
+  });
+
+  test('Ruler endpoint returns a successful response with provisioned alert rules', async ({ page }) => {
+    const response = await page.request.get(
+      '/api/prometheus/grafana/api/v1/rules?limit_alerts=0'
+    );
+
+    expect(response.ok()).toBe(true);
+
+    const body = await response.json();
+
+    expect(body.status).toBe('success');
+    expect(Array.isArray(body.data.groups)).toBe(true);
+    expect(body.data.groups.length).toBeGreaterThan(0);
+
+    const group = body.data.groups.find(
+      (g: { name: string }) => g.name === 'test-evaluation-group-00'
+    );
+    expect(group).toBeDefined();
+    expect(group.rules.length).toBe(2);
+
+    const ruleNames = group.rules.map((r: { name: string }) => r.name);
+    expect(ruleNames).toContain('test-rule-00');
+    expect(ruleNames).toContain('test-rule-01');
+
+    for (const rule of group.rules) {
+      expect(rule.type).toBe('alerting');
+      expect(typeof rule.query).toBe('string');
+      expect(rule.query.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('Ruler endpoint with state=firing filter returns empty groups when no alerts are firing', async ({ page }) => {
+    const response = await page.request.get(
+      '/api/prometheus/grafana/api/v1/rules?state=firing&limit_alerts=0'
+    );
+
+    expect(response.ok()).toBe(true);
+
+    const body = await response.json();
+
+    expect(body.status).toBe('success');
+    expect(Array.isArray(body.data.groups)).toBe(true);
+    expect(body.data.groups).toHaveLength(0);
+  });
+});

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchFiringAlertMetrics.test.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchFiringAlertMetrics.test.ts
@@ -1,0 +1,239 @@
+import { getBackendSrv } from '@grafana/runtime';
+
+import { logger } from 'shared/logger/logger';
+
+import { fetchFiringAlertMetrics } from '../fetchFiringAlertMetrics';
+
+jest.mock('@grafana/runtime');
+jest.mock('shared/logger/logger');
+
+function setup() {
+  const get = jest.fn() as jest.Mock;
+  (getBackendSrv as jest.Mock).mockImplementation(() => ({ get }));
+  return { get };
+}
+
+function buildRulerResponse(groups: Array<{ name: string; rules: Array<Record<string, unknown>> }>) {
+  return {
+    status: 'success',
+    data: {
+      groups: groups.map((g) => ({
+        name: g.name,
+        file: 'test.yaml',
+        rules: g.rules,
+        interval: 60,
+      })),
+    },
+  };
+}
+
+function alertingRule(name: string, query: string) {
+  return { type: 'alerting', name, query, state: 'firing', health: 'ok', alerts: [], labels: {}, annotations: {} };
+}
+
+function recordingRule(name: string, query: string) {
+  return { type: 'recording', name, query, health: 'ok' };
+}
+
+describe('fetchFiringAlertMetrics()', () => {
+  test('calls the correct endpoint with state=firing and limit_alerts=0', async () => {
+    const { get } = setup();
+    get.mockResolvedValueOnce(buildRulerResponse([]));
+
+    await fetchFiringAlertMetrics();
+
+    expect(get).toHaveBeenCalledWith(
+      '/api/prometheus/grafana/api/v1/rules',
+      { state: 'firing', limit_alerts: 0 },
+      'grafana-metricsdrilldown-app-firing-alert-metric-usage',
+      expect.any(Object)
+    );
+  });
+
+  describe('happy path', () => {
+    test('returns metric counts from firing alerting rules across groups', async () => {
+      const { get } = setup();
+
+      get.mockResolvedValueOnce(
+        buildRulerResponse([
+          {
+            name: 'group-1',
+            rules: [alertingRule('HighLatency', 'rate(http_requests_total[5m]) > 100')],
+          },
+          {
+            name: 'group-2',
+            rules: [alertingRule('HighErrors', 'sum(rate(http_errors_total[5m])) > 10')],
+          },
+        ])
+      );
+
+      const result = await fetchFiringAlertMetrics();
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.get('http_requests_total')).toBe(1);
+      expect(result.get('http_errors_total')).toBe(1);
+    });
+
+    test('sums counts when the same metric is referenced by multiple firing rules', async () => {
+      const { get } = setup();
+
+      get.mockResolvedValueOnce(
+        buildRulerResponse([
+          {
+            name: 'group-1',
+            rules: [
+              alertingRule('HighLatency', 'rate(http_requests_total[5m]) > 100'),
+              alertingRule('LowThroughput', 'rate(http_requests_total[5m]) < 1'),
+            ],
+          },
+        ])
+      );
+
+      const result = await fetchFiringAlertMetrics();
+
+      expect(result.get('http_requests_total')).toBe(2);
+    });
+
+    test('extracts multiple metrics from a single PromQL expression', async () => {
+      const { get } = setup();
+
+      get.mockResolvedValueOnce(
+        buildRulerResponse([
+          {
+            name: 'group-1',
+            rules: [alertingRule('ErrorRatio', 'rate(http_errors_total[5m]) / rate(http_requests_total[5m]) > 0.5')],
+          },
+        ])
+      );
+
+      const result = await fetchFiringAlertMetrics();
+
+      expect(result.get('http_errors_total')).toBe(1);
+      expect(result.get('http_requests_total')).toBe(1);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('returns empty Map when API returns empty groups array', async () => {
+      const { get } = setup();
+      get.mockResolvedValueOnce(buildRulerResponse([]));
+
+      const result = await fetchFiringAlertMetrics();
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    test('excludes recording rules from the output', async () => {
+      const { get } = setup();
+
+      get.mockResolvedValueOnce(
+        buildRulerResponse([
+          {
+            name: 'mixed-group',
+            rules: [
+              alertingRule('HighLatency', 'rate(http_requests_total[5m]) > 100'),
+              recordingRule('job:http_requests:rate5m', 'sum(rate(http_requests_total[5m])) by (job)'),
+            ],
+          },
+        ])
+      );
+
+      const result = await fetchFiringAlertMetrics();
+
+      expect(result.size).toBe(1);
+      expect(result.get('http_requests_total')).toBe(1);
+    });
+
+    test('skips rules with empty query strings', async () => {
+      const { get } = setup();
+
+      get.mockResolvedValueOnce(
+        buildRulerResponse([
+          {
+            name: 'group-1',
+            rules: [
+              alertingRule('EmptyQuery', ''),
+              alertingRule('ValidRule', 'up == 0'),
+            ],
+          },
+        ])
+      );
+
+      const result = await fetchFiringAlertMetrics();
+
+      expect(result.size).toBe(1);
+      expect(result.get('up')).toBe(1);
+    });
+
+    test('skips rules with unparseable PromQL and logs a warning', async () => {
+      const { get } = setup();
+
+      get.mockResolvedValueOnce(
+        buildRulerResponse([
+          {
+            name: 'group-1',
+            rules: [
+              alertingRule('BadQuery', '{{{invalid promql'),
+              alertingRule('GoodQuery', 'node_cpu_seconds_total > 0.9'),
+            ],
+          },
+        ])
+      );
+
+      const result = await fetchFiringAlertMetrics();
+
+      // The valid rule should still be processed
+      expect(result.get('node_cpu_seconds_total')).toBe(1);
+    });
+
+    test('handles response with missing data.groups gracefully', async () => {
+      const { get } = setup();
+      get.mockResolvedValueOnce({ status: 'success', data: {} });
+
+      const result = await fetchFiringAlertMetrics();
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    test('handles group with missing rules array gracefully', async () => {
+      const { get } = setup();
+      get.mockResolvedValueOnce({
+        status: 'success',
+        data: {
+          groups: [{ name: 'bad-group', file: 'test.yaml' }],
+        },
+      });
+
+      const result = await fetchFiringAlertMetrics();
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+  });
+
+  describe('error handling', () => {
+    test('returns empty Map and logs error when API call fails', async () => {
+      const { get } = setup();
+      get.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await fetchFiringAlertMetrics();
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+      expect(logger.error).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ message: expect.any(String) }));
+    });
+
+    test('handles string error from API', async () => {
+      const { get } = setup();
+      get.mockRejectedValueOnce('Unauthorized');
+
+      const result = await fetchFiringAlertMetrics();
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+      expect(logger.error).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ message: expect.any(String) }));
+    });
+  });
+});

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchFiringAlertMetrics.test.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchFiringAlertMetrics.test.ts
@@ -2,6 +2,7 @@ import { getBackendSrv } from '@grafana/runtime';
 
 import { logger } from 'shared/logger/logger';
 
+import { GRAFANA_RULER_RULES_URL } from '../shared';
 import { fetchFiringAlertMetrics } from '../fetchFiringAlertMetrics';
 
 jest.mock('@grafana/runtime');
@@ -43,7 +44,7 @@ describe('fetchFiringAlertMetrics()', () => {
     await fetchFiringAlertMetrics();
 
     expect(get).toHaveBeenCalledWith(
-      '/api/prometheus/grafana/api/v1/rules',
+      GRAFANA_RULER_RULES_URL,
       { state: 'firing', limit_alerts: 0 },
       'grafana-metricsdrilldown-app-firing-alert-metric-usage',
       expect.any(Object)

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchFiringAlertMetrics.test.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchFiringAlertMetrics.test.ts
@@ -7,6 +7,17 @@ import { GRAFANA_RULER_RULES_URL } from '../shared';
 
 jest.mock('@grafana/runtime');
 jest.mock('shared/logger/logger');
+jest.mock('../../../../../shared/utils/utils.promql', () => ({
+  extractMetricNames: jest.fn(),
+}));
+
+const { extractMetricNames: realExtractMetricNames } = jest.requireActual(
+  '../../../../../shared/utils/utils.promql'
+) as { extractMetricNames: (...args: unknown[]) => string[] };
+
+const { extractMetricNames: mockExtractMetricNames } = jest.requireMock<{ extractMetricNames: jest.Mock }>(
+  '../../../../../shared/utils/utils.promql'
+);
 
 function setup() {
   const get = jest.fn() as jest.Mock;
@@ -37,6 +48,10 @@ function recordingRule(name: string, query: string) {
 }
 
 describe('fetchFiringAlertMetrics()', () => {
+  beforeEach(() => {
+    mockExtractMetricNames.mockImplementation(realExtractMetricNames);
+  });
+
   test('calls the correct endpoint with state=firing and limit_alerts=0', async () => {
     const { get } = setup();
     get.mockResolvedValueOnce(buildRulerResponse([]));
@@ -164,7 +179,7 @@ describe('fetchFiringAlertMetrics()', () => {
       expect(result.get('up')).toBe(1);
     });
 
-    test('skips rules with unparseable PromQL and logs a warning', async () => {
+    test('returns zero metrics for malformed PromQL that yields no identifiers', async () => {
       const { get } = setup();
 
       get.mockResolvedValueOnce(
@@ -181,7 +196,39 @@ describe('fetchFiringAlertMetrics()', () => {
 
       const result = await fetchFiringAlertMetrics();
 
-      // The valid rule should still be processed
+      // The lezer PromQL parser is tolerant — malformed input returns [] rather than throwing.
+      // The valid rule should still be processed.
+      expect(result.size).toBe(1);
+      expect(result.get('node_cpu_seconds_total')).toBe(1);
+    });
+
+    test('logs a warning and continues processing when metric extraction throws', async () => {
+      const { get } = setup();
+      mockExtractMetricNames
+        .mockImplementationOnce(() => {
+          throw new TypeError('unexpected failure');
+        })
+        .mockImplementationOnce(() => ['node_cpu_seconds_total']);
+
+      get.mockResolvedValueOnce(
+        buildRulerResponse([
+          {
+            name: 'group-1',
+            rules: [
+              alertingRule('FailRule', 'some_expr > 1'),
+              alertingRule('GoodRule', 'node_cpu_seconds_total > 0.9'),
+            ],
+          },
+        ])
+      );
+
+      const result = await fetchFiringAlertMetrics();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.any(TypeError),
+        expect.objectContaining({ message: expect.stringContaining('FailRule') })
+      );
+      expect(result.size).toBe(1);
       expect(result.get('node_cpu_seconds_total')).toBe(1);
     });
 

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchFiringAlertMetrics.test.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchFiringAlertMetrics.test.ts
@@ -2,8 +2,8 @@ import { getBackendSrv } from '@grafana/runtime';
 
 import { logger } from 'shared/logger/logger';
 
-import { GRAFANA_RULER_RULES_URL } from '../shared';
 import { fetchFiringAlertMetrics } from '../fetchFiringAlertMetrics';
+import { GRAFANA_RULER_RULES_URL } from '../shared';
 
 jest.mock('@grafana/runtime');
 jest.mock('shared/logger/logger');
@@ -153,10 +153,7 @@ describe('fetchFiringAlertMetrics()', () => {
         buildRulerResponse([
           {
             name: 'group-1',
-            rules: [
-              alertingRule('EmptyQuery', ''),
-              alertingRule('ValidRule', 'up == 0'),
-            ],
+            rules: [alertingRule('EmptyQuery', ''), alertingRule('ValidRule', 'up == 0')],
           },
         ])
       );
@@ -223,7 +220,10 @@ describe('fetchFiringAlertMetrics()', () => {
 
       expect(result).toBeInstanceOf(Map);
       expect(result.size).toBe(0);
-      expect(logger.error).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ message: expect.any(String) }));
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ message: expect.any(String) })
+      );
     });
 
     test('handles string error from API', async () => {
@@ -234,7 +234,10 @@ describe('fetchFiringAlertMetrics()', () => {
 
       expect(result).toBeInstanceOf(Map);
       expect(result.size).toBe(0);
-      expect(logger.error).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ message: expect.any(String) }));
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ message: expect.any(String) })
+      );
     });
   });
 });

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchAlertingMetrics.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchAlertingMetrics.ts
@@ -1,8 +1,9 @@
 import { t } from '@grafana/i18n';
-import { getBackendSrv, type BackendSrvRequest } from '@grafana/runtime';
+import { getBackendSrv } from '@grafana/runtime';
 
 import { logger } from 'shared/logger/logger';
 
+import { usageRequestOptions } from './shared';
 import { extractMetricNames } from '../../../../shared/utils/utils.promql';
 
 import type { MetricUsageDetails } from './fetchDashboardMetrics';
@@ -25,11 +26,6 @@ interface AlertingRule {
     };
   }>;
 }
-
-const usageRequestOptions: Partial<BackendSrvRequest> = {
-  showSuccessAlert: false,
-  showErrorAlert: false,
-} as const;
 
 // TODO: update parseAlertingRules to do what the dashboards function does
 function transformCountsToAlertingUsage(counts: Record<string, number>): Record<string, MetricUsageDetails> {

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchDashboardMetrics.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchDashboardMetrics.ts
@@ -1,11 +1,12 @@
 import { t } from '@grafana/i18n';
-import { getBackendSrv, type BackendSrvRequest } from '@grafana/runtime';
+import { getBackendSrv } from '@grafana/runtime';
 import { type Dashboard, type Panel } from '@grafana/schema';
 import { limitFunction } from 'p-limit';
 
 import { displayWarning } from 'MetricsReducer/helpers/displayStatus';
 import { logger } from 'shared/logger/logger';
 
+import { usageRequestOptions } from './shared';
 import { isPrometheusDataSource } from '../../../../shared/utils/utils.datasource';
 import { extractMetricNames } from '../../../../shared/utils/utils.promql';
 
@@ -29,11 +30,6 @@ export type MetricUsageDetails =
   | { usageType: 'alerting-usage'; count: number }; // TODO: implement `alerts: Record<string, number>`
 
 type MetricUsageMap = Record<string, MetricUsageDetails>;
-
-const usageRequestOptions: Partial<BackendSrvRequest> = {
-  showSuccessAlert: false,
-  showErrorAlert: false,
-} as const;
 
 type DashboardWithUrl = Dashboard & { url: string };
 

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts
@@ -10,25 +10,28 @@ import { extractMetricNames } from '../../../../shared/utils/utils.promql';
 /**
  * Prometheus-compatible ruler API response shape.
  * Returned by GET /api/prometheus/grafana/api/v1/rules
+ *
+ * Fields are typed as optional where parseFiringRules defensively checks
+ * for their presence, so the types reflect the actual runtime guarantees.
  */
 interface RulerRulesResponse {
-  status: string;
-  data: {
-    groups: RuleGroup[];
+  status?: string;
+  data?: {
+    groups?: RuleGroup[];
   };
 }
 
 interface RuleGroup {
-  name: string;
-  file: string;
-  rules: Rule[];
-  interval: number;
+  name?: string;
+  file?: string;
+  rules?: Rule[];
+  interval?: number;
 }
 
 interface Rule {
-  type: 'alerting' | 'recording';
-  name: string;
-  query: string;
+  type?: string;
+  name?: string;
+  query?: unknown;
   state?: string;
   health?: string;
   alerts?: unknown[];
@@ -81,7 +84,7 @@ function parseFiringRules(response: RulerRulesResponse): Map<string, number> {
     }
 
     const alertingRules = group.rules.filter(
-      (rule): rule is Rule & { query: string } =>
+      (rule): rule is Rule & { name: string; query: string } =>
         rule.type === 'alerting' && typeof rule.query === 'string' && rule.query !== ''
     );
 
@@ -93,7 +96,7 @@ function parseFiringRules(response: RulerRulesResponse): Map<string, number> {
   return metricCounts;
 }
 
-function countMetricsFromRule(rule: Rule, metricCounts: Map<string, number>): void {
+function countMetricsFromRule(rule: Rule & { name: string; query: string }, metricCounts: Map<string, number>): void {
   try {
     const metrics = extractMetricNames(rule.query);
 

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts
@@ -1,0 +1,112 @@
+import { t } from '@grafana/i18n';
+import { getBackendSrv, type BackendSrvRequest } from '@grafana/runtime';
+
+import { logger } from 'shared/logger/logger';
+
+import { extractMetricNames } from '../../../../shared/utils/utils.promql';
+
+/**
+ * Prometheus-compatible ruler API response shape.
+ * Returned by GET /api/prometheus/grafana/api/v1/rules
+ */
+interface RulerRulesResponse {
+  status: string;
+  data: {
+    groups: RuleGroup[];
+  };
+}
+
+interface RuleGroup {
+  name: string;
+  file: string;
+  rules: Rule[];
+  interval: number;
+}
+
+interface Rule {
+  type: 'alerting' | 'recording';
+  name: string;
+  query: string;
+  state?: string;
+  health?: string;
+  alerts?: unknown[];
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+  duration?: number;
+}
+
+const usageRequestOptions: Partial<BackendSrvRequest> = {
+  showSuccessAlert: false,
+  showErrorAlert: false,
+} as const;
+
+/**
+ * Fetches currently firing alert rules from Grafana's Prometheus-compatible ruler endpoint
+ * and maps them to metric names.
+ *
+ * Uses the `?state=firing` server-side filter to reduce payload size, and `limit_alerts=0`
+ * to skip individual alert instance details.
+ *
+ * @returns A Map of metric name → count of firing alert rules that reference the metric
+ */
+export async function fetchFiringAlertMetrics(): Promise<Map<string, number>> {
+  try {
+    const response = await getBackendSrv().get<RulerRulesResponse>(
+      '/api/prometheus/grafana/api/v1/rules',
+      { state: 'firing', limit_alerts: 0 },
+      'grafana-metricsdrilldown-app-firing-alert-metric-usage',
+      usageRequestOptions
+    );
+
+    return parseFiringRules(response);
+  } catch (err) {
+    const error = typeof err === 'string' ? new Error(err) : (err as Error);
+    logger.error(error, {
+      message: t(
+        'fetch-firing-alert-metrics.error',
+        'Failed to fetch firing alert rules from Prometheus ruler endpoint'
+      ),
+    });
+    return new Map();
+  }
+}
+
+function parseFiringRules(response: RulerRulesResponse): Map<string, number> {
+  const metricCounts = new Map<string, number>();
+
+  const groups = response?.data?.groups;
+  if (!Array.isArray(groups)) {
+    return metricCounts;
+  }
+
+  for (const group of groups) {
+    if (!Array.isArray(group?.rules)) {
+      continue;
+    }
+
+    for (const rule of group.rules) {
+      // Only process alerting rules, skip recording rules
+      if (rule.type !== 'alerting') {
+        continue;
+      }
+
+      if (typeof rule.query !== 'string' || rule.query === '') {
+        continue;
+      }
+
+      try {
+        const metrics = extractMetricNames(rule.query);
+
+        for (const metric of metrics) {
+          metricCounts.set(metric, (metricCounts.get(metric) || 0) + 1);
+        }
+      } catch (error) {
+        logger.warn(error, {
+          message: `Failed to parse PromQL expression in firing alert rule ${rule.name}`,
+        });
+      }
+    }
+  }
+
+  return metricCounts;
+}

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts
@@ -1,8 +1,10 @@
 import { t } from '@grafana/i18n';
-import { getBackendSrv, type BackendSrvRequest } from '@grafana/runtime';
+import { getBackendSrv } from '@grafana/runtime';
 
+import { ensureErrorObject } from 'App/errorUtils';
 import { logger } from 'shared/logger/logger';
 
+import { usageRequestOptions } from './shared';
 import { extractMetricNames } from '../../../../shared/utils/utils.promql';
 
 /**
@@ -35,11 +37,6 @@ interface Rule {
   duration?: number;
 }
 
-const usageRequestOptions: Partial<BackendSrvRequest> = {
-  showSuccessAlert: false,
-  showErrorAlert: false,
-} as const;
-
 /**
  * Fetches currently firing alert rules from Grafana's Prometheus-compatible ruler endpoint
  * and maps them to metric names.
@@ -60,8 +57,7 @@ export async function fetchFiringAlertMetrics(): Promise<Map<string, number>> {
 
     return parseFiringRules(response);
   } catch (err) {
-    const error = typeof err === 'string' ? new Error(err) : (err as Error);
-    logger.error(error, {
+    logger.error(ensureErrorObject(err, 'Failed to fetch firing alert rules'), {
       message: t(
         'fetch-firing-alert-metrics.error',
         'Failed to fetch firing alert rules from Prometheus ruler endpoint'
@@ -84,29 +80,29 @@ function parseFiringRules(response: RulerRulesResponse): Map<string, number> {
       continue;
     }
 
-    for (const rule of group.rules) {
-      // Only process alerting rules, skip recording rules
-      if (rule.type !== 'alerting') {
-        continue;
-      }
+    const alertingRules = group.rules.filter(
+      (rule): rule is Rule & { query: string } =>
+        rule.type === 'alerting' && typeof rule.query === 'string' && rule.query !== ''
+    );
 
-      if (typeof rule.query !== 'string' || rule.query === '') {
-        continue;
-      }
-
-      try {
-        const metrics = extractMetricNames(rule.query);
-
-        for (const metric of metrics) {
-          metricCounts.set(metric, (metricCounts.get(metric) || 0) + 1);
-        }
-      } catch (error) {
-        logger.warn(error, {
-          message: `Failed to parse PromQL expression in firing alert rule ${rule.name}`,
-        });
-      }
+    for (const rule of alertingRules) {
+      countMetricsFromRule(rule, metricCounts);
     }
   }
 
   return metricCounts;
+}
+
+function countMetricsFromRule(rule: Rule, metricCounts: Map<string, number>): void {
+  try {
+    const metrics = extractMetricNames(rule.query);
+
+    for (const metric of metrics) {
+      metricCounts.set(metric, (metricCounts.get(metric) || 0) + 1);
+    }
+  } catch (error) {
+    logger.warn(error, {
+      message: `Failed to parse PromQL expression in firing alert rule ${rule.name}`,
+    });
+  }
 }

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts
@@ -98,6 +98,8 @@ function parseFiringRules(response: RulerRulesResponse): Map<string, number> {
 
 function countMetricsFromRule(rule: Rule & { name: string; query: string }, metricCounts: Map<string, number>): void {
   try {
+    // Safety net: the lezer PromQL parser is tolerant and won't throw on malformed
+    // strings, but we keep this catch for unexpected failures in extractMetricNames.
     const metrics = extractMetricNames(rule.query);
 
     for (const metric of metrics) {

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts
@@ -4,7 +4,7 @@ import { getBackendSrv } from '@grafana/runtime';
 import { ensureErrorObject } from 'App/errorUtils';
 import { logger } from 'shared/logger/logger';
 
-import { usageRequestOptions } from './shared';
+import { GRAFANA_RULER_RULES_URL, usageRequestOptions } from './shared';
 import { extractMetricNames } from '../../../../shared/utils/utils.promql';
 
 /**
@@ -49,7 +49,7 @@ interface Rule {
 export async function fetchFiringAlertMetrics(): Promise<Map<string, number>> {
   try {
     const response = await getBackendSrv().get<RulerRulesResponse>(
-      '/api/prometheus/grafana/api/v1/rules',
+      GRAFANA_RULER_RULES_URL,
       { state: 'firing', limit_alerts: 0 },
       'grafana-metricsdrilldown-app-firing-alert-metric-usage',
       usageRequestOptions

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/shared.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/shared.ts
@@ -4,3 +4,5 @@ export const usageRequestOptions: Partial<BackendSrvRequest> = {
   showSuccessAlert: false,
   showErrorAlert: false,
 } as const;
+
+export const GRAFANA_RULER_RULES_URL = '/api/prometheus/grafana/api/v1/rules';

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/shared.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/shared.ts
@@ -1,0 +1,6 @@
+import { type BackendSrvRequest } from '@grafana/runtime';
+
+export const usageRequestOptions: Partial<BackendSrvRequest> = {
+  showSuccessAlert: false,
+  showErrorAlert: false,
+} as const;

--- a/src/locales/en-US/grafana-metricsdrilldown-app.json
+++ b/src/locales/en-US/grafana-metricsdrilldown-app.json
@@ -87,6 +87,9 @@
     "limit-warning-body": "Your organization has more dashboards than this limit. Usage counts may be incomplete.",
     "limit-warning-title": "Dashboard usage sort is limited to 500 dashboards."
   },
+  "fetch-firing-alert-metrics": {
+    "error": "Failed to fetch firing alert rules from Prometheus ruler endpoint"
+  },
   "filtered-metrics-variable": {
     "label": "Filtered Metrics"
   },

--- a/src/shared/featureFlags/openFeature.ts
+++ b/src/shared/featureFlags/openFeature.ts
@@ -36,6 +36,11 @@ const goffFeatureFlags = {
     defaultValue: 'excluded',
     trackingKey: 'experiment_grafana_assistant_quick_search_tab_test',
   },
+  'drilldown.metrics.sort_by_firing_alerts': {
+    valueType: 'boolean',
+    values: [true, false] as const,
+    defaultValue: false,
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 /**


### PR DESCRIPTION
### ✨ Description

**Related issue(s):**
Resolves https://github.com/grafana/metrics-drilldown/issues/1259
Part of https://github.com/grafana/metrics-drilldown/issues/1258 (Handle Sea of Metrics Problem — Phase 1)

Adds `fetchFiringAlertMetrics.ts`, the foundational data layer that fetches currently firing alert rules from Grafana's Prometheus-compatible ruler endpoint and maps them to metric names. This is the first building block for firing-alert-aware features (filter chip, sort option, visual indicators).

### 📖 Summary of the changes

**New fetcher** (`src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts`)
- Calls `GET /api/prometheus/grafana/api/v1/rules?state=firing&limit_alerts=0` via `getBackendSrv()`
- Parses the grouped Prometheus ruler response, filters to alerting rules only
- Extracts metric names from PromQL expressions using `extractMetricNames()`
- Returns `Map<string, number>` mapping each metric to the count of firing rules referencing it
- Graceful error handling — returns empty Map on API failure

**Shared constant extraction** (`fetchers/shared.ts`)
- Extracted `usageRequestOptions` (duplicated across all 3 fetchers) into a shared module
- Updated `fetchAlertingMetrics.ts` and `fetchDashboardMetrics.ts` to import from shared

**Simplifications to the new fetcher**
- Uses existing `ensureErrorObject()` from `App/errorUtils` instead of inline error coercion
- Extracted `countMetricsFromRule()` helper to reduce cognitive complexity

### 🧪 How to test?

**Unit tests** (12 tests):
```sh
npx jest fetchFiringAlertMetrics --no-coverage --forceExit
```

Covers: multi-group metric extraction, count aggregation, recording rule exclusion, empty/missing data, unparseable PromQL, network errors, string errors.

**E2E tests** (2 tests):
```sh
npx playwright test e2e/tests/metrics-reducer/firing-alert-metrics.spec.ts --config=e2e/config/playwright.config.local.ts
```

Validates the Prometheus ruler API contract our fetcher depends on:
1. Endpoint returns provisioned alert rules with expected shape
2. `state=firing` filter returns empty groups when no alerts are firing

**Existing tests** — `fetchDashboardMetrics` tests pass unchanged (shared constant extraction is transparent).