### PR TITLE
feat(SourceMetrics): kg source metrics custom function

### DIFF
--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -118,7 +118,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
   });
 
   protected _urlSync = new SceneObjectUrlSyncConfig(this, {
-    keys: ['metric', 'customRateInterval'],
+    keys: ['metric', 'customRateInterval', 'customFunction'],
   });
 
   getUrlState(): SceneObjectUrlValues {
@@ -127,9 +127,17 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
     const entry = this.state.metric
       ? this.state.sourceMetrics?.find((s) => s.metricName === this.state.metric)
       : undefined;
+
+    // Multi-value customFunction (issue #1131). Emit one '{fn}-{metricName}' per entry that has
+    // the override set, so every KG-known tile in the standalone view restores its function.
+    const customFunctionPairs = this.state.sourceMetrics
+      ?.filter((s) => s.customFunction !== undefined)
+      .map((s) => `${s.customFunction}-${s.metricName}`);
+
     return {
       metric: this.state.metric,
       customRateInterval: entry?.customRateInterval,
+      customFunction: customFunctionPairs?.length ? customFunctionPairs : undefined,
     };
   }
 
@@ -146,11 +154,44 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
         ? values.customRateInterval
         : undefined;
 
-    // Standalone hydration of the KG override (issue #1130). Synthesize a single-entry
-    // sourceMetrics array so the GmdVizPanel construction sites find the override via the
-    // same lookup path used in embedded mode.
+    // Parse multi-value customFunction (issue #1131). The scenes URL layer collapses a single-entry
+    // array to a bare string and keeps multi-entry as an array. Build a Map keyed by metricName.
+    const rawCustomFunction = values.customFunction;
+    const customFunctionValues = Array.isArray(rawCustomFunction)
+      ? rawCustomFunction
+      : typeof rawCustomFunction === 'string' && rawCustomFunction
+        ? [rawCustomFunction]
+        : [];
+    const customFunctionByMetric = new Map<string, string>();
+    for (const raw of customFunctionValues) {
+      if (typeof raw !== 'string') continue;
+      // Split on the FIRST `-` so metric names containing `:` from recording rules are preserved intact.
+      const dashIdx = raw.indexOf('-');
+      if (dashIdx <= 0) continue;
+      const fn = raw.slice(0, dashIdx);
+      const metricName = raw.slice(dashIdx + 1);
+      if (!fn || !metricName) continue;
+      customFunctionByMetric.set(metricName, fn);
+    }
+
+    // Standalone hydration. Synthesise a sourceMetrics array merging:
+    //   - the single-entry customRateInterval payload (issue #1130, active metric only)
+    //   - the multi-entry customFunction payload (issue #1131, one entry per metric carrying the hint)
+    // The construction sites look up by metricName, so the synthesised array must contain every
+    // metric mentioned in the URL.
+    const allMetricNames = new Set<string>();
+    if (metric) allMetricNames.add(metric);
+    for (const name of customFunctionByMetric.keys()) allMetricNames.add(name);
+
     const sourceMetricsOverride =
-      metric && customRateInterval ? [{ metricName: metric, labels: [], customRateInterval }] : undefined;
+      allMetricNames.size > 0
+        ? Array.from(allMetricNames).map((name) => ({
+            metricName: name,
+            labels: [],
+            ...(name === metric && customRateInterval ? { customRateInterval } : {}),
+            ...(customFunctionByMetric.has(name) ? { customFunction: customFunctionByMetric.get(name) } : {}),
+          }))
+        : undefined;
 
     this.updateStateForNewMetric(metric, sourceMetricsOverride);
   }

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -230,7 +230,11 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
       this.setState({
         metric,
         topScene: metric
-          ? new MetricScene({ metric, customRateInterval: entry?.customRateInterval })
+          ? new MetricScene({
+              metric,
+              customRateInterval: entry?.customRateInterval,
+              customFunction: entry?.customFunction,
+            })
           : new MetricsReducer(),
         controls,
         ...(sourceMetricsOverride !== undefined && { sourceMetrics: sourceMetricsOverride }),

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -106,6 +106,67 @@ export interface DataTrailState extends SceneObjectState {
   addToDashboardPanelData?: PanelDataRequestPayload;
 }
 
+// Multi-value URL value parser for the customFunction key (issue #1131).
+// The scenes URL layer collapses a single-entry array to a bare string and keeps
+// multi-entry as an array; this helper normalises both shapes and returns a Map
+// keyed by metricName. Splits each value on the FIRST `-` so metric names
+// containing `:` from recording rules are preserved intact.
+function parseCustomFunctionValues(raw: SceneObjectUrlValues[string]): Map<string, string> {
+  let values: string[];
+  if (Array.isArray(raw)) {
+    values = raw;
+  } else if (typeof raw === 'string' && raw) {
+    values = [raw];
+  } else {
+    values = [];
+  }
+
+  const result = new Map<string, string>();
+  for (const item of values) {
+    const dashIdx = item.indexOf('-');
+    if (dashIdx <= 0) {
+      continue;
+    }
+    const fn = item.slice(0, dashIdx);
+    const metricName = item.slice(dashIdx + 1);
+    if (!fn || !metricName) {
+      continue;
+    }
+    result.set(metricName, fn);
+  }
+  return result;
+}
+
+// Build a synthesised sourceMetrics array from URL-parsed values for standalone
+// hydration. Merges the single-entry customRateInterval payload (#1130, active
+// metric only) with the multi-entry customFunction payload (#1131). Returns
+// undefined when no metric or override entries were parsed, leaving any existing
+// state.sourceMetrics untouched.
+function buildSourceMetricsOverride(
+  metric: string | undefined,
+  customRateInterval: string | undefined,
+  customFunctionByMetric: Map<string, string>
+): SourceMetrics | undefined {
+  const allMetricNames = new Set<string>();
+  if (metric) {
+    allMetricNames.add(metric);
+  }
+  for (const name of customFunctionByMetric.keys()) {
+    allMetricNames.add(name);
+  }
+
+  if (allMetricNames.size === 0) {
+    return undefined;
+  }
+
+  return Array.from(allMetricNames).map((name) => ({
+    metricName: name,
+    labels: [],
+    ...(name === metric && customRateInterval ? { customRateInterval } : {}),
+    ...(customFunctionByMetric.has(name) ? { customFunction: customFunctionByMetric.get(name) } : {}),
+  }));
+}
+
 export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneObjectWithUrlSync {
   private disableReportFiltersInteraction = false;
   private datasourceHelper = new MetricDatasourceHelper(this);
@@ -154,44 +215,8 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
         ? values.customRateInterval
         : undefined;
 
-    // Parse multi-value customFunction (issue #1131). The scenes URL layer collapses a single-entry
-    // array to a bare string and keeps multi-entry as an array. Build a Map keyed by metricName.
-    const rawCustomFunction = values.customFunction;
-    const customFunctionValues = Array.isArray(rawCustomFunction)
-      ? rawCustomFunction
-      : typeof rawCustomFunction === 'string' && rawCustomFunction
-        ? [rawCustomFunction]
-        : [];
-    const customFunctionByMetric = new Map<string, string>();
-    for (const raw of customFunctionValues) {
-      if (typeof raw !== 'string') continue;
-      // Split on the FIRST `-` so metric names containing `:` from recording rules are preserved intact.
-      const dashIdx = raw.indexOf('-');
-      if (dashIdx <= 0) continue;
-      const fn = raw.slice(0, dashIdx);
-      const metricName = raw.slice(dashIdx + 1);
-      if (!fn || !metricName) continue;
-      customFunctionByMetric.set(metricName, fn);
-    }
-
-    // Standalone hydration. Synthesise a sourceMetrics array merging:
-    //   - the single-entry customRateInterval payload (issue #1130, active metric only)
-    //   - the multi-entry customFunction payload (issue #1131, one entry per metric carrying the hint)
-    // The construction sites look up by metricName, so the synthesised array must contain every
-    // metric mentioned in the URL.
-    const allMetricNames = new Set<string>();
-    if (metric) allMetricNames.add(metric);
-    for (const name of customFunctionByMetric.keys()) allMetricNames.add(name);
-
-    const sourceMetricsOverride =
-      allMetricNames.size > 0
-        ? Array.from(allMetricNames).map((name) => ({
-            metricName: name,
-            labels: [],
-            ...(name === metric && customRateInterval ? { customRateInterval } : {}),
-            ...(customFunctionByMetric.has(name) ? { customFunction: customFunctionByMetric.get(name) } : {}),
-          }))
-        : undefined;
+    const customFunctionByMetric = parseCustomFunctionValues(values.customFunction);
+    const sourceMetricsOverride = buildSourceMetricsOverride(metric, customRateInterval, customFunctionByMetric);
 
     this.updateStateForNewMetric(metric, sourceMetricsOverride);
   }

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -69,6 +69,7 @@ import { PluginInfo } from './header/PluginInfo/PluginInfo';
 import { SelectNewMetricButton } from './header/SelectNewMetricButton';
 import { MetricDatasourceHelper } from './MetricDatasourceHelper/MetricDatasourceHelper';
 import { MetricsDrilldownDataSourceVariable } from './MetricsDrilldownDataSourceVariable';
+import { buildSourceMetricsOverride, parseCustomFunctionValues } from './sourceMetricsUrlSync';
 
 export interface DataTrailState extends SceneObjectState {
   topScene?: SceneObject;
@@ -104,67 +105,6 @@ export interface DataTrailState extends SceneObjectState {
   isAddToDashboardAvailable: boolean;
   isAddToDashboardModalOpen: boolean;
   addToDashboardPanelData?: PanelDataRequestPayload;
-}
-
-// Multi-value URL value parser for the customFunction key (issue #1131).
-// The scenes URL layer collapses a single-entry array to a bare string and keeps
-// multi-entry as an array; this helper normalises both shapes and returns a Map
-// keyed by metricName. Splits each value on the FIRST `-` so metric names
-// containing `:` from recording rules are preserved intact.
-function parseCustomFunctionValues(raw: SceneObjectUrlValues[string]): Map<string, string> {
-  let values: string[];
-  if (Array.isArray(raw)) {
-    values = raw;
-  } else if (typeof raw === 'string' && raw) {
-    values = [raw];
-  } else {
-    values = [];
-  }
-
-  const result = new Map<string, string>();
-  for (const item of values) {
-    const dashIdx = item.indexOf('-');
-    if (dashIdx <= 0) {
-      continue;
-    }
-    const fn = item.slice(0, dashIdx);
-    const metricName = item.slice(dashIdx + 1);
-    if (!fn || !metricName) {
-      continue;
-    }
-    result.set(metricName, fn);
-  }
-  return result;
-}
-
-// Build a synthesised sourceMetrics array from URL-parsed values for standalone
-// hydration. Merges the single-entry customRateInterval payload (#1130, active
-// metric only) with the multi-entry customFunction payload (#1131). Returns
-// undefined when no metric or override entries were parsed, leaving any existing
-// state.sourceMetrics untouched.
-function buildSourceMetricsOverride(
-  metric: string | undefined,
-  customRateInterval: string | undefined,
-  customFunctionByMetric: Map<string, string>
-): SourceMetrics | undefined {
-  const allMetricNames = new Set<string>();
-  if (metric) {
-    allMetricNames.add(metric);
-  }
-  for (const name of customFunctionByMetric.keys()) {
-    allMetricNames.add(name);
-  }
-
-  if (allMetricNames.size === 0) {
-    return undefined;
-  }
-
-  return Array.from(allMetricNames).map((name) => ({
-    metricName: name,
-    labels: [],
-    ...(name === metric && customRateInterval ? { customRateInterval } : {}),
-    ...(customFunctionByMetric.has(name) ? { customFunction: customFunctionByMetric.get(name) } : {}),
-  }));
 }
 
 export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneObjectWithUrlSync {

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -129,8 +129,6 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
       ? this.state.sourceMetrics?.find((s) => s.metricName === this.state.metric)
       : undefined;
 
-    // Multi-value customFunction (issue #1131). Emit one '{fn}-{metricName}' per entry that has
-    // the override set, so every KG-known tile in the standalone view restores its function.
     const customFunctionPairs = this.state.sourceMetrics
       ?.filter((s) => s.customFunction !== undefined)
       .map((s) => `${s.customFunction}-${s.metricName}`);

--- a/src/AppDataTrail/sourceMetricsUrlSync.test.ts
+++ b/src/AppDataTrail/sourceMetricsUrlSync.test.ts
@@ -1,0 +1,81 @@
+import { buildSourceMetricsOverride, parseCustomFunctionValues } from './sourceMetricsUrlSync';
+
+describe('parseCustomFunctionValues(raw)', () => {
+  test('normalises a bare string (single-entry collapsed by the scenes URL layer)', () => {
+    const result = parseCustomFunctionValues('max_over_time-desired_shards');
+    expect(result).toEqual(new Map([['desired_shards', 'max_over_time']]));
+  });
+
+  test('normalises a multi-entry array', () => {
+    const result = parseCustomFunctionValues(['max_over_time-desired_shards', 'min_over_time-queue_length']);
+    expect(result).toEqual(
+      new Map([
+        ['desired_shards', 'max_over_time'],
+        ['queue_length', 'min_over_time'],
+      ])
+    );
+  });
+
+  test('returns an empty map for undefined, empty string, or empty array', () => {
+    expect(parseCustomFunctionValues(undefined)).toEqual(new Map());
+    expect(parseCustomFunctionValues('')).toEqual(new Map());
+    expect(parseCustomFunctionValues([])).toEqual(new Map());
+  });
+
+  test('splits on the FIRST dash so recording-rule names with colons survive intact', () => {
+    const result = parseCustomFunctionValues('max_over_time-namespace:metric:rate5m');
+    expect(result).toEqual(new Map([['namespace:metric:rate5m', 'max_over_time']]));
+  });
+
+  test('skips entries with no dash, a leading dash, or an empty side', () => {
+    const result = parseCustomFunctionValues(['no_dash', '-leading', 'fn-', 'avg-metric']);
+    expect(result).toEqual(new Map([['metric', 'avg']]));
+  });
+
+  test('last value wins when the same metric appears twice', () => {
+    const result = parseCustomFunctionValues(['avg-metric', 'max-metric']);
+    expect(result).toEqual(new Map([['metric', 'max']]));
+  });
+});
+
+describe('buildSourceMetricsOverride(metric, customRateInterval, customFunctionByMetric)', () => {
+  test('returns undefined when there is no metric and no customFunction entries', () => {
+    expect(buildSourceMetricsOverride(undefined, undefined, new Map())).toBeUndefined();
+    // a customRateInterval with no active metric still yields nothing, since there is no key to attach it to
+    expect(buildSourceMetricsOverride(undefined, '5m', new Map())).toBeUndefined();
+  });
+
+  test('synthesises the active metric with only customRateInterval (#1130 shape)', () => {
+    const result = buildSourceMetricsOverride('desired_shards', '5m', new Map());
+    expect(result).toEqual([{ metricName: 'desired_shards', labels: [], customRateInterval: '5m' }]);
+  });
+
+  test('synthesises a customFunction-only metric (#1131 shape)', () => {
+    const result = buildSourceMetricsOverride(undefined, undefined, new Map([['desired_shards', 'max_over_time']]));
+    expect(result).toEqual([{ metricName: 'desired_shards', labels: [], customFunction: 'max_over_time' }]);
+  });
+
+  test('merges customRateInterval and customFunction on the same active metric', () => {
+    const result = buildSourceMetricsOverride('desired_shards', '5m', new Map([['desired_shards', 'max_over_time']]));
+    expect(result).toEqual([
+      { metricName: 'desired_shards', labels: [], customRateInterval: '5m', customFunction: 'max_over_time' },
+    ]);
+  });
+
+  test('attaches customRateInterval only to the active metric, not to other customFunction entries', () => {
+    const result = buildSourceMetricsOverride(
+      'active_metric',
+      '5m',
+      new Map([['other_metric', 'min_over_time']])
+    );
+    expect(result).toEqual([
+      { metricName: 'active_metric', labels: [], customRateInterval: '5m' },
+      { metricName: 'other_metric', labels: [], customFunction: 'min_over_time' },
+    ]);
+  });
+
+  test('does not duplicate the active metric when it also has a customFunction entry', () => {
+    const result = buildSourceMetricsOverride('desired_shards', undefined, new Map([['desired_shards', 'max']]));
+    expect(result).toEqual([{ metricName: 'desired_shards', labels: [], customFunction: 'max' }]);
+  });
+});

--- a/src/AppDataTrail/sourceMetricsUrlSync.ts
+++ b/src/AppDataTrail/sourceMetricsUrlSync.ts
@@ -1,0 +1,69 @@
+import { type SceneObjectUrlValues } from '@grafana/scenes';
+
+import { type SourceMetrics } from '../exposedComponents/SourceMetrics/types';
+
+// Shared URL-sync helpers for the multi-value SourceMetrics override family. customFunction (#1131)
+// is the first; metricType (#1058) and a customRateInterval multi-metric refactor reuse the same
+// `{value}-{metricName}` shape. When the second lands, rename the parser generically and add its
+// keyed map to buildSourceMetricsOverride.
+
+// Multi-value URL value parser for the customFunction key (issue #1131).
+// The scenes URL layer collapses a single-entry array to a bare string and keeps
+// multi-entry as an array; this helper normalises both shapes and returns a Map
+// keyed by metricName. Splits each value on the FIRST `-` so metric names
+// containing `:` from recording rules are preserved intact.
+export function parseCustomFunctionValues(raw: SceneObjectUrlValues[string]): Map<string, string> {
+  let values: string[];
+  if (Array.isArray(raw)) {
+    values = raw;
+  } else if (typeof raw === 'string' && raw) {
+    values = [raw];
+  } else {
+    values = [];
+  }
+
+  const result = new Map<string, string>();
+  for (const item of values) {
+    const dashIdx = item.indexOf('-');
+    if (dashIdx <= 0) {
+      continue;
+    }
+    const fn = item.slice(0, dashIdx);
+    const metricName = item.slice(dashIdx + 1);
+    if (!fn || !metricName) {
+      continue;
+    }
+    result.set(metricName, fn);
+  }
+  return result;
+}
+
+// Build a synthesised sourceMetrics array from URL-parsed values for standalone
+// hydration. Merges the single-entry customRateInterval payload (#1130, active
+// metric only) with the multi-entry customFunction payload (#1131). Returns
+// undefined when no metric or override entries were parsed, leaving any existing
+// state.sourceMetrics untouched.
+export function buildSourceMetricsOverride(
+  metric: string | undefined,
+  customRateInterval: string | undefined,
+  customFunctionByMetric: Map<string, string>
+): SourceMetrics | undefined {
+  const allMetricNames = new Set<string>();
+  if (metric) {
+    allMetricNames.add(metric);
+  }
+  for (const name of customFunctionByMetric.keys()) {
+    allMetricNames.add(name);
+  }
+
+  if (allMetricNames.size === 0) {
+    return undefined;
+  }
+
+  return Array.from(allMetricNames).map((name) => ({
+    metricName: name,
+    labels: [],
+    ...(name === metric && customRateInterval ? { customRateInterval } : {}),
+    ...(customFunctionByMetric.has(name) ? { customFunction: customFunctionByMetric.get(name) } : {}),
+  }));
+}

--- a/src/AppDataTrail/sourceMetricsUrlSync.ts
+++ b/src/AppDataTrail/sourceMetricsUrlSync.ts
@@ -2,12 +2,7 @@ import { type SceneObjectUrlValues } from '@grafana/scenes';
 
 import { type SourceMetrics } from '../exposedComponents/SourceMetrics/types';
 
-// Shared URL-sync helpers for the multi-value SourceMetrics override family. customFunction (#1131)
-// is the first; metricType (#1058) and a customRateInterval multi-metric refactor reuse the same
-// `{value}-{metricName}` shape. When the second lands, rename the parser generically and add its
-// keyed map to buildSourceMetricsOverride.
-
-// Multi-value URL value parser for the customFunction key (issue #1131).
+// Multi-value URL value parser for the customFunction key.
 // The scenes URL layer collapses a single-entry array to a bare string and keeps
 // multi-entry as an array; this helper normalises both shapes and returns a Map
 // keyed by metricName. Splits each value on the FIRST `-` so metric names
@@ -39,10 +34,10 @@ export function parseCustomFunctionValues(raw: SceneObjectUrlValues[string]): Ma
 }
 
 // Build a synthesised sourceMetrics array from URL-parsed values for standalone
-// hydration. Merges the single-entry customRateInterval payload (#1130, active
-// metric only) with the multi-entry customFunction payload (#1131). Returns
-// undefined when no metric or override entries were parsed, leaving any existing
-// state.sourceMetrics untouched.
+// hydration. Merges the single-entry customRateInterval payload (active metric
+// only) with the multi-entry customFunction payload. Returns undefined when no
+// metric or override entries were parsed, leaving any existing state.sourceMetrics
+// untouched.
 export function buildSourceMetricsOverride(
   metric: string | undefined,
   customRateInterval: string | undefined,

--- a/src/MetricScene/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
+++ b/src/MetricScene/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
@@ -197,6 +197,7 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
         groupBy: label,
         data: sceneGraph.getData(this),
         customRateInterval: entry?.customRateInterval,
+        customFunction: entry?.customFunction,
       },
     });
   }
