### PR TITLE
chore(ci): bump plugin-ci-workflows for GATB

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
         github.event_name == 'push' &&
         contains(github.event.head_commit.message, 'pnpm version')
       )
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.3.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
         github.event_name == 'push' &&
         contains(github.event.head_commit.message, 'pnpm version')
       )
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v9.0.0
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
         github.event_name == 'push' &&
         contains(github.event.head_commit.message, 'pnpm version')
       )
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         (github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'pnpm version')) ||
         (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
       )
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.3.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
     with:
       environment: 'prod' # publishing to 'prod' will also deploy to 'ops' and 'dev'
       attestation: true # this guarantees that the plugin was built from the source code provided in the release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         (github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'pnpm version')) ||
         (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
       )
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v9.0.0
     with:
       environment: 'prod' # publishing to 'prod' will also deploy to 'ops' and 'dev'
       attestation: true # this guarantees that the plugin was built from the source code provided in the release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         (github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'pnpm version')) ||
         (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
       )
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     with:
       environment: 'prod' # publishing to 'prod' will also deploy to 'ops' and 'dev'
       attestation: true # this guarantees that the plugin was built from the source code provided in the release

--- a/.github/workflows/version-bump-changelog.yml
+++ b/.github/workflows/version-bump-changelog.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Version bump
-        uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@ci-cd-workflows/v7.3.1
+        uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@ci-cd-workflows/v8.0.0
         with:
           generate-changelog: ${{ inputs.generate-changelog }}
           version: ${{ inputs.version }}

--- a/.github/workflows/version-bump-changelog.yml
+++ b/.github/workflows/version-bump-changelog.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Version bump
-        uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@ci-cd-workflows/v8.0.0
+        uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@plugins-version-bump-changelog/v2.0.0
         with:
           generate-changelog: ${{ inputs.generate-changelog }}
           version: ${{ inputs.version }}


### PR DESCRIPTION
### ✨ Description

Security hardening initiative to migrate CI workflows to `plugin-ci-workflows` v9, which moves `ci-cd` and `version-bump-changelog` workflows to GATB (GitHub App Token Broker) authentication.

Reference PR: https://github.com/grafana/business-calendar/pull/66

### 📖 Summary of the changes

Bumps `grafana/plugin-ci-workflows` references to GATB-compatible versions:

  - `.github/workflows/publish.yml` — `cd.yml` reusable workflow → `ci-cd-workflows/v9.0.0`
  - `.github/workflows/ci-cd.yml` — `cd.yml` reusable workflow → `ci-cd-workflows/v9.0.0`
  - `.github/workflows/version-bump-changelog.yml` — `version-bump-changelog` action → `plugins-version-bump-changelog/v2.0.0`

Note: the optional `version-bump-changelog` action uses its own tag scheme separate from `ci-cd-workflows/vX`, per the migration guide.

### 🧪 How to test?

  - CI must pass on this PR (exercises `ci-cd.yml` against v9.0.0, including the Playwright e2e suite).
  - `publish.yml` and `version-bump-changelog.yml` are only triggered on release / manual dispatch, so they'll be validated on the next version bump and publish run.
  - The companion `deployment_tools` GATB YAML (handled by a teammate) must be merged before this PR is exercised in production.