### PR TITLE
chore(deps): bump @openfeature/ofrep-web-provider from 0.3.5 to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@grafana/schema": "^13.0.0",
     "@grafana/ui": "^12.4.0",
     "@lezer/common": "^1.5.0",
-    "@openfeature/ofrep-web-provider": "^0.3.5",
+    "@openfeature/ofrep-web-provider": "^0.4.1",
     "@openfeature/web-sdk": "^1.7.2",
     "@prometheus-io/lezer-promql": "^0.311.0",
     "@react-aria/utils": "3.34.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.1
       '@openfeature/ofrep-web-provider':
-        specifier: ^0.3.5
-        version: 0.3.5(@openfeature/core@1.9.2)(@openfeature/web-sdk@1.7.3(@openfeature/core@1.9.2))
+        specifier: ^0.4.1
+        version: 0.4.1(@openfeature/core@1.9.2)(@openfeature/web-sdk@1.7.3(@openfeature/core@1.9.2))
       '@openfeature/web-sdk':
         specifier: ^1.7.2
         version: 1.7.3(@openfeature/core@1.9.2)
@@ -1205,8 +1205,18 @@ packages:
     peerDependencies:
       '@openfeature/core': ^1.6.0
 
+  '@openfeature/ofrep-core@2.2.0':
+    resolution: {integrity: sha512-YbeT8mYS4Ggo/JFcYY1IzN0O0UvsCx7RPk1m40TFc4ip0gJdFVpYc5a8WDwZC2v/YqxreJ7NWBDxHxP5SOevsA==}
+    peerDependencies:
+      '@openfeature/core': ^1.6.0
+
   '@openfeature/ofrep-web-provider@0.3.5':
     resolution: {integrity: sha512-BhFaEANBhd9GO8sIq/NBcdpQUP7R1QtFE8HjPdXWv6m3DabZ2LiGlCdpAUfVZEkq4cCuxaR0SehyVdheOKP/0w==}
+    peerDependencies:
+      '@openfeature/web-sdk': ^1.4.0
+
+  '@openfeature/ofrep-web-provider@0.4.1':
+    resolution: {integrity: sha512-DoWFtDT+9r+KyqvOYLPTgPgZLKIlUejaUkM++y/VSmVwWZiuKuJP3c8bqBMV+Mi8GSQ9ihJETLzk/BLNXWChpg==}
     peerDependencies:
       '@openfeature/web-sdk': ^1.4.0
 
@@ -7694,9 +7704,20 @@ snapshots:
     dependencies:
       '@openfeature/core': 1.9.2
 
+  '@openfeature/ofrep-core@2.2.0(@openfeature/core@1.9.2)':
+    dependencies:
+      '@openfeature/core': 1.9.2
+
   '@openfeature/ofrep-web-provider@0.3.5(@openfeature/core@1.9.2)(@openfeature/web-sdk@1.7.3(@openfeature/core@1.9.2))':
     dependencies:
       '@openfeature/ofrep-core': 2.0.0(@openfeature/core@1.9.2)
+      '@openfeature/web-sdk': 1.7.3(@openfeature/core@1.9.2)
+    transitivePeerDependencies:
+      - '@openfeature/core'
+
+  '@openfeature/ofrep-web-provider@0.4.1(@openfeature/core@1.9.2)(@openfeature/web-sdk@1.7.3(@openfeature/core@1.9.2))':
+    dependencies:
+      '@openfeature/ofrep-core': 2.2.0(@openfeature/core@1.9.2)
       '@openfeature/web-sdk': 1.7.3(@openfeature/core@1.9.2)
     transitivePeerDependencies:
       - '@openfeature/core'

--- a/src/shared/featureFlags/openFeature.test.ts
+++ b/src/shared/featureFlags/openFeature.test.ts
@@ -121,7 +121,8 @@ describe('initOpenFeatureProvider', () => {
 
     expect(OFREPWebProvider).toHaveBeenCalledWith({
       baseUrl: '/grafana/apis/features.grafana.app/v0alpha1/namespaces/test-namespace',
-      pollInterval: -1,
+      disableVisibilityRefresh: true,
+      cacheMode: 'disabled',
       timeoutMs: 10_000,
     });
   });

--- a/src/shared/featureFlags/openFeature.ts
+++ b/src/shared/featureFlags/openFeature.ts
@@ -112,7 +112,8 @@ export function initOpenFeatureProvider(): Promise<void> {
     OPEN_FEATURE_DOMAIN,
     new OFREPWebProvider({
       baseUrl: `${subPath}/apis/features.grafana.app/v0alpha1/namespaces/${config.namespace}`,
-      pollInterval: -1, // Do not poll - flags are fetched once on init
+      disableVisibilityRefresh: true, // Do not refresh
+      cacheMode: 'disabled', // Do not write to localStorage
       timeoutMs: 10_000, // Timeout after 10 seconds
     }),
     {


### PR DESCRIPTION
### ✨ Description

Updates the OFREP Web Provider for OpenFeature across a breaking change, disabling the new refresh on window focus functionality, disabling the localStorage caching functionality, and removing the polling disable (as it is now disabled by default).

cc https://github.com/grafana/grafana-backend-services-squad/pull/16 https://github.com/open-feature/js-sdk-contrib/pull/1535

### 📖 Summary of the changes

See above.

### 🧪 How to test?

Feature flags continue to load.