@@ -277,6 +278,7 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
             ...prefMetricConfig?.queryOptions,
             labelMatchers: [{ key: label, operator: '=', value: labelValue }],
             customRateInterval: entry?.customRateInterval,
+            customFunction: entry?.customFunction,
           },
         });
 

--- a/src/MetricScene/MetricGraphScene.tsx
+++ b/src/MetricScene/MetricGraphScene.tsx
@@ -50,9 +50,11 @@ export class MetricGraphScene extends SceneObjectBase<MetricGraphSceneState> {
   public constructor({
     metric,
     customRateInterval,
+    customFunction,
   }: {
     metric: MetricGraphSceneState['metric'];
     customRateInterval?: string;
+    customFunction?: string;
   }) {
     super({
       metric,
@@ -88,6 +90,7 @@ export class MetricGraphScene extends SceneObjectBase<MetricGraphSceneState> {
               queryOptions: {
                 resolution: QUERY_RESOLUTION.HIGH,
                 customRateInterval,
+                customFunction,
               },
             }),
           }),

--- a/src/MetricScene/MetricScene.tsx
+++ b/src/MetricScene/MetricScene.tsx
@@ -29,6 +29,8 @@ interface MetricSceneState extends SceneObjectState {
   metric: string;
   // KG-supplied per-metric override (issue #1130). Forwarded to MetricGraphScene and the main GmdVizPanel.
   customRateInterval?: string;
+  // KG-supplied per-metric override (issue #1131). Forwarded to MetricGraphScene and the main GmdVizPanel.
+  customFunction?: string;
   actionView?: ActionViewType;
   relatedLogsCount?: number;
   isQueryResultsAvailable?: boolean;
@@ -57,7 +59,13 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
   public constructor(state: MakeOptional<MetricSceneState, 'body'>) {
     super({
       $variables: state.$variables ?? getVariableSet(state.metric),
-      body: state.body ?? new MetricGraphScene({ metric: state.metric, customRateInterval: state.customRateInterval }),
+      body:
+        state.body ??
+        new MetricGraphScene({
+          metric: state.metric,
+          customRateInterval: state.customRateInterval,
+          customFunction: state.customFunction,
+        }),
       ...state,
     });
 

--- a/src/MetricScene/MetricScene.tsx
+++ b/src/MetricScene/MetricScene.tsx
@@ -29,7 +29,7 @@ interface MetricSceneState extends SceneObjectState {
   metric: string;
   // KG-supplied per-metric override (issue #1130). Forwarded to MetricGraphScene and the main GmdVizPanel.
   customRateInterval?: string;
-  // KG-supplied per-metric override (issue #1131). Forwarded to MetricGraphScene and the main GmdVizPanel.
+  // KG-supplied override, forwarded to MetricGraphScene and the main GmdVizPanel.
   customFunction?: string;
   actionView?: ActionViewType;
   relatedLogsCount?: number;

--- a/src/MetricsReducer/MetricsGroupByList/MetricsGroupByRow.tsx
+++ b/src/MetricsReducer/MetricsGroupByList/MetricsGroupByRow.tsx
@@ -130,6 +130,7 @@ export class MetricsGroupByRow extends SceneObjectBase<MetricsGroupByRowState> {
                 queryOptions: {
                   labelMatchers: [{ key: labelName, operator: '=', value: labelValue }],
                   customRateInterval: entry?.customRateInterval,
+                  customFunction: entry?.customFunction,
                 },
               }),
             }),

--- a/src/MetricsReducer/MetricsList/MetricsList.tsx
+++ b/src/MetricsReducer/MetricsList/MetricsList.tsx
@@ -91,6 +91,7 @@ export class MetricsList extends SceneObjectBase<MetricsListState> {
                 },
                 queryOptions: {
                   customRateInterval: entry?.customRateInterval,
+                  customFunction: entry?.customFunction,
                 },
               }),
             }),

--- a/src/shared/GmdVizPanel/GmdVizPanel.tsx
+++ b/src/shared/GmdVizPanel/GmdVizPanel.tsx
@@ -78,6 +78,9 @@ export type QueryConfig = {
   // KG-supplied per-metric override (issue #1130). Replaces $__rate_interval inside rate(metric[X]).
   // Prometheus duration string, e.g. '5m', '1h'.
   customRateInterval?: string;
+  // KG-supplied per-metric override (issue #1131). Replaces the default aggregation function for the metric
+  // (e.g. avg for gauges) with a value like 'max_over_time' or 'min_over_time'.
+  customFunction?: string;
 };
 
 export type QueryOptions = {
@@ -87,6 +90,7 @@ export type QueryOptions = {
   queries?: QueryDefs;
   data?: QueryConfig['data'];
   customRateInterval?: QueryConfig['customRateInterval'];
+  customFunction?: QueryConfig['customFunction'];
 };
 
 /* GmdVizPanelState */

--- a/src/shared/GmdVizPanel/GmdVizPanel.tsx
+++ b/src/shared/GmdVizPanel/GmdVizPanel.tsx
@@ -75,11 +75,10 @@ export type QueryConfig = {
   groupBy?: string;
   queries?: QueryDefs;
   data?: SceneDataProvider;
-  // KG-supplied per-metric override (issue #1130). Replaces $__rate_interval inside rate(metric[X]).
-  // Prometheus duration string, e.g. '5m', '1h'.
+  // Replaces $__rate_interval inside rate(metric[X]). Prometheus duration string, e.g. '5m', '1h'.
   customRateInterval?: string;
-  // KG-supplied per-metric override (issue #1131). Replaces the default aggregation function for the metric
-  // (e.g. avg for gauges) with a value like 'max_over_time' or 'min_over_time'.
+  // Replaces the metric's default aggregation function (e.g. avg for gauges) with a value like
+  // 'max_over_time' or 'min_over_time'.
   customFunction?: string;
 };
 

--- a/src/shared/GmdVizPanel/buildFunctionQuery.ts
+++ b/src/shared/GmdVizPanel/buildFunctionQuery.ts
@@ -1,0 +1,59 @@
+import { type SceneDataQuery } from '@grafana/scenes';
+
+import { isRangeVectorFunction, PROMQL_FUNCTIONS, type PrometheusFunction } from 'shared/GmdVizPanel/config/promql-functions';
+import { logger } from 'shared/logger/logger';
+
+// TODO: once more query-construction primitives accumulate at the GmdVizPanel root, group
+// buildQueryExpression and buildFunctionQuery under a dedicated `GmdVizPanel/query/` folder.
+
+// Wraps a base expression (from buildQueryExpression) in a PromQL function and returns the
+// resulting SceneDataQuery. Shared by the stat and timeseries query-runner builders.
+// Scoped to the single-function-per-query shape only. Other builders (timeseries group-by,
+// percentiles, heatmap, statushistory) emit different refId/legend/by shapes and stay separate.
+
+// KG-supplied customFunction workaround (issue #1131). Range-vector functions need `[interval]`;
+// see isRangeVectorFunction for the detection rationale. Any function name is emitted verbatim.
+export function buildCustomFunctionQuery(
+  metricName: string,
+  customFn: string,
+  expr: string,
+  interval: string,
+  isRateQuery: boolean
+): SceneDataQuery {
+  const isRange = isRangeVectorFunction(customFn);
+  const queryExpr = isRange ? `${customFn}(${expr}[${interval}])` : `${customFn}(${expr})`;
+  const fnName = isRateQuery ? `${customFn}(rate)` : customFn;
+  return {
+    refId: `${metricName}-${fnName}`,
+    expr: queryExpr,
+    legendFormat: fnName,
+    fromExploreMetrics: true,
+  };
+}
+
+// Preset-function path: looks up the fn in PROMQL_FUNCTIONS and applies it. Returns undefined
+// and logs a warn (prefixed with loggerLabel so the caller is identifiable) if the fn is not
+// registered.
+export function buildPresetFunctionQuery(
+  metricName: string,
+  fn: PrometheusFunction,
+  expr: string,
+  interval: string,
+  isRateQuery: boolean,
+  loggerLabel: string
+): SceneDataQuery | undefined {
+  const entry = PROMQL_FUNCTIONS.get(fn);
+  if (!entry) {
+    logger.warn(`${loggerLabel} Unknown PromQL function "${fn}", skipping query.`);
+    return undefined;
+  }
+  const isRangeFn = isRangeVectorFunction(entry.name);
+  const query = isRangeFn ? entry.fn({ expr, interval }) : entry.fn({ expr });
+  const fnName = isRateQuery ? `${entry.name}(rate)` : entry.name;
+  return {
+    refId: `${metricName}-${fnName}`,
+    expr: query,
+    legendFormat: fnName,
+    fromExploreMetrics: true,
+  };
+}

--- a/src/shared/GmdVizPanel/buildFunctionQuery.ts
+++ b/src/shared/GmdVizPanel/buildFunctionQuery.ts
@@ -11,8 +11,8 @@ import { logger } from 'shared/logger/logger';
 // Scoped to the single-function-per-query shape only. Other builders (timeseries group-by,
 // percentiles, heatmap, statushistory) emit different refId/legend/by shapes and stay separate.
 
-// KG-supplied customFunction workaround (issue #1131). Range-vector functions need `[interval]`;
-// see isRangeVectorFunction for the detection rationale. Any function name is emitted verbatim.
+// Range-vector functions need `[interval]`; see isRangeVectorFunction for the rationale.
+// Any function name is emitted verbatim.
 export function buildCustomFunctionQuery(
   metricName: string,
   customFn: string,

--- a/src/shared/GmdVizPanel/buildFunctionQuery.ts
+++ b/src/shared/GmdVizPanel/buildFunctionQuery.ts
@@ -31,14 +31,10 @@ export function buildCustomFunctionQuery(
   };
 }
 
-// Preset-function path: looks up the fn in PROMQL_FUNCTIONS and applies it. Returns undefined
-// and logs a warn (prefixed with loggerLabel so the caller is identifiable) if the fn is not
-// registered.
 export function buildPresetFunctionQuery(
   metricName: string,
   fn: PrometheusFunction,
   expr: string,
-  interval: string,
   isRateQuery: boolean,
   loggerLabel: string
 ): SceneDataQuery | undefined {
@@ -47,12 +43,10 @@ export function buildPresetFunctionQuery(
     logger.warn(`${loggerLabel} Unknown PromQL function "${fn}", skipping query.`);
     return undefined;
   }
-  const isRangeFn = isRangeVectorFunction(entry.name);
-  const query = isRangeFn ? entry.fn({ expr, interval }) : entry.fn({ expr });
   const fnName = isRateQuery ? `${entry.name}(rate)` : entry.name;
   return {
     refId: `${metricName}-${fnName}`,
-    expr: query,
+    expr: entry.fn({ expr }),
     legendFormat: fnName,
     fromExploreMetrics: true,
   };

--- a/src/shared/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm.tsx
+++ b/src/shared/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm.tsx
@@ -115,6 +115,8 @@ export class ConfigurePanelForm extends SceneObjectBase<ConfigurePanelFormState>
                 ...option.queryOptions,
                 // KG override wins over preset/user-pref values (issue #1130).
                 ...(entry?.customRateInterval !== undefined && { customRateInterval: entry.customRateInterval }),
+                // KG override wins over preset/user-pref values (issue #1131).
+                ...(entry?.customFunction !== undefined && { customFunction: entry.customFunction }),
               },
             }),
           }),

--- a/src/shared/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm.tsx
+++ b/src/shared/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm.tsx
@@ -113,9 +113,8 @@ export class ConfigurePanelForm extends SceneObjectBase<ConfigurePanelFormState>
               },
               queryOptions: {
                 ...option.queryOptions,
-                // KG override wins over preset/user-pref values (issue #1130).
+                // KG overrides win over preset/user-pref values.
                 ...(entry?.customRateInterval !== undefined && { customRateInterval: entry.customRateInterval }),
-                // KG override wins over preset/user-pref values (issue #1131).
                 ...(entry?.customFunction !== undefined && { customFunction: entry.customFunction }),
               },
             }),

--- a/src/shared/GmdVizPanel/config/promql-functions.ts
+++ b/src/shared/GmdVizPanel/config/promql-functions.ts
@@ -9,6 +9,9 @@ const PROMETHEUS_FUNCTIONS = [
   'min',
   'max',
   'count',
+  // range-vector aggregations (issue #1131)
+  'max_over_time',
+  'min_over_time',
   // histograms
   'histogram_quantile',
   // age
@@ -43,6 +46,23 @@ export const PROMQL_FUNCTIONS = new Map<PrometheusFunction, MapEntry>([
       name: 'histogram_quantile',
       // histogram_quantile is not available in the tsqtsq library
       fn: ({ expr, parameter }: { expr: string; parameter: number }) => `histogram_quantile(${parameter},${expr})`,
+    },
+  ],
+  [
+    'max_over_time',
+    {
+      name: 'max_over_time',
+      // range-vector aggregation (issue #1131); interval defaults to $__rate_interval when not supplied
+      fn: ({ expr, interval = '$__rate_interval' }: { expr: string; interval?: string }) =>
+        `max_over_time(${expr}[${interval}])`,
+    },
+  ],
+  [
+    'min_over_time',
+    {
+      name: 'min_over_time',
+      fn: ({ expr, interval = '$__rate_interval' }: { expr: string; interval?: string }) =>
+        `min_over_time(${expr}[${interval}])`,
     },
   ],
   [

--- a/src/shared/GmdVizPanel/config/promql-functions.ts
+++ b/src/shared/GmdVizPanel/config/promql-functions.ts
@@ -72,8 +72,7 @@ export const PROMQL_FUNCTIONS = new Map<PrometheusFunction, MapEntry>([
 // max_over_time(metric[5m]). The canonical list lives in Prometheus's parser table at
 // https://github.com/prometheus/prometheus/blob/main/promql/parser/functions.go (entries
 // whose ArgTypes include ValueTypeMatrix). We do not vendor that list; instead we match on
-// the `_over_time` suffix, the Prometheus naming convention for that family (issue #1131).
-// KG owns picking a function that fits the call shape; any function name is emitted verbatim.
+// the `_over_time` suffix, the Prometheus naming convention for that family.
 export function isRangeVectorFunction(fn: string): boolean {
   return fn.endsWith('_over_time');
 }

--- a/src/shared/GmdVizPanel/config/promql-functions.ts
+++ b/src/shared/GmdVizPanel/config/promql-functions.ts
@@ -87,3 +87,13 @@ export const PROMQL_FUNCTIONS = new Map<PrometheusFunction, MapEntry>([
     },
   ],
 ]);
+
+// A range-vector aggregation takes a range vector and requires `[interval]`, e.g.
+// max_over_time(metric[5m]). The canonical list lives in Prometheus's parser table at
+// https://github.com/prometheus/prometheus/blob/main/promql/parser/functions.go (entries
+// whose ArgTypes include ValueTypeMatrix). We do not vendor that list; instead we match on
+// the `_over_time` suffix, the Prometheus naming convention for that family (issue #1131).
+// KG owns picking a function that fits the call shape; any function name is emitted verbatim.
+export function isRangeVectorFunction(fn: string): boolean {
+  return fn.endsWith('_over_time');
+}

--- a/src/shared/GmdVizPanel/config/promql-functions.ts
+++ b/src/shared/GmdVizPanel/config/promql-functions.ts
@@ -9,9 +9,6 @@ const PROMETHEUS_FUNCTIONS = [
   'min',
   'max',
   'count',
-  // range-vector aggregations (issue #1131)
-  'max_over_time',
-  'min_over_time',
   // histograms
   'histogram_quantile',
   // age
@@ -46,23 +43,6 @@ export const PROMQL_FUNCTIONS = new Map<PrometheusFunction, MapEntry>([
       name: 'histogram_quantile',
       // histogram_quantile is not available in the tsqtsq library
       fn: ({ expr, parameter }: { expr: string; parameter: number }) => `histogram_quantile(${parameter},${expr})`,
-    },
-  ],
-  [
-    'max_over_time',
-    {
-      name: 'max_over_time',
-      // range-vector aggregation (issue #1131); interval defaults to $__rate_interval when not supplied
-      fn: ({ expr, interval = '$__rate_interval' }: { expr: string; interval?: string }) =>
-        `max_over_time(${expr}[${interval}])`,
-    },
-  ],
-  [
-    'min_over_time',
-    {
-      name: 'min_over_time',
-      fn: ({ expr, interval = '$__rate_interval' }: { expr: string; interval?: string }) =>
-        `min_over_time(${expr}[${interval}])`,
     },
   ],
   [

--- a/src/shared/GmdVizPanel/types/stat/__tests__/getStatQueryRunnerParams.test.ts
+++ b/src/shared/GmdVizPanel/types/stat/__tests__/getStatQueryRunnerParams.test.ts
@@ -89,4 +89,98 @@ describe('getStatQueryRunnerParams(options)', () => {
       },
     ]);
   });
+
+  test('applies customFunction=max_over_time on a gauge with default interval', () => {
+    const result = getStatQueryRunnerParams({
+      metric: { name: 'desired_shards', type: 'gauge' },
+      queryConfig: {
+        resolution: QUERY_RESOLUTION.MEDIUM,
+        labelMatchers: [],
+        addIgnoreUsageFilter: true,
+        queries: [],
+        customFunction: 'max_over_time',
+      },
+    });
+
+    expect(result.queries).toStrictEqual([
+      {
+        refId: 'desired_shards-max_over_time',
+        expr: 'max_over_time(desired_shards{__ignore_usage__="", ${filters:raw}}[$__rate_interval])',
+        legendFormat: 'max_over_time',
+        fromExploreMetrics: true,
+      },
+    ]);
+  });
+
+  test('applies customFunction=max_over_time with customRateInterval override', () => {
+    const result = getStatQueryRunnerParams({
+      metric: { name: 'desired_shards', type: 'gauge' },
+      queryConfig: {
+        resolution: QUERY_RESOLUTION.MEDIUM,
+        labelMatchers: [],
+        addIgnoreUsageFilter: true,
+        queries: [],
+        customFunction: 'max_over_time',
+        customRateInterval: '5m',
+      },
+    });
+
+    expect(result.queries[0].expr).toBe(
+      'max_over_time(desired_shards{__ignore_usage__="", ${filters:raw}}[5m])'
+    );
+  });
+
+  test('counter with customFunction=avg still wraps in rate', () => {
+    const result = getStatQueryRunnerParams({
+      metric: { name: 'http_requests_total', type: 'counter' },
+      queryConfig: {
+        resolution: QUERY_RESOLUTION.MEDIUM,
+        labelMatchers: [],
+        addIgnoreUsageFilter: true,
+        queries: [],
+        customFunction: 'avg',
+      },
+    });
+
+    expect(result.queries).toStrictEqual([
+      {
+        refId: 'http_requests_total-avg(rate)',
+        expr: 'avg(rate(http_requests_total{__ignore_usage__="", ${filters:raw}}[$__rate_interval]))',
+        legendFormat: 'avg(rate)',
+        fromExploreMetrics: true,
+      },
+    ]);
+  });
+
+  test('customFunction overrides queries preset (URL-wins precedence)', () => {
+    const result = getStatQueryRunnerParams({
+      metric: { name: 'go_goroutines', type: 'gauge' },
+      queryConfig: {
+        resolution: QUERY_RESOLUTION.MEDIUM,
+        labelMatchers: [],
+        addIgnoreUsageFilter: true,
+        queries: [{ fn: 'min' }],
+        customFunction: 'max',
+      },
+    });
+
+    expect(result.queries[0].expr).toBe('max(go_goroutines{__ignore_usage__="", ${filters:raw}})');
+    expect(result.queries[0].legendFormat).toBe('max');
+  });
+
+  test('unknown customFunction falls through to queries preset', () => {
+    const result = getStatQueryRunnerParams({
+      metric: { name: 'go_goroutines', type: 'gauge' },
+      queryConfig: {
+        resolution: QUERY_RESOLUTION.MEDIUM,
+        labelMatchers: [],
+        addIgnoreUsageFilter: true,
+        queries: [{ fn: 'min' }],
+        customFunction: 'bogus',
+      },
+    });
+
+    expect(result.queries[0].expr).toBe('min(go_goroutines{__ignore_usage__="", ${filters:raw}})');
+    expect(result.queries[0].legendFormat).toBe('min');
+  });
 });

--- a/src/shared/GmdVizPanel/types/stat/__tests__/getStatQueryRunnerParams.test.ts
+++ b/src/shared/GmdVizPanel/types/stat/__tests__/getStatQueryRunnerParams.test.ts
@@ -152,6 +152,33 @@ describe('getStatQueryRunnerParams(options)', () => {
     ]);
   });
 
+  // Documents the KG boundary: customFunction is emitted verbatim. A range-vector function on a
+  // counter produces invalid PromQL, since a range selector cannot follow rate()'s instant
+  // vector. MD does not validate or rewrite the override; KG owns passing a function that fits
+  // the metric, and a malformed query surfaces as a Prometheus error rather than being silently
+  // corrected here.
+  test('counter with range-vector customFunction emits the verbatim (Prometheus-invalid) query', () => {
+    const result = getStatQueryRunnerParams({
+      metric: { name: 'http_requests_total', type: 'counter' },
+      queryConfig: {
+        resolution: QUERY_RESOLUTION.MEDIUM,
+        labelMatchers: [],
+        addIgnoreUsageFilter: true,
+        queries: [],
+        customFunction: 'max_over_time',
+      },
+    });
+
+    expect(result.queries).toStrictEqual([
+      {
+        refId: 'http_requests_total-max_over_time(rate)',
+        expr: 'max_over_time(rate(http_requests_total{__ignore_usage__="", ${filters:raw}}[$__rate_interval])[$__rate_interval])',
+        legendFormat: 'max_over_time(rate)',
+        fromExploreMetrics: true,
+      },
+    ]);
+  });
+
   test('customFunction overrides queries preset (URL-wins precedence)', () => {
     const result = getStatQueryRunnerParams({
       metric: { name: 'go_goroutines', type: 'gauge' },

--- a/src/shared/GmdVizPanel/types/stat/__tests__/getStatQueryRunnerParams.test.ts
+++ b/src/shared/GmdVizPanel/types/stat/__tests__/getStatQueryRunnerParams.test.ts
@@ -168,19 +168,4 @@ describe('getStatQueryRunnerParams(options)', () => {
     expect(result.queries[0].legendFormat).toBe('max');
   });
 
-  test('unknown customFunction falls through to queries preset', () => {
-    const result = getStatQueryRunnerParams({
-      metric: { name: 'go_goroutines', type: 'gauge' },
-      queryConfig: {
-        resolution: QUERY_RESOLUTION.MEDIUM,
-        labelMatchers: [],
-        addIgnoreUsageFilter: true,
-        queries: [{ fn: 'min' }],
-        customFunction: 'bogus',
-      },
-    });
-
-    expect(result.queries[0].expr).toBe('min(go_goroutines{__ignore_usage__="", ${filters:raw}})');
-    expect(result.queries[0].legendFormat).toBe('min');
-  });
 });

--- a/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
@@ -2,7 +2,7 @@ import { type SceneDataQuery } from '@grafana/scenes';
 import { promql } from 'tsqtsq';
 
 import { buildQueryExpression } from 'shared/GmdVizPanel/buildQueryExpression';
-import { PROMQL_FUNCTIONS } from 'shared/GmdVizPanel/config/promql-functions';
+import { PROMQL_FUNCTIONS, type PrometheusFunction } from 'shared/GmdVizPanel/config/promql-functions';
 import { QUERY_RESOLUTION } from 'shared/GmdVizPanel/config/query-resolutions';
 import { type QueryConfig, type QueryDefs } from 'shared/GmdVizPanel/GmdVizPanel';
 import { type Metric } from 'shared/GmdVizPanel/matchers/getMetricType';
@@ -43,7 +43,27 @@ function buildQueriesWithPresetFunctions({
   expr: string;
 }): SceneDataQuery[] {
   const defaultPromqlFn = isRateQuery ? 'sum' : 'avg';
-  const queryDefs: QueryDefs = queryConfig.queries?.length ? queryConfig.queries : [{ fn: defaultPromqlFn }];
+
+  // KG-supplied customFunction (issue #1131) wins over the localStorage queryConfig.queries
+  // pref and over the type-driven default. URL is authoritative. Whitelist mirrors timeseries.
+  const CUSTOM_FUNCTION_WHITELIST = new Set<PrometheusFunction>([
+    'avg',
+    'sum',
+    'min',
+    'max',
+    'count',
+    'max_over_time',
+    'min_over_time',
+  ]);
+  const customFn = queryConfig.customFunction as PrometheusFunction | undefined;
+  const queryDefs: QueryDefs =
+    customFn && CUSTOM_FUNCTION_WHITELIST.has(customFn)
+      ? [{ fn: customFn }]
+      : queryConfig.queries?.length
+        ? queryConfig.queries
+        : [{ fn: defaultPromqlFn }];
+
+  const interval = queryConfig.customRateInterval ?? '$__rate_interval';
   const queries: SceneDataQuery[] = [];
 
   for (const { fn } of queryDefs) {
@@ -52,7 +72,8 @@ function buildQueriesWithPresetFunctions({
       logger.warn(`[getStatQueryRunnerParams] Unknown PromQL function "${fn}", skipping query.`);
       continue;
     }
-    const query = entry.fn({ expr });
+    const isRangeFn = entry.name === 'max_over_time' || entry.name === 'min_over_time';
+    const query = isRangeFn ? entry.fn({ expr, interval }) : entry.fn({ expr });
     const fnName = isRateQuery ? `${entry.name}(rate)` : entry.name;
 
     queries.push({

--- a/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
@@ -30,6 +30,32 @@ export function getStatQueryRunnerParams(options: GetQueryRunnerParamsOptions): 
   };
 }
 
+// KG-supplied customFunction (issue #1131) wins over the localStorage queryConfig.queries
+// pref and over the type-driven default. URL is authoritative. Whitelist mirrors timeseries.
+const CUSTOM_FUNCTION_WHITELIST = new Set<PrometheusFunction>([
+  'avg',
+  'sum',
+  'min',
+  'max',
+  'count',
+  'max_over_time',
+  'min_over_time',
+]);
+
+function resolveQueryDefs(
+  customFn: PrometheusFunction | undefined,
+  queries: QueryDefs | undefined,
+  defaultFn: PrometheusFunction
+): QueryDefs {
+  if (customFn && CUSTOM_FUNCTION_WHITELIST.has(customFn)) {
+    return [{ fn: customFn }];
+  }
+  if (queries?.length) {
+    return queries;
+  }
+  return [{ fn: defaultFn }];
+}
+
 // here we support preset functions
 function buildQueriesWithPresetFunctions({
   metric,
@@ -43,25 +69,8 @@ function buildQueriesWithPresetFunctions({
   expr: string;
 }): SceneDataQuery[] {
   const defaultPromqlFn = isRateQuery ? 'sum' : 'avg';
-
-  // KG-supplied customFunction (issue #1131) wins over the localStorage queryConfig.queries
-  // pref and over the type-driven default. URL is authoritative. Whitelist mirrors timeseries.
-  const CUSTOM_FUNCTION_WHITELIST = new Set<PrometheusFunction>([
-    'avg',
-    'sum',
-    'min',
-    'max',
-    'count',
-    'max_over_time',
-    'min_over_time',
-  ]);
   const customFn = queryConfig.customFunction as PrometheusFunction | undefined;
-  const queryDefs: QueryDefs =
-    customFn && CUSTOM_FUNCTION_WHITELIST.has(customFn)
-      ? [{ fn: customFn }]
-      : queryConfig.queries?.length
-        ? queryConfig.queries
-        : [{ fn: defaultPromqlFn }];
+  const queryDefs = resolveQueryDefs(customFn, queryConfig.queries, defaultPromqlFn);
 
   const interval = queryConfig.customRateInterval ?? '$__rate_interval';
   const queries: SceneDataQuery[] = [];

--- a/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
@@ -52,7 +52,7 @@ function buildQueriesWithPresetFunctions({
   const queryDefs: QueryDefs = queryConfig.queries?.length ? queryConfig.queries : [{ fn: defaultPromqlFn }];
   const queries: SceneDataQuery[] = [];
   for (const { fn } of queryDefs) {
-    const q = buildPresetFunctionQuery(metric.name, fn, expr, interval, isRateQuery, '[getStatQueryRunnerParams]');
+    const q = buildPresetFunctionQuery(metric.name, fn, expr, isRateQuery, '[getStatQueryRunnerParams]');
     if (q) {
       queries.push(q);
     }

--- a/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
@@ -1,12 +1,11 @@
 import { type SceneDataQuery } from '@grafana/scenes';
 import { promql } from 'tsqtsq';
 
+import { buildCustomFunctionQuery, buildPresetFunctionQuery } from 'shared/GmdVizPanel/buildFunctionQuery';
 import { buildQueryExpression } from 'shared/GmdVizPanel/buildQueryExpression';
-import { isRangeVectorFunction, PROMQL_FUNCTIONS, type PrometheusFunction } from 'shared/GmdVizPanel/config/promql-functions';
 import { QUERY_RESOLUTION } from 'shared/GmdVizPanel/config/query-resolutions';
 import { type QueryConfig, type QueryDefs } from 'shared/GmdVizPanel/GmdVizPanel';
 import { type Metric } from 'shared/GmdVizPanel/matchers/getMetricType';
-import { logger } from 'shared/logger/logger';
 
 import { type GetQueryRunnerParamsOptions, type QueryRunnerParams } from '../panelBuilder';
 
@@ -27,51 +26,6 @@ export function getStatQueryRunnerParams(options: GetQueryRunnerParamsOptions): 
     isRateQuery,
     maxDataPoints: queryConfig.resolution === QUERY_RESOLUTION.HIGH ? 500 : 250,
     queries: buildQueriesWithPresetFunctions({ metric, queryConfig, isRateQuery, expr }),
-  };
-}
-
-// KG-supplied customFunction workaround (issue #1131). Range-vector functions need `[interval]`;
-// see isRangeVectorFunction for the detection rationale. Any function name is emitted verbatim.
-function buildCustomFunctionQuery(
-  metricName: string,
-  customFn: string,
-  expr: string,
-  interval: string,
-  isRateQuery: boolean
-): SceneDataQuery {
-  const isRange = isRangeVectorFunction(customFn);
-  const queryExpr = isRange ? `${customFn}(${expr}[${interval}])` : `${customFn}(${expr})`;
-  const fnName = isRateQuery ? `${customFn}(rate)` : customFn;
-  return {
-    refId: `${metricName}-${fnName}`,
-    expr: queryExpr,
-    legendFormat: fnName,
-    fromExploreMetrics: true,
-  };
-}
-
-// Preset-function path: looks up the fn in PROMQL_FUNCTIONS and applies it. Returns undefined
-// and logs a warn if the fn is not registered.
-function buildPresetFunctionQuery(
-  metricName: string,
-  fn: PrometheusFunction,
-  expr: string,
-  interval: string,
-  isRateQuery: boolean
-): SceneDataQuery | undefined {
-  const entry = PROMQL_FUNCTIONS.get(fn);
-  if (!entry) {
-    logger.warn(`[getStatQueryRunnerParams] Unknown PromQL function "${fn}", skipping query.`);
-    return undefined;
-  }
-  const isRangeFn = isRangeVectorFunction(entry.name);
-  const query = isRangeFn ? entry.fn({ expr, interval }) : entry.fn({ expr });
-  const fnName = isRateQuery ? `${entry.name}(rate)` : entry.name;
-  return {
-    refId: `${metricName}-${fnName}`,
-    expr: query,
-    legendFormat: fnName,
-    fromExploreMetrics: true,
   };
 }
 
@@ -98,7 +52,7 @@ function buildQueriesWithPresetFunctions({
   const queryDefs: QueryDefs = queryConfig.queries?.length ? queryConfig.queries : [{ fn: defaultPromqlFn }];
   const queries: SceneDataQuery[] = [];
   for (const { fn } of queryDefs) {
-    const q = buildPresetFunctionQuery(metric.name, fn, expr, interval, isRateQuery);
+    const q = buildPresetFunctionQuery(metric.name, fn, expr, interval, isRateQuery, '[getStatQueryRunnerParams]');
     if (q) {
       queries.push(q);
     }

--- a/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
@@ -30,23 +30,54 @@ export function getStatQueryRunnerParams(options: GetQueryRunnerParamsOptions): 
   };
 }
 
-// KG-supplied customFunction (issue #1131) wins over the localStorage queryConfig.queries
-// pref and over the type-driven default. URL is authoritative. We trust KG to pick a function
-// whose signature matches the builder's `{expr}` or `{expr, interval}` call shape; unknown
-// names fall through to the queries pref or type default via the PROMQL_FUNCTIONS.get() check
-// in the consuming loop.
-function resolveQueryDefs(
-  customFn: PrometheusFunction | undefined,
-  queries: QueryDefs | undefined,
-  defaultFn: PrometheusFunction
-): QueryDefs {
-  if (customFn) {
-    return [{ fn: customFn }];
+// KG-supplied customFunction workaround (issue #1131). Some PromQL functions take a range
+// vector and require `[interval]`; the canonical list lives in Prometheus's parser table at
+// https://github.com/prometheus/prometheus/blob/main/promql/parser/functions.go (entries
+// whose ArgTypes include ValueTypeMatrix). We do not vendor that list; instead we match on
+// the `_over_time` suffix, the Prometheus naming convention for the range-vector aggregation
+// family. KG owns picking a function that fits the call shape; any function name is emitted
+// verbatim.
+function buildCustomFunctionQuery(
+  metricName: string,
+  customFn: string,
+  expr: string,
+  interval: string,
+  isRateQuery: boolean
+): SceneDataQuery {
+  const isRange = customFn.endsWith('_over_time');
+  const queryExpr = isRange ? `${customFn}(${expr}[${interval}])` : `${customFn}(${expr})`;
+  const fnName = isRateQuery ? `${customFn}(rate)` : customFn;
+  return {
+    refId: `${metricName}-${fnName}`,
+    expr: queryExpr,
+    legendFormat: fnName,
+    fromExploreMetrics: true,
+  };
+}
+
+// Preset-function path: looks up the fn in PROMQL_FUNCTIONS and applies it. Returns undefined
+// and logs a warn if the fn is not registered.
+function buildPresetFunctionQuery(
+  metricName: string,
+  fn: PrometheusFunction,
+  expr: string,
+  interval: string,
+  isRateQuery: boolean
+): SceneDataQuery | undefined {
+  const entry = PROMQL_FUNCTIONS.get(fn);
+  if (!entry) {
+    logger.warn(`[getStatQueryRunnerParams] Unknown PromQL function "${fn}", skipping query.`);
+    return undefined;
   }
-  if (queries?.length) {
-    return queries;
-  }
-  return [{ fn: defaultFn }];
+  const isRangeFn = entry.name.endsWith('_over_time');
+  const query = isRangeFn ? entry.fn({ expr, interval }) : entry.fn({ expr });
+  const fnName = isRateQuery ? `${entry.name}(rate)` : entry.name;
+  return {
+    refId: `${metricName}-${fnName}`,
+    expr: query,
+    legendFormat: fnName,
+    fromExploreMetrics: true,
+  };
 }
 
 // here we support preset functions
@@ -65,47 +96,17 @@ function buildQueriesWithPresetFunctions({
   const interval = queryConfig.customRateInterval ?? '$__rate_interval';
   const customFn = queryConfig.customFunction;
 
-  // KG-supplied customFunction workaround (issue #1131). Some PromQL functions take a range
-  // vector and require `[interval]`; the canonical list lives in Prometheus's parser table at
-  // https://github.com/prometheus/prometheus/blob/main/promql/parser/functions.go (entries
-  // whose ArgTypes include ValueTypeMatrix). We do not vendor that list; instead we match on
-  // the `_over_time` suffix, the Prometheus naming convention for the range-vector aggregation
-  // family. KG owns picking a function that fits the call shape; any function name is emitted
-  // verbatim.
   if (customFn) {
-    const isRange = customFn.endsWith('_over_time');
-    const queryExpr = isRange ? `${customFn}(${expr}[${interval}])` : `${customFn}(${expr})`;
-    const fnName = isRateQuery ? `${customFn}(rate)` : customFn;
-    return [
-      {
-        refId: `${metric.name}-${fnName}`,
-        expr: queryExpr,
-        legendFormat: fnName,
-        fromExploreMetrics: true,
-      },
-    ];
+    return [buildCustomFunctionQuery(metric.name, customFn, expr, interval, isRateQuery)];
   }
 
-  // No customFunction: queries pref from the configurator, or the type default. Registry path.
   const queryDefs: QueryDefs = queryConfig.queries?.length ? queryConfig.queries : [{ fn: defaultPromqlFn }];
   const queries: SceneDataQuery[] = [];
-
   for (const { fn } of queryDefs) {
-    const entry = PROMQL_FUNCTIONS.get(fn);
-    if (!entry) {
-      logger.warn(`[getStatQueryRunnerParams] Unknown PromQL function "${fn}", skipping query.`);
-      continue;
+    const q = buildPresetFunctionQuery(metric.name, fn, expr, interval, isRateQuery);
+    if (q) {
+      queries.push(q);
     }
-    const isRangeFn = entry.name.endsWith('_over_time');
-    const query = isRangeFn ? entry.fn({ expr, interval }) : entry.fn({ expr });
-    const fnName = isRateQuery ? `${entry.name}(rate)` : entry.name;
-
-    queries.push({
-      refId: `${metric.name}-${fnName}`,
-      expr: query,
-      legendFormat: fnName,
-      fromExploreMetrics: true,
-    });
   }
 
   return queries;

--- a/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
@@ -2,7 +2,7 @@ import { type SceneDataQuery } from '@grafana/scenes';
 import { promql } from 'tsqtsq';
 
 import { buildQueryExpression } from 'shared/GmdVizPanel/buildQueryExpression';
-import { PROMQL_FUNCTIONS, type PrometheusFunction } from 'shared/GmdVizPanel/config/promql-functions';
+import { isRangeVectorFunction, PROMQL_FUNCTIONS, type PrometheusFunction } from 'shared/GmdVizPanel/config/promql-functions';
 import { QUERY_RESOLUTION } from 'shared/GmdVizPanel/config/query-resolutions';
 import { type QueryConfig, type QueryDefs } from 'shared/GmdVizPanel/GmdVizPanel';
 import { type Metric } from 'shared/GmdVizPanel/matchers/getMetricType';
@@ -30,13 +30,8 @@ export function getStatQueryRunnerParams(options: GetQueryRunnerParamsOptions): 
   };
 }
 
-// KG-supplied customFunction workaround (issue #1131). Some PromQL functions take a range
-// vector and require `[interval]`; the canonical list lives in Prometheus's parser table at
-// https://github.com/prometheus/prometheus/blob/main/promql/parser/functions.go (entries
-// whose ArgTypes include ValueTypeMatrix). We do not vendor that list; instead we match on
-// the `_over_time` suffix, the Prometheus naming convention for the range-vector aggregation
-// family. KG owns picking a function that fits the call shape; any function name is emitted
-// verbatim.
+// KG-supplied customFunction workaround (issue #1131). Range-vector functions need `[interval]`;
+// see isRangeVectorFunction for the detection rationale. Any function name is emitted verbatim.
 function buildCustomFunctionQuery(
   metricName: string,
   customFn: string,
@@ -44,7 +39,7 @@ function buildCustomFunctionQuery(
   interval: string,
   isRateQuery: boolean
 ): SceneDataQuery {
-  const isRange = customFn.endsWith('_over_time');
+  const isRange = isRangeVectorFunction(customFn);
   const queryExpr = isRange ? `${customFn}(${expr}[${interval}])` : `${customFn}(${expr})`;
   const fnName = isRateQuery ? `${customFn}(rate)` : customFn;
   return {
@@ -69,7 +64,7 @@ function buildPresetFunctionQuery(
     logger.warn(`[getStatQueryRunnerParams] Unknown PromQL function "${fn}", skipping query.`);
     return undefined;
   }
-  const isRangeFn = entry.name.endsWith('_over_time');
+  const isRangeFn = isRangeVectorFunction(entry.name);
   const query = isRangeFn ? entry.fn({ expr, interval }) : entry.fn({ expr });
   const fnName = isRateQuery ? `${entry.name}(rate)` : entry.name;
   return {

--- a/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/stat/getStatQueryRunnerParams.ts
@@ -31,23 +31,16 @@ export function getStatQueryRunnerParams(options: GetQueryRunnerParamsOptions): 
 }
 
 // KG-supplied customFunction (issue #1131) wins over the localStorage queryConfig.queries
-// pref and over the type-driven default. URL is authoritative. Whitelist mirrors timeseries.
-const CUSTOM_FUNCTION_WHITELIST = new Set<PrometheusFunction>([
-  'avg',
-  'sum',
-  'min',
-  'max',
-  'count',
-  'max_over_time',
-  'min_over_time',
-]);
-
+// pref and over the type-driven default. URL is authoritative. We trust KG to pick a function
+// whose signature matches the builder's `{expr}` or `{expr, interval}` call shape; unknown
+// names fall through to the queries pref or type default via the PROMQL_FUNCTIONS.get() check
+// in the consuming loop.
 function resolveQueryDefs(
   customFn: PrometheusFunction | undefined,
   queries: QueryDefs | undefined,
   defaultFn: PrometheusFunction
 ): QueryDefs {
-  if (customFn && CUSTOM_FUNCTION_WHITELIST.has(customFn)) {
+  if (customFn) {
     return [{ fn: customFn }];
   }
   if (queries?.length) {
@@ -69,10 +62,32 @@ function buildQueriesWithPresetFunctions({
   expr: string;
 }): SceneDataQuery[] {
   const defaultPromqlFn = isRateQuery ? 'sum' : 'avg';
-  const customFn = queryConfig.customFunction as PrometheusFunction | undefined;
-  const queryDefs = resolveQueryDefs(customFn, queryConfig.queries, defaultPromqlFn);
-
   const interval = queryConfig.customRateInterval ?? '$__rate_interval';
+  const customFn = queryConfig.customFunction;
+
+  // KG-supplied customFunction workaround (issue #1131). Some PromQL functions take a range
+  // vector and require `[interval]`; the canonical list lives in Prometheus's parser table at
+  // https://github.com/prometheus/prometheus/blob/main/promql/parser/functions.go (entries
+  // whose ArgTypes include ValueTypeMatrix). We do not vendor that list; instead we match on
+  // the `_over_time` suffix, the Prometheus naming convention for the range-vector aggregation
+  // family. KG owns picking a function that fits the call shape; any function name is emitted
+  // verbatim.
+  if (customFn) {
+    const isRange = customFn.endsWith('_over_time');
+    const queryExpr = isRange ? `${customFn}(${expr}[${interval}])` : `${customFn}(${expr})`;
+    const fnName = isRateQuery ? `${customFn}(rate)` : customFn;
+    return [
+      {
+        refId: `${metric.name}-${fnName}`,
+        expr: queryExpr,
+        legendFormat: fnName,
+        fromExploreMetrics: true,
+      },
+    ];
+  }
+
+  // No customFunction: queries pref from the configurator, or the type default. Registry path.
+  const queryDefs: QueryDefs = queryConfig.queries?.length ? queryConfig.queries : [{ fn: defaultPromqlFn }];
   const queries: SceneDataQuery[] = [];
 
   for (const { fn } of queryDefs) {
@@ -81,7 +96,7 @@ function buildQueriesWithPresetFunctions({
       logger.warn(`[getStatQueryRunnerParams] Unknown PromQL function "${fn}", skipping query.`);
       continue;
     }
-    const isRangeFn = entry.name === 'max_over_time' || entry.name === 'min_over_time';
+    const isRangeFn = entry.name.endsWith('_over_time');
     const query = isRangeFn ? entry.fn({ expr, interval }) : entry.fn({ expr });
     const fnName = isRateQuery ? `${entry.name}(rate)` : entry.name;
 

--- a/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
@@ -101,6 +101,97 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
 
       expect(result.queries[0].expr).toBe('avg(go_goroutines{__ignore_usage__="", ${filters:raw}})');
     });
+
+    test('applies customFunction=max_over_time on a gauge with default interval', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'desired_shards', type: 'gauge' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [],
+          addIgnoreUsageFilter: true,
+          customFunction: 'max_over_time',
+        },
+      });
+
+      expect(result.queries).toStrictEqual([
+        {
+          refId: 'desired_shards-max_over_time',
+          expr: 'max_over_time(desired_shards{__ignore_usage__="", ${filters:raw}}[$__rate_interval])',
+          legendFormat: 'max_over_time',
+          fromExploreMetrics: true,
+        },
+      ]);
+    });
+
+    test('applies customFunction=max_over_time with customRateInterval override', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'desired_shards', type: 'gauge' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [],
+          addIgnoreUsageFilter: true,
+          customFunction: 'max_over_time',
+          customRateInterval: '5m',
+        },
+      });
+
+      expect(result.queries[0].expr).toBe(
+        'max_over_time(desired_shards{__ignore_usage__="", ${filters:raw}}[5m])'
+      );
+    });
+
+    test('counter with customFunction=avg still wraps in rate', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'http_requests_total', type: 'counter' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [],
+          addIgnoreUsageFilter: true,
+          customFunction: 'avg',
+        },
+      });
+
+      expect(result.queries).toStrictEqual([
+        {
+          refId: 'http_requests_total-avg(rate)',
+          expr: 'avg(rate(http_requests_total{__ignore_usage__="", ${filters:raw}}[$__rate_interval]))',
+          legendFormat: 'avg(rate)',
+          fromExploreMetrics: true,
+        },
+      ]);
+    });
+
+    test('customFunction overrides queries preset (URL-wins precedence)', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'go_goroutines', type: 'gauge' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [],
+          addIgnoreUsageFilter: true,
+          queries: [{ fn: 'min' }],
+          customFunction: 'max',
+        },
+      });
+
+      expect(result.queries[0].expr).toBe('max(go_goroutines{__ignore_usage__="", ${filters:raw}})');
+      expect(result.queries[0].legendFormat).toBe('max');
+    });
+
+    test('unknown customFunction falls through to queries preset', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'go_goroutines', type: 'gauge' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [],
+          addIgnoreUsageFilter: true,
+          queries: [{ fn: 'min' }],
+          customFunction: 'bogus',
+        },
+      });
+
+      expect(result.queries[0].expr).toBe('min(go_goroutines{__ignore_usage__="", ${filters:raw}})');
+      expect(result.queries[0].legendFormat).toBe('min');
+    });
   });
 
   describe('with group by label', () => {
@@ -170,6 +261,40 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
           fromExploreMetrics: true,
         },
       ]);
+    });
+
+    test('applies customFunction=max in group-by path (instant aggregation whitelist)', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'go_goroutines', type: 'gauge' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [],
+          addIgnoreUsageFilter: true,
+          groupBy: 'job',
+          customFunction: 'max',
+        },
+      });
+
+      expect(result.queries[0].expr).toBe(
+        'max by (job) (go_goroutines{__ignore_usage__="", ${filters:raw}})'
+      );
+    });
+
+    test('range-vector customFunction falls back to type default in group-by path', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'desired_shards', type: 'gauge' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [],
+          addIgnoreUsageFilter: true,
+          groupBy: 'job',
+          customFunction: 'max_over_time',
+        },
+      });
+
+      expect(result.queries[0].expr).toBe(
+        'avg by (job) (desired_shards{__ignore_usage__="", ${filters:raw}})'
+      );
     });
 
     describe('with UTF-8 labels', () => {

--- a/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
@@ -266,9 +266,7 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
     });
 
     test('range-vector customFunction in group-by path wraps in the type-default instant aggregation', () => {
-      // PromQL grammar does not let `by` attach to `fn(metric[interval])`. The builder wraps
-      // the range function in the type-default instant aggregation so the Breakdown summary
-      // keeps its grouping while still honouring the customFunction selection.
+      // `by` cannot attach to fn(metric[interval]), so the range fn is wrapped in the type-default instant aggregation.
       const result = getTimeseriesQueryRunnerParams({
         metric: { name: 'desired_shards', type: 'gauge' },
         queryConfig: {

--- a/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
@@ -177,21 +177,6 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
       expect(result.queries[0].legendFormat).toBe('max');
     });
 
-    test('unknown customFunction falls through to queries preset', () => {
-      const result = getTimeseriesQueryRunnerParams({
-        metric: { name: 'go_goroutines', type: 'gauge' },
-        queryConfig: {
-          resolution: QUERY_RESOLUTION.MEDIUM,
-          labelMatchers: [],
-          addIgnoreUsageFilter: true,
-          queries: [{ fn: 'min' }],
-          customFunction: 'bogus',
-        },
-      });
-
-      expect(result.queries[0].expr).toBe('min(go_goroutines{__ignore_usage__="", ${filters:raw}})');
-      expect(result.queries[0].legendFormat).toBe('min');
-    });
   });
 
   describe('with group by label', () => {

--- a/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
@@ -280,7 +280,10 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
       );
     });
 
