### PR TITLE
fix(i18n): use fromJSON output for Crowdin token from vault secrets

### DIFF
--- a/.github/workflows/i18n-crowdin-create-tasks.yml
+++ b/.github/workflows/i18n-crowdin-create-tasks.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Create tasks in Crowdin
         uses: grafana/grafana-github-actions/crowdin-create-tasks@main
         with:
-          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 38

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Download from Crowdin
         uses: grafana/grafana-github-actions/crowdin-download@main
         with:
-          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 38
           pr_labels: 'i18n'
           github_board_id: 516 # GMD Project

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Upload to Crowdin
         uses: grafana/grafana-github-actions/crowdin-upload@main
         with:
-          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 38


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/metrics-drilldown/issues/1307
Resolves https://github.com/grafana/metrics-drilldown/issues/1307

[grafana/shared-workflows#1957](https://github.com/grafana/shared-workflows/pull/1957) (merged 2026-06-04) removed environment variable export from the `get-vault-secrets` action. Secrets are now only available via JSON output, so all three Crowdin workflows were silently passing an empty token to the Crowdin CLI — resulting in:

```
❌ Configuration file is invalid. Check the following parameters in your configuration file:
    - Required option 'api_token' is missing
```

### 📖 Summary of the changes

In each of the three Crowdin workflow files, replace the now-broken env-var pattern with the JSON output pattern:

| File | Change |
|------|--------|
| `i18n-crowdin-upload.yml` | `${{ env.CROWDIN_TOKEN }}` → `${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}` |
| `i18n-crowdin-download.yml` | same |
| `i18n-crowdin-create-tasks.yml` | same |

### 🧪 How to test?

Trigger the `Crowdin Upload Action` workflow via `workflow_dispatch` after merging and confirm the step succeeds without the _'api_token is missing'_ error.