### PR TITLE
fix: use prerelease-inclusive semver ranges in grafanaDependency

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -4,7 +4,7 @@
   "name": "Grafana Metrics Drilldown",
   "id": "grafana-metricsdrilldown-app",
   "dependencies": {
-    "grafanaDependency": ">=11.6.11 <12 || >=12.0.10 <12.1 || >=12.1.7 <12.2 || >=12.2.5",
+    "grafanaDependency": ">=11.6.11-0 <12 || >=12.0.10-0 <12.1 || >=12.1.7-0 <12.2 || >=12.2.5-0",
     "plugins": [],
     "extensions": {
       "exposedComponents": [


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/metrics-drilldown/actions/runs/27367620365/job/80876105883

The "Publish to catalog (dev)" CI job fails because the plugin catalog now requires Grafana-owned plugins to use prerelease-inclusive semver ranges (`>=X.Y.Z-0`) in `grafanaDependency`.

### 📖 Summary of the changes

Appends `-0` to each `>=` lower bound in `grafanaDependency` in `src/plugin.json`:

```diff
- ">=11.6.11 <12 || >=12.0.10 <12.1 || >=12.1.7 <12.2 || >=12.2.5"
+ ">=11.6.11-0 <12 || >=12.0.10-0 <12.1 || >=12.1.7-0 <12.2 || >=12.2.5-0"
```

The `-0` suffix means these ranges now include prerelease Grafana versions (e.g. `12.2.5-beta.1`), which is what the catalog API expects for Grafana-owned plugins.

### 🧪 How to test?

Merge and verify the "Publish to catalog (dev)" CI job passes.