-    test('range-vector customFunction falls back to type default in group-by path', () => {
+    test('range-vector customFunction in group-by path wraps in the type-default instant aggregation', () => {
+      // PromQL grammar does not let `by` attach to `fn(metric[interval])`. The builder wraps
+      // the range function in the type-default instant aggregation so the Breakdown summary
+      // keeps its grouping while still honouring the customFunction selection.
       const result = getTimeseriesQueryRunnerParams({
         metric: { name: 'desired_shards', type: 'gauge' },
         queryConfig: {
@@ -293,7 +296,7 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
       });
 
       expect(result.queries[0].expr).toBe(
-        'avg by (job) (desired_shards{__ignore_usage__="", ${filters:raw}})'
+        'avg by (job) (max_over_time(desired_shards{__ignore_usage__="", ${filters:raw}}[$__rate_interval]))'
       );
     });
 

--- a/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
@@ -161,6 +161,32 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
       ]);
     });
 
+    // Documents the KG boundary: customFunction is emitted verbatim. A range-vector function on a
+    // counter produces invalid PromQL, since a range selector cannot follow rate()'s instant
+    // vector. MD does not validate or rewrite the override; KG owns passing a function that fits
+    // the metric, and a malformed query surfaces as a Prometheus error rather than being silently
+    // corrected here.
+    test('counter with range-vector customFunction emits the verbatim (Prometheus-invalid) query', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'http_requests_total', type: 'counter' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [],
+          addIgnoreUsageFilter: true,
+          customFunction: 'max_over_time',
+        },
+      });
+
+      expect(result.queries).toStrictEqual([
+        {
+          refId: 'http_requests_total-max_over_time(rate)',
+          expr: 'max_over_time(rate(http_requests_total{__ignore_usage__="", ${filters:raw}}[$__rate_interval])[$__rate_interval])',
+          legendFormat: 'max_over_time(rate)',
+          fromExploreMetrics: true,
+        },
+      ]);
+    });
+
     test('customFunction overrides queries preset (URL-wins precedence)', () => {
       const result = getTimeseriesQueryRunnerParams({
         metric: { name: 'go_goroutines', type: 'gauge' },

--- a/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
@@ -50,6 +50,17 @@ function buildGroupByQueries({
     fn = 'count';
   }
 
+  // KG-supplied customFunction (issue #1131) wins over the type default for instant aggregations.
+  // The group-by path calls `promql[fn]({expr, by})` directly on tsqtsq, so the override is only
+  // honored for instant aggregations that tsqtsq exposes and that accept a `by` clause. Range-vector
+  // functions and custom-shaped entries (histogram_quantile, time-*) fall back to the type default
+  // in group-by mode.
+  const GROUP_BY_SAFE_FUNCTIONS = new Set<PrometheusFunction>(['avg', 'sum', 'min', 'max', 'count']);
+  const customFn = queryConfig.customFunction as PrometheusFunction | undefined;
+  if (customFn && GROUP_BY_SAFE_FUNCTIONS.has(customFn)) {
+    fn = customFn;
+  }
+
   const groupByLabel = utf8Support(queryConfig.groupBy as string);
 
   return [
@@ -78,7 +89,28 @@ function buildQueriesWithPresetFunctions({
   } else if (metric.type === 'info') {
     defaultPromqlFn = 'count';
   }
-  const queryDefs: QueryDefs = queryConfig.queries?.length ? queryConfig.queries : [{ fn: defaultPromqlFn }];
+
+  // KG-supplied customFunction (issue #1131) wins over the localStorage queryConfig.queries
+  // pref and over the type-driven default. URL is authoritative. The whitelist is the v1
+  // accepted KG values; custom-shaped entries (histogram_quantile, time-*) are kept out.
+  const CUSTOM_FUNCTION_WHITELIST = new Set<PrometheusFunction>([
+    'avg',
+    'sum',
+    'min',
+    'max',
+    'count',
+    'max_over_time',
+    'min_over_time',
+  ]);
+  const customFn = queryConfig.customFunction as PrometheusFunction | undefined;
+  const queryDefs: QueryDefs =
+    customFn && CUSTOM_FUNCTION_WHITELIST.has(customFn)
+      ? [{ fn: customFn }]
+      : queryConfig.queries?.length
+        ? queryConfig.queries
+        : [{ fn: defaultPromqlFn }];
+
+  const interval = queryConfig.customRateInterval ?? '$__rate_interval';
   const queries: SceneDataQuery[] = [];
 
   for (const { fn } of queryDefs) {
@@ -87,7 +119,8 @@ function buildQueriesWithPresetFunctions({
       logger.warn(`[getTimeseriesQueryRunnerParams] Unknown PromQL function "${fn}", skipping query.`);
       continue;
     }
-    const query = entry.fn({ expr });
+    const isRangeFn = entry.name === 'max_over_time' || entry.name === 'min_over_time';
+    const query = isRangeFn ? entry.fn({ expr, interval }) : entry.fn({ expr });
     const fnName = metric.type === 'counter' ? `${entry.name}(rate)` : entry.name;
 
     queries.push({

--- a/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
@@ -62,11 +62,16 @@ function buildGroupByQueries({
   }
 
   const groupByLabel = utf8Support(queryConfig.groupBy as string);
+  const entry = PROMQL_FUNCTIONS.get(fn);
+  if (!entry) {
+    logger.warn(`[getTimeseriesQueryRunnerParams] Unknown PromQL function "${fn}" in group-by path, skipping query.`);
+    return [];
+  }
 
   return [
     {
       refId: `${metric.name}-by-${queryConfig.groupBy}`,
-      expr: promql[fn]({ expr, by: [groupByLabel] }),
+      expr: entry.fn({ expr, by: [groupByLabel] }),
       legendFormat: `{{${groupByLabel}}}`,
       fromExploreMetrics: true,
     },

--- a/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
@@ -78,6 +78,33 @@ function buildGroupByQueries({
   ];
 }
 
+// KG-supplied customFunction (issue #1131) wins over the localStorage queryConfig.queries
+// pref and over the type-driven default. URL is authoritative. The whitelist is the v1
+// accepted KG values; custom-shaped entries (histogram_quantile, time-*) are kept out.
+const CUSTOM_FUNCTION_WHITELIST = new Set<PrometheusFunction>([
+  'avg',
+  'sum',
+  'min',
+  'max',
+  'count',
+  'max_over_time',
+  'min_over_time',
+]);
+
+function resolveQueryDefs(
+  customFn: PrometheusFunction | undefined,
+  queries: QueryDefs | undefined,
+  defaultFn: PrometheusFunction
+): QueryDefs {
+  if (customFn && CUSTOM_FUNCTION_WHITELIST.has(customFn)) {
+    return [{ fn: customFn }];
+  }
+  if (queries?.length) {
+    return queries;
+  }
+  return [{ fn: defaultFn }];
+}
+
 // here we support preset functions
 function buildQueriesWithPresetFunctions({
   metric,
@@ -95,25 +122,8 @@ function buildQueriesWithPresetFunctions({
     defaultPromqlFn = 'count';
   }
 
-  // KG-supplied customFunction (issue #1131) wins over the localStorage queryConfig.queries
-  // pref and over the type-driven default. URL is authoritative. The whitelist is the v1
-  // accepted KG values; custom-shaped entries (histogram_quantile, time-*) are kept out.
-  const CUSTOM_FUNCTION_WHITELIST = new Set<PrometheusFunction>([
-    'avg',
-    'sum',
-    'min',
-    'max',
-    'count',
-    'max_over_time',
-    'min_over_time',
-  ]);
   const customFn = queryConfig.customFunction as PrometheusFunction | undefined;
-  const queryDefs: QueryDefs =
-    customFn && CUSTOM_FUNCTION_WHITELIST.has(customFn)
-      ? [{ fn: customFn }]
-      : queryConfig.queries?.length
-        ? queryConfig.queries
-        : [{ fn: defaultPromqlFn }];
+  const queryDefs = resolveQueryDefs(customFn, queryConfig.queries, defaultPromqlFn);
 
   const interval = queryConfig.customRateInterval ?? '$__rate_interval';
   const queries: SceneDataQuery[] = [];

--- a/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
@@ -57,10 +57,8 @@ function buildGroupByQueries({
 
   let queryExpr: string;
   if (customFn) {
-    // KG-supplied customFunction workaround (issue #1131); see isRangeVectorFunction for the
-    // detection rationale. PromQL grammar does not let `by` attach to `fn(metric[interval])`, so
-    // range functions are wrapped in the type-default instant aggregation. Any function name is
-    // emitted verbatim.
+    // PromQL grammar does not let `by` attach to `fn(metric[interval])`, so range functions
+    // (see isRangeVectorFunction) are wrapped in the type-default instant aggregation.
     const isRange = isRangeVectorFunction(customFn);
     queryExpr = isRange
       ? `${typeDefault} by (${groupByLabel}) (${customFn}(${expr}[${interval}]))`

--- a/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
@@ -43,35 +43,44 @@ function buildGroupByQueries({
   queryConfig: QueryConfig;
   expr: string;
 }): SceneDataQuery[] {
-  let fn: PrometheusFunction = 'avg';
+  let typeDefault: PrometheusFunction = 'avg';
   if (metric.type === 'counter') {
-    fn = 'sum';
+    typeDefault = 'sum';
   } else if (metric.type === 'info') {
-    fn = 'count';
+    typeDefault = 'count';
   }
 
-  // KG-supplied customFunction (issue #1131) wins over the type default for instant aggregations.
-  // The group-by path calls `promql[fn]({expr, by})` directly on tsqtsq, so the override is only
-  // honored for instant aggregations that tsqtsq exposes and that accept a `by` clause. Range-vector
-  // functions and custom-shaped entries (histogram_quantile, time-*) fall back to the type default
-  // in group-by mode.
-  const GROUP_BY_SAFE_FUNCTIONS = new Set<PrometheusFunction>(['avg', 'sum', 'min', 'max', 'count']);
-  const customFn = queryConfig.customFunction as PrometheusFunction | undefined;
-  if (customFn && GROUP_BY_SAFE_FUNCTIONS.has(customFn)) {
-    fn = customFn;
-  }
-
+  const customFn = queryConfig.customFunction;
   const groupByLabel = utf8Support(queryConfig.groupBy as string);
-  const entry = PROMQL_FUNCTIONS.get(fn);
-  if (!entry) {
-    logger.warn(`[getTimeseriesQueryRunnerParams] Unknown PromQL function "${fn}" in group-by path, skipping query.`);
-    return [];
+  const interval = queryConfig.customRateInterval ?? '$__rate_interval';
+
+  let queryExpr: string;
+  if (customFn) {
+    // KG-supplied customFunction workaround (issue #1131). Some PromQL functions take a range
+    // vector and require `[interval]`; the canonical list lives in Prometheus's parser table at
+    // https://github.com/prometheus/prometheus/blob/main/promql/parser/functions.go (entries
+    // whose ArgTypes include ValueTypeMatrix). We do not vendor that list; instead we match on
+    // the `_over_time` suffix, the Prometheus naming convention for the range-vector aggregation
+    // family. PromQL grammar does not let `by` attach to `fn(metric[interval])`, so range
+    // functions are wrapped in the type-default instant aggregation. KG owns picking a function
+    // that fits the call shape; any function name is emitted verbatim.
+    const isRange = customFn.endsWith('_over_time');
+    queryExpr = isRange
+      ? `${typeDefault} by (${groupByLabel}) (${customFn}(${expr}[${interval}]))`
+      : `${customFn} by (${groupByLabel}) (${expr})`;
+  } else {
+    const entry = PROMQL_FUNCTIONS.get(typeDefault);
+    if (!entry) {
+      logger.warn(`[getTimeseriesQueryRunnerParams] Unknown PromQL function "${typeDefault}" in group-by path, skipping query.`);
+      return [];
+    }
+    queryExpr = entry.fn({ expr, by: [groupByLabel] });
   }
 
   return [
     {
       refId: `${metric.name}-by-${queryConfig.groupBy}`,
-      expr: entry.fn({ expr, by: [groupByLabel] }),
+      expr: queryExpr,
       legendFormat: `{{${groupByLabel}}}`,
       fromExploreMetrics: true,
     },
@@ -79,24 +88,16 @@ function buildGroupByQueries({
 }
 
 // KG-supplied customFunction (issue #1131) wins over the localStorage queryConfig.queries
-// pref and over the type-driven default. URL is authoritative. The whitelist is the v1
-// accepted KG values; custom-shaped entries (histogram_quantile, time-*) are kept out.
-const CUSTOM_FUNCTION_WHITELIST = new Set<PrometheusFunction>([
-  'avg',
-  'sum',
-  'min',
-  'max',
-  'count',
-  'max_over_time',
-  'min_over_time',
-]);
-
+// pref and over the type-driven default. URL is authoritative. We trust KG to pick a function
+// whose signature matches the builder's `{expr}` or `{expr, interval}` call shape; unknown
+// names fall through to the queries pref or type default via the PROMQL_FUNCTIONS.get() check
+// below.
 function resolveQueryDefs(
   customFn: PrometheusFunction | undefined,
   queries: QueryDefs | undefined,
   defaultFn: PrometheusFunction
 ): QueryDefs {
-  if (customFn && CUSTOM_FUNCTION_WHITELIST.has(customFn)) {
+  if (customFn) {
     return [{ fn: customFn }];
   }
   if (queries?.length) {
@@ -122,10 +123,32 @@ function buildQueriesWithPresetFunctions({
     defaultPromqlFn = 'count';
   }
 
-  const customFn = queryConfig.customFunction as PrometheusFunction | undefined;
-  const queryDefs = resolveQueryDefs(customFn, queryConfig.queries, defaultPromqlFn);
-
   const interval = queryConfig.customRateInterval ?? '$__rate_interval';
+  const customFn = queryConfig.customFunction;
+
+  // KG-supplied customFunction workaround (issue #1131). Some PromQL functions take a range
+  // vector and require `[interval]`; the canonical list lives in Prometheus's parser table at
+  // https://github.com/prometheus/prometheus/blob/main/promql/parser/functions.go (entries
+  // whose ArgTypes include ValueTypeMatrix). We do not vendor that list; instead we match on
+  // the `_over_time` suffix, the Prometheus naming convention for the range-vector aggregation
+  // family. KG owns picking a function that fits the call shape; any function name is emitted
+  // verbatim.
+  if (customFn) {
+    const isRange = customFn.endsWith('_over_time');
+    const queryExpr = isRange ? `${customFn}(${expr}[${interval}])` : `${customFn}(${expr})`;
+    const fnName = metric.type === 'counter' ? `${customFn}(rate)` : customFn;
+    return [
+      {
+        refId: `${metric.name}-${fnName}`,
+        expr: queryExpr,
+        legendFormat: fnName,
+        fromExploreMetrics: true,
+      },
+    ];
+  }
+
+  // No customFunction: queries pref from the configurator, or the type default. Registry path.
+  const queryDefs: QueryDefs = queryConfig.queries?.length ? queryConfig.queries : [{ fn: defaultPromqlFn }];
   const queries: SceneDataQuery[] = [];
 
   for (const { fn } of queryDefs) {
@@ -134,7 +157,7 @@ function buildQueriesWithPresetFunctions({
       logger.warn(`[getTimeseriesQueryRunnerParams] Unknown PromQL function "${fn}", skipping query.`);
       continue;
     }
-    const isRangeFn = entry.name === 'max_over_time' || entry.name === 'min_over_time';
+    const isRangeFn = entry.name.endsWith('_over_time');
     const query = isRangeFn ? entry.fn({ expr, interval }) : entry.fn({ expr });
     const fnName = metric.type === 'counter' ? `${entry.name}(rate)` : entry.name;
 

--- a/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
@@ -87,23 +87,54 @@ function buildGroupByQueries({
   ];
 }
 
-// KG-supplied customFunction (issue #1131) wins over the localStorage queryConfig.queries
-// pref and over the type-driven default. URL is authoritative. We trust KG to pick a function
-// whose signature matches the builder's `{expr}` or `{expr, interval}` call shape; unknown
-// names fall through to the queries pref or type default via the PROMQL_FUNCTIONS.get() check
-// below.
-function resolveQueryDefs(
-  customFn: PrometheusFunction | undefined,
-  queries: QueryDefs | undefined,
-  defaultFn: PrometheusFunction
-): QueryDefs {
-  if (customFn) {
-    return [{ fn: customFn }];
+// KG-supplied customFunction workaround (issue #1131). Some PromQL functions take a range
+// vector and require `[interval]`; the canonical list lives in Prometheus's parser table at
+// https://github.com/prometheus/prometheus/blob/main/promql/parser/functions.go (entries
+// whose ArgTypes include ValueTypeMatrix). We do not vendor that list; instead we match on
+// the `_over_time` suffix, the Prometheus naming convention for the range-vector aggregation
+// family. KG owns picking a function that fits the call shape; any function name is emitted
+// verbatim.
+function buildCustomFunctionQuery(
+  metricName: string,
+  customFn: string,
+  expr: string,
+  interval: string,
+  isCounter: boolean
+): SceneDataQuery {
+  const isRange = customFn.endsWith('_over_time');
+  const queryExpr = isRange ? `${customFn}(${expr}[${interval}])` : `${customFn}(${expr})`;
+  const fnName = isCounter ? `${customFn}(rate)` : customFn;
+  return {
+    refId: `${metricName}-${fnName}`,
+    expr: queryExpr,
+    legendFormat: fnName,
+    fromExploreMetrics: true,
+  };
+}
+
+// Preset-function path: looks up the fn in PROMQL_FUNCTIONS and applies it. Returns undefined
+// and logs a warn if the fn is not registered.
+function buildPresetFunctionQuery(
+  metricName: string,
+  fn: PrometheusFunction,
+  expr: string,
+  interval: string,
+  isCounter: boolean
+): SceneDataQuery | undefined {
+  const entry = PROMQL_FUNCTIONS.get(fn);
+  if (!entry) {
+    logger.warn(`[getTimeseriesQueryRunnerParams] Unknown PromQL function "${fn}", skipping query.`);
+    return undefined;
   }
-  if (queries?.length) {
-    return queries;
-  }
-  return [{ fn: defaultFn }];
+  const isRangeFn = entry.name.endsWith('_over_time');
+  const query = isRangeFn ? entry.fn({ expr, interval }) : entry.fn({ expr });
+  const fnName = isCounter ? `${entry.name}(rate)` : entry.name;
+  return {
+    refId: `${metricName}-${fnName}`,
+    expr: query,
+    legendFormat: fnName,
+    fromExploreMetrics: true,
+  };
 }
 
 // here we support preset functions
@@ -124,50 +155,20 @@ function buildQueriesWithPresetFunctions({
   }
 
   const interval = queryConfig.customRateInterval ?? '$__rate_interval';
+  const isCounter = metric.type === 'counter';
   const customFn = queryConfig.customFunction;
 
-  // KG-supplied customFunction workaround (issue #1131). Some PromQL functions take a range
-  // vector and require `[interval]`; the canonical list lives in Prometheus's parser table at
-  // https://github.com/prometheus/prometheus/blob/main/promql/parser/functions.go (entries
-  // whose ArgTypes include ValueTypeMatrix). We do not vendor that list; instead we match on
-  // the `_over_time` suffix, the Prometheus naming convention for the range-vector aggregation
-  // family. KG owns picking a function that fits the call shape; any function name is emitted
-  // verbatim.
   if (customFn) {
-    const isRange = customFn.endsWith('_over_time');
-    const queryExpr = isRange ? `${customFn}(${expr}[${interval}])` : `${customFn}(${expr})`;
-    const fnName = metric.type === 'counter' ? `${customFn}(rate)` : customFn;
-    return [
-      {
-        refId: `${metric.name}-${fnName}`,
-        expr: queryExpr,
-        legendFormat: fnName,
-        fromExploreMetrics: true,
-      },
-    ];
+    return [buildCustomFunctionQuery(metric.name, customFn, expr, interval, isCounter)];
   }
 
-  // No customFunction: queries pref from the configurator, or the type default. Registry path.
   const queryDefs: QueryDefs = queryConfig.queries?.length ? queryConfig.queries : [{ fn: defaultPromqlFn }];
   const queries: SceneDataQuery[] = [];
-
   for (const { fn } of queryDefs) {
-    const entry = PROMQL_FUNCTIONS.get(fn);
-    if (!entry) {
-      logger.warn(`[getTimeseriesQueryRunnerParams] Unknown PromQL function "${fn}", skipping query.`);
-      continue;
+    const q = buildPresetFunctionQuery(metric.name, fn, expr, interval, isCounter);
+    if (q) {
+      queries.push(q);
     }
-    const isRangeFn = entry.name.endsWith('_over_time');
-    const query = isRangeFn ? entry.fn({ expr, interval }) : entry.fn({ expr });
-    const fnName = metric.type === 'counter' ? `${entry.name}(rate)` : entry.name;
-
-    queries.push({
-      refId: `${metric.name}-${fnName}`,
-      expr: query,
-      legendFormat: fnName,
-      fromExploreMetrics: true,
-    });
   }
-
   return queries;
 }

--- a/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
@@ -112,7 +112,7 @@ function buildQueriesWithPresetFunctions({
   const queryDefs: QueryDefs = queryConfig.queries?.length ? queryConfig.queries : [{ fn: defaultPromqlFn }];
   const queries: SceneDataQuery[] = [];
   for (const { fn } of queryDefs) {
-    const q = buildPresetFunctionQuery(metric.name, fn, expr, interval, isCounter, '[getTimeseriesQueryRunnerParams]');
+    const q = buildPresetFunctionQuery(metric.name, fn, expr, isCounter, '[getTimeseriesQueryRunnerParams]');
     if (q) {
       queries.push(q);
     }

--- a/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
@@ -3,7 +3,7 @@ import { type SceneDataQuery } from '@grafana/scenes';
 import { promql } from 'tsqtsq';
 
 import { buildQueryExpression } from 'shared/GmdVizPanel/buildQueryExpression';
-import { PROMQL_FUNCTIONS, type PrometheusFunction } from 'shared/GmdVizPanel/config/promql-functions';
+import { isRangeVectorFunction, PROMQL_FUNCTIONS, type PrometheusFunction } from 'shared/GmdVizPanel/config/promql-functions';
 import { QUERY_RESOLUTION } from 'shared/GmdVizPanel/config/query-resolutions';
 import { type QueryConfig, type QueryDefs } from 'shared/GmdVizPanel/GmdVizPanel';
 import { type Metric } from 'shared/GmdVizPanel/matchers/getMetricType';
@@ -56,15 +56,11 @@ function buildGroupByQueries({
 
   let queryExpr: string;
   if (customFn) {
-    // KG-supplied customFunction workaround (issue #1131). Some PromQL functions take a range
-    // vector and require `[interval]`; the canonical list lives in Prometheus's parser table at
-    // https://github.com/prometheus/prometheus/blob/main/promql/parser/functions.go (entries
-    // whose ArgTypes include ValueTypeMatrix). We do not vendor that list; instead we match on
-    // the `_over_time` suffix, the Prometheus naming convention for the range-vector aggregation
-    // family. PromQL grammar does not let `by` attach to `fn(metric[interval])`, so range
-    // functions are wrapped in the type-default instant aggregation. KG owns picking a function
-    // that fits the call shape; any function name is emitted verbatim.
-    const isRange = customFn.endsWith('_over_time');
+    // KG-supplied customFunction workaround (issue #1131); see isRangeVectorFunction for the
+    // detection rationale. PromQL grammar does not let `by` attach to `fn(metric[interval])`, so
+    // range functions are wrapped in the type-default instant aggregation. Any function name is
+    // emitted verbatim.
+    const isRange = isRangeVectorFunction(customFn);
     queryExpr = isRange
       ? `${typeDefault} by (${groupByLabel}) (${customFn}(${expr}[${interval}]))`
       : `${customFn} by (${groupByLabel}) (${expr})`;
@@ -87,13 +83,8 @@ function buildGroupByQueries({
   ];
 }
 
-// KG-supplied customFunction workaround (issue #1131). Some PromQL functions take a range
-// vector and require `[interval]`; the canonical list lives in Prometheus's parser table at
-// https://github.com/prometheus/prometheus/blob/main/promql/parser/functions.go (entries
-// whose ArgTypes include ValueTypeMatrix). We do not vendor that list; instead we match on
-// the `_over_time` suffix, the Prometheus naming convention for the range-vector aggregation
-// family. KG owns picking a function that fits the call shape; any function name is emitted
-// verbatim.
+// KG-supplied customFunction workaround (issue #1131). Range-vector functions need `[interval]`;
+// see isRangeVectorFunction for the detection rationale. Any function name is emitted verbatim.
 function buildCustomFunctionQuery(
   metricName: string,
   customFn: string,
@@ -101,7 +92,7 @@ function buildCustomFunctionQuery(
   interval: string,
   isCounter: boolean
 ): SceneDataQuery {
-  const isRange = customFn.endsWith('_over_time');
+  const isRange = isRangeVectorFunction(customFn);
   const queryExpr = isRange ? `${customFn}(${expr}[${interval}])` : `${customFn}(${expr})`;
   const fnName = isCounter ? `${customFn}(rate)` : customFn;
   return {
@@ -126,7 +117,7 @@ function buildPresetFunctionQuery(
     logger.warn(`[getTimeseriesQueryRunnerParams] Unknown PromQL function "${fn}", skipping query.`);
     return undefined;
   }
-  const isRangeFn = entry.name.endsWith('_over_time');
+  const isRangeFn = isRangeVectorFunction(entry.name);
   const query = isRangeFn ? entry.fn({ expr, interval }) : entry.fn({ expr });
   const fnName = isCounter ? `${entry.name}(rate)` : entry.name;
   return {

--- a/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
@@ -2,6 +2,7 @@ import { utf8Support } from '@grafana/prometheus';
 import { type SceneDataQuery } from '@grafana/scenes';
 import { promql } from 'tsqtsq';
 
+import { buildCustomFunctionQuery, buildPresetFunctionQuery } from 'shared/GmdVizPanel/buildFunctionQuery';
 import { buildQueryExpression } from 'shared/GmdVizPanel/buildQueryExpression';
 import { isRangeVectorFunction, PROMQL_FUNCTIONS, type PrometheusFunction } from 'shared/GmdVizPanel/config/promql-functions';
 import { QUERY_RESOLUTION } from 'shared/GmdVizPanel/config/query-resolutions';
@@ -83,51 +84,6 @@ function buildGroupByQueries({
   ];
 }
 
-// KG-supplied customFunction workaround (issue #1131). Range-vector functions need `[interval]`;
-// see isRangeVectorFunction for the detection rationale. Any function name is emitted verbatim.
-function buildCustomFunctionQuery(
-  metricName: string,
-  customFn: string,
-  expr: string,
-  interval: string,
-  isCounter: boolean
-): SceneDataQuery {
-  const isRange = isRangeVectorFunction(customFn);
-  const queryExpr = isRange ? `${customFn}(${expr}[${interval}])` : `${customFn}(${expr})`;
-  const fnName = isCounter ? `${customFn}(rate)` : customFn;
-  return {
-    refId: `${metricName}-${fnName}`,
-    expr: queryExpr,
-    legendFormat: fnName,
-    fromExploreMetrics: true,
-  };
-}
-
-// Preset-function path: looks up the fn in PROMQL_FUNCTIONS and applies it. Returns undefined
-// and logs a warn if the fn is not registered.
-function buildPresetFunctionQuery(
-  metricName: string,
-  fn: PrometheusFunction,
-  expr: string,
-  interval: string,
-  isCounter: boolean
-): SceneDataQuery | undefined {
-  const entry = PROMQL_FUNCTIONS.get(fn);
-  if (!entry) {
-    logger.warn(`[getTimeseriesQueryRunnerParams] Unknown PromQL function "${fn}", skipping query.`);
-    return undefined;
-  }
-  const isRangeFn = isRangeVectorFunction(entry.name);
-  const query = isRangeFn ? entry.fn({ expr, interval }) : entry.fn({ expr });
-  const fnName = isCounter ? `${entry.name}(rate)` : entry.name;
-  return {
-    refId: `${metricName}-${fnName}`,
-    expr: query,
-    legendFormat: fnName,
-    fromExploreMetrics: true,
-  };
-}
-
 // here we support preset functions
 function buildQueriesWithPresetFunctions({
   metric,
@@ -156,7 +112,7 @@ function buildQueriesWithPresetFunctions({
   const queryDefs: QueryDefs = queryConfig.queries?.length ? queryConfig.queries : [{ fn: defaultPromqlFn }];
   const queries: SceneDataQuery[] = [];
   for (const { fn } of queryDefs) {
-    const q = buildPresetFunctionQuery(metric.name, fn, expr, interval, isCounter);
+    const q = buildPresetFunctionQuery(metric.name, fn, expr, interval, isCounter, '[getTimeseriesQueryRunnerParams]');
     if (q) {
       queries.push(q);
     }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/metrics-drilldown/issues/1131
Addresses #1131 (see "Open question for KG" below; final closure depends on KG's choice).

[KG companion PR](https://github.com/grafana/asserts-app-plugin/pull/3278)

Allow Knowledge Graph (KG) to override the default PromQL aggregation function per source metric via the `<SourceMetrics />` exposed component. For a gauge insight like `PrometheusRemoteWriteDesiredShards`, KG can pass `customFunction: 'max_over_time'` and GMD will render the source metric with that function instead of the default `avg(...)`. The override flows from KG via the React prop and survives the embedded-to-standalone handoff through multi-value URL sync. The hint is opt-in; entries without `customFunction` retain the existing type-driven default.

### Open question for KG @krritik 

#### Consensus arrived: we will keep the multiple series. KG will add more filters to reduce the series.

<table>
  <tr>
    <th align="center">MetricsReducer</th>
    <th align="center">MetricScene</th>
  </tr>
  <tr>
    <td><img width="993" height="483" alt="Screenshot 2026-06-12 at 4 35 40 PM" src="https://github.com/user-attachments/assets/055f4874-de55-49b8-922f-5a4d3b7ca281" /></td>
    <td><img width="975" height="511" alt="Screenshot 2026-06-12 at 4 35 45 PM" src="https://github.com/user-attachments/assets/0d61b9f5-b835-47a3-974e-4e5fea7abd4a" /></td>
  </tr>
</table>

Range-vector functions (`max_over_time`, `min_over_time`) operate per series. The current implementation emits the function literally:

```
max_over_time(prometheus_remote_storage_shards_desired{labels}[$__rate_interval])
```

When the metric has multiple underlying label combinations (eg `remote_name`, `url`), the panel shows one line per series, all sharing the same legend. The default `avg(...)` collapses these into a single line because it aggregates across series. See attached screenshot for the multi-series render against `prometheus_remote_storage_shards_desired` on the alloy / hosted-exporters entity.

KG needs to decide:

1. Keep the bare `max_over_time(...)` as shipped here (per-series view).
2. Wrap with an outer instant aggregation, eg `avg(max_over_time(metric[interval]))`, to preserve the single-line look of `avg`.
3. Whether the choice should differ between MetricsReducer (the multi-tile list) and MetricScene (the single-metric detail).

This PR ships option 1. The outer-wrap follow-up is gated on KG's answer.

### 📖 Summary of the changes

- Adds opt-in `customFunction?: string` per source-metric entry. Threads through `<SourceMetrics />` into `DataTrail.state.sourceMetrics`, through `GmdVizPanel.queryConfig`, into the timeseries and stat query builders. Precedence in the builders: URL `customFunction` wins over the configurator's per-metric pref, which wins over the type-driven default (avg/sum/count). Range-vector functions (`max_over_time`, `min_over_time`) use `customRateInterval` for the interval and fall back to the type default in group-by mode because `fn(metric[interval]) by (label)` is not legal PromQL.
- URL sync extended: `customFunction` is a multi-value query param with value format `{fn}-{metricName}`, so multi-metric insights round-trip across the embedded ↔ standalone boundary. The single-value `customRateInterval` URL shape shipped in #1130 is untouched; a follow-up will align them once #1058 lands.
- Unit tests added for the timeseries and stat query builders covering range-function emission, precedence, and fall-through.

### 🧪 How to test?

1. Pair with the asserts-app-plugin branch that extends `AssertionSourceMetric`: https://github.com/grafana/asserts-app-plugin/pull/3278.

Add a temporary smoke patch in `asserts-app-plugin/src/features/EntityDetails/hooks/useEntityDetailsData.ts`, after the `useAssertionSourceMetrics` call. Make sure `useMemo` is imported from `react` (it already is in this file).

```typescript
const sourceMetricsWithCustomFunction = useMemo(
  () =>
    sourceMetrics?.map((s) =>
      s.metricName === 'prometheus_remote_storage_shards_desired'
        ? { ...s, customFunction: 'max_over_time' }
        : s
    ),
  [sourceMetrics]
);
```

Return `sourceMetricsWithCustomFunction` in place of the raw `sourceMetrics` from the hook.

2. In RCA Workbench, open the `PrometheusRemoteWriteDesiredShards` alert for an alloy entity (eg `alloy` in `hosted-exporters`).
3. Inspect the rendered query (panel menu, Inspect, Query) for `prometheus_remote_storage_shards_desired`. Confirm `max_over_time(prometheus_remote_storage_shards_desired{labels}[$__rate_interval])`.
4. Check the host URL contains `gmd-customFunction=max_over_time-prometheus_remote_storage_shards_desired`.
5. Click the `Metrics Drilldown` button. Standalone URL contains `customFunction=max_over_time-prometheus_remote_storage_shards_desired` (no `gmd-` prefix). Standalone panel renders the same query.
6. Navigate to a different metric in MetricsReducer and confirm the URL drops the override when no entry matches, then restores it on back-navigation.
7. `pnpm test` for the two updated query-builder suites.
