### PR TITLE
chore: remove grafana version from plugin info

### DIFF
--- a/src/AppDataTrail/header/PluginInfo/PluginInfo.tsx
+++ b/src/AppDataTrail/header/PluginInfo/PluginInfo.tsx
@@ -112,9 +112,8 @@ function InfoMenu({ getPrometheusBuildInfo }: Readonly<PluginInfoProps>) {
       />
       <Menu.Divider />
       <Menu.Item
-        label={t('plugin-info.menu.grafana-version', 'Grafana {{edition}} v{{version}} ({{env}})', {
+        label={t('plugin-info.menu.grafana-version', 'Grafana {{edition}} ({{env}})', {
           edition: grafanaBuildInfo.edition,
-          version: grafanaBuildInfo.version,
           env: grafanaBuildInfo.env,
         })}
         icon="grafana"

--- a/src/locales/en-US/grafana-metricsdrilldown-app.json
+++ b/src/locales/en-US/grafana-metricsdrilldown-app.json
@@ -249,7 +249,7 @@
       "commit-sha": "Commit SHA: {{sha}}",
       "contribute": "Contribute",
       "documentation": "Documentation",
-      "grafana-version": "Grafana {{edition}} v{{version}} ({{env}})",
+      "grafana-version": "Grafana {{edition}} ({{env}})",
       "prom-build-info": "{{application}} {{version}} {{buildDate}}",
       "report-issue": "Report an issue"
     }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** <!-- Paste a GitHub issue URL or another pull request URL -->
Resolves <!-- Paste Github issue that is resolved by this pull request -->

Remove grafana version. See here for context https://raintank-corp.slack.com/archives/C075BDBTX96/p1780488924349469

### Test

1. open plugin info and see that the specific grafana version is not listed