### PR TITLE
feat(sourceMetrics): add metricType per-entry override

### DIFF
--- a/src/AppDataTrail/DataTrail.test.tsx
+++ b/src/AppDataTrail/DataTrail.test.tsx
@@ -158,7 +158,7 @@ describe('DataTrail - URL serialization of KG overrides', () => {
   });
 
   describe('getUrlState', () => {
-    it('emits metricType when active metric has one in sourceMetrics', () => {
+    it('emits metricType as an array of type-metric pairs', () => {
       trail.setState({
         metric: 'my_recording_rule',
         sourceMetrics: [{ metricName: 'my_recording_rule', labels: [], metricType: 'counter' }],
@@ -166,10 +166,25 @@ describe('DataTrail - URL serialization of KG overrides', () => {
 
       const urlState = trail.getUrlState();
 
-      expect(urlState.metricType).toBe('counter-my_recording_rule');
+      expect(urlState.metricType).toEqual(['counter-my_recording_rule']);
     });
 
-    it('omits metricType when entry has no metricType', () => {
+    it('emits metricType for all source metrics with overrides, not just the active one', () => {
+      trail.setState({
+        metric: 'metric_a',
+        sourceMetrics: [
+          { metricName: 'metric_a', labels: [], metricType: 'counter' },
+          { metricName: 'metric_b', labels: [], metricType: 'gauge' },
+          { metricName: 'metric_c', labels: [] },
+        ],
+      });
+
+      const urlState = trail.getUrlState();
+
+      expect(urlState.metricType).toEqual(['counter-metric_a', 'gauge-metric_b']);
+    });
+
+    it('omits metricType when no entries have metricType', () => {
       trail.setState({
         metric: 'my_metric',
         sourceMetrics: [{ metricName: 'my_metric', labels: [] }],
@@ -179,33 +194,27 @@ describe('DataTrail - URL serialization of KG overrides', () => {
 
       expect(urlState.metricType).toBeUndefined();
     });
-
-    it('omits metricType when no sourceMetrics entry matches', () => {
-      trail.setState({
-        metric: 'my_metric',
-        sourceMetrics: [{ metricName: 'other_metric', labels: [], metricType: 'gauge' }],
-      });
-
-      const urlState = trail.getUrlState();
-
-      expect(urlState.metricType).toBeUndefined();
-    });
   });
 
   describe('updateFromUrl', () => {
-    it('parses metricType and creates sourceMetrics override', () => {
+    it('parses a single metricType and creates sourceMetrics override', () => {
       trail.updateFromUrl({ metric: 'my_rule', metricType: 'counter-my_rule' });
 
       expect(trail.state.sourceMetrics).toEqual([
-        { metricName: 'my_rule', labels: [], customRateInterval: undefined, metricType: 'counter' },
+        { metricName: 'my_rule', labels: [], metricType: 'counter' },
       ]);
     });
 
-    it('creates sourceMetrics with metricType only (no customRateInterval)', () => {
-      trail.updateFromUrl({ metric: 'my_rule', metricType: 'histogram-my_rule' });
+    it('parses multiple metricType entries', () => {
+      trail.updateFromUrl({
+        metric: 'metric_a',
+        metricType: ['counter-metric_a', 'gauge-metric_b'],
+      });
 
-      expect(trail.state.sourceMetrics?.[0]?.metricType).toBe('histogram');
-      expect(trail.state.sourceMetrics?.[0]?.customRateInterval).toBeUndefined();
+      expect(trail.state.sourceMetrics).toEqual([
+        { metricName: 'metric_a', labels: [], metricType: 'counter' },
+        { metricName: 'metric_b', labels: [], metricType: 'gauge' },
+      ]);
     });
 
     it('creates sourceMetrics with both metricType and customRateInterval', () => {
@@ -219,10 +228,25 @@ describe('DataTrail - URL serialization of KG overrides', () => {
       expect(trail.state.sourceMetrics?.[0]?.customRateInterval).toBe('5m');
     });
 
+    it('merges metricType with customFunction on different metrics', () => {
+      trail.updateFromUrl({
+        metric: 'metric_a',
+        metricType: 'counter-metric_a',
+        customFunction: 'max_over_time-metric_b',
+      });
+
+      expect(trail.state.sourceMetrics).toEqual([
+        { metricName: 'metric_a', labels: [], metricType: 'counter' },
+        { metricName: 'metric_b', labels: [], customFunction: 'max_over_time' },
+      ]);
+    });
+
     it('ignores invalid metricType values', () => {
       trail.updateFromUrl({ metric: 'my_rule', metricType: 'invalid-my_rule' });
 
-      expect(trail.state.sourceMetrics).toBeUndefined();
+      expect(trail.state.sourceMetrics).toEqual([
+        { metricName: 'my_rule', labels: [] },
+      ]);
     });
 
     it('skips URL values in embedded mode', () => {

--- a/src/AppDataTrail/DataTrail.test.tsx
+++ b/src/AppDataTrail/DataTrail.test.tsx
@@ -150,6 +150,91 @@ describe('DataTrail', () => {
   });
 });
 
+describe('DataTrail - URL serialization of KG overrides', () => {
+  let trail: DataTrail;
+
+  beforeEach(() => {
+    trail = new DataTrail({});
+  });
+
+  describe('getUrlState', () => {
+    it('emits metricType when active metric has one in sourceMetrics', () => {
+      trail.setState({
+        metric: 'my_recording_rule',
+        sourceMetrics: [{ metricName: 'my_recording_rule', labels: [], metricType: 'counter' }],
+      });
+
+      const urlState = trail.getUrlState();
+
+      expect(urlState.metricType).toBe('counter-my_recording_rule');
+    });
+
+    it('omits metricType when entry has no metricType', () => {
+      trail.setState({
+        metric: 'my_metric',
+        sourceMetrics: [{ metricName: 'my_metric', labels: [] }],
+      });
+
+      const urlState = trail.getUrlState();
+
+      expect(urlState.metricType).toBeUndefined();
+    });
+
+    it('omits metricType when no sourceMetrics entry matches', () => {
+      trail.setState({
+        metric: 'my_metric',
+        sourceMetrics: [{ metricName: 'other_metric', labels: [], metricType: 'gauge' }],
+      });
+
+      const urlState = trail.getUrlState();
+
+      expect(urlState.metricType).toBeUndefined();
+    });
+  });
+
+  describe('updateFromUrl', () => {
+    it('parses metricType and creates sourceMetrics override', () => {
+      trail.updateFromUrl({ metric: 'my_rule', metricType: 'counter-my_rule' });
+
+      expect(trail.state.sourceMetrics).toEqual([
+        { metricName: 'my_rule', labels: [], customRateInterval: undefined, metricType: 'counter' },
+      ]);
+    });
+
+    it('creates sourceMetrics with metricType only (no customRateInterval)', () => {
+      trail.updateFromUrl({ metric: 'my_rule', metricType: 'histogram-my_rule' });
+
+      expect(trail.state.sourceMetrics?.[0]?.metricType).toBe('histogram');
+      expect(trail.state.sourceMetrics?.[0]?.customRateInterval).toBeUndefined();
+    });
+
+    it('creates sourceMetrics with both metricType and customRateInterval', () => {
+      trail.updateFromUrl({
+        metric: 'my_rule',
+        metricType: 'counter-my_rule',
+        customRateInterval: '5m',
+      });
+
+      expect(trail.state.sourceMetrics?.[0]?.metricType).toBe('counter');
+      expect(trail.state.sourceMetrics?.[0]?.customRateInterval).toBe('5m');
+    });
+
+    it('ignores invalid metricType values', () => {
+      trail.updateFromUrl({ metric: 'my_rule', metricType: 'invalid-my_rule' });
+
+      expect(trail.state.sourceMetrics).toBeUndefined();
+    });
+
+    it('skips URL values in embedded mode', () => {
+      trail.setState({ embedded: true });
+
+      trail.updateFromUrl({ metric: 'my_rule', metricType: 'counter-my_rule' });
+
+      expect(trail.state.metric).toBeUndefined();
+    });
+  });
+});
+
 describe('DataTrail - Add to Dashboard', () => {
   let dataTrail: DataTrail;
 

--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -59,6 +59,7 @@ import { type SourceMetrics } from '../exposedComponents/SourceMetrics/types';
 import { resetYAxisSync } from '../MetricScene/Breakdown/MetricLabelsList/behaviors/syncYAxis';
 import { MetricScene } from '../MetricScene/MetricScene';
 import { type PanelDataRequestPayload } from '../shared/GmdVizPanel/components/addToDashboard/addToDashboard';
+import { type KgMetricType } from '../shared/GmdVizPanel/matchers/mapKgMetricType';
 import { MetricSelectedEvent, trailDS, VAR_DATASOURCE, VAR_FILTERS } from '../shared/shared';
 import { reportChangeInLabelFilters, reportExploreMetrics } from '../shared/tracking/interactions';
 import { buildFilterExpression } from '../shared/utils/utils.queries';
@@ -118,7 +119,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
   });
 
   protected _urlSync = new SceneObjectUrlSyncConfig(this, {
-    keys: ['metric', 'customRateInterval'],
+    keys: ['metric', 'customRateInterval', 'metricType'],
   });
 
   getUrlState(): SceneObjectUrlValues {
@@ -130,6 +131,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
     return {
       metric: this.state.metric,
       customRateInterval: entry?.customRateInterval,
+      metricType: entry?.metricType ? `${entry.metricType}-${this.state.metric}` : undefined,
     };
   }
 
@@ -146,11 +148,15 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
         ? values.customRateInterval
         : undefined;
 
-    // Standalone hydration of the KG override (issue #1130). Synthesize a single-entry
+    const parsedKgMetricType = parseKgMetricTypeFromUrl(values.metricType);
+
+    // Standalone hydration of KG overrides (issues #1130, #1058). Synthesize a single-entry
     // sourceMetrics array so the GmdVizPanel construction sites find the override via the
     // same lookup path used in embedded mode.
     const sourceMetricsOverride =
-      metric && customRateInterval ? [{ metricName: metric, labels: [], customRateInterval }] : undefined;
+      metric && (customRateInterval || parsedKgMetricType)
+        ? [{ metricName: metric, labels: [], customRateInterval, metricType: parsedKgMetricType }]
+        : undefined;
 
     this.updateStateForNewMetric(metric, sourceMetricsOverride);
   }
@@ -230,7 +236,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
       this.setState({
         metric,
         topScene: metric
-          ? new MetricScene({ metric, customRateInterval: entry?.customRateInterval })
+          ? new MetricScene({ metric, customRateInterval: entry?.customRateInterval, kgMetricType: entry?.metricType })
           : new MetricsReducer(),
         controls,
         ...(sourceMetricsOverride !== undefined && { sourceMetrics: sourceMetricsOverride }),
@@ -618,6 +624,20 @@ function updateAppControlsHeight() {
 
   const { height } = appControls.getBoundingClientRect();
   document.documentElement.style.setProperty('--app-controls-height', `${height}px`);
+}
+
+const VALID_KG_METRIC_TYPES = new Set(['counter', 'gauge', 'histogram', 'summary']);
+
+function parseKgMetricTypeFromUrl(raw: unknown): KgMetricType | undefined {
+  if (typeof raw !== 'string') {
+    return undefined;
+  }
+  const dashIdx = raw.indexOf('-');
+  if (dashIdx <= 0) {
+    return undefined;
+  }
+  const type = raw.slice(0, dashIdx);
+  return VALID_KG_METRIC_TYPES.has(type) ? (type as KgMetricType) : undefined;
 }
 
 function isScopesSupported(): boolean {

--- a/src/AppDataTrail/sourceMetricsUrlSync.test.ts
+++ b/src/AppDataTrail/sourceMetricsUrlSync.test.ts
@@ -1,4 +1,4 @@
-import { buildSourceMetricsOverride, parseCustomFunctionValues } from './sourceMetricsUrlSync';
+import { buildSourceMetricsOverride, parseCustomFunctionValues, parseMetricTypeValues } from './sourceMetricsUrlSync';
 
 describe('parseCustomFunctionValues(raw)', () => {
   test('normalises a bare string (single-entry collapsed by the scenes URL layer)', () => {
@@ -38,7 +38,67 @@ describe('parseCustomFunctionValues(raw)', () => {
   });
 });
 
-describe('buildSourceMetricsOverride(metric, customRateInterval, customFunctionByMetric)', () => {
+describe('parseMetricTypeValues(raw)', () => {
+  test('normalises a bare string (single-entry collapsed by the scenes URL layer)', () => {
+    const result = parseMetricTypeValues('counter-desired_shards');
+    expect(result).toEqual(new Map([['desired_shards', 'counter']]));
+  });
+
+  test('normalises a multi-entry array', () => {
+    const result = parseMetricTypeValues(['counter-desired_shards', 'gauge-queue_length']);
+    expect(result).toEqual(
+      new Map([
+        ['desired_shards', 'counter'],
+        ['queue_length', 'gauge'],
+      ])
+    );
+  });
+
+  test('returns an empty map for undefined, empty string, or empty array', () => {
+    expect(parseMetricTypeValues(undefined)).toEqual(new Map());
+    expect(parseMetricTypeValues('')).toEqual(new Map());
+    expect(parseMetricTypeValues([])).toEqual(new Map());
+  });
+
+  test('splits on the FIRST dash so recording-rule names survive intact', () => {
+    const result = parseMetricTypeValues('histogram-namespace:metric:rate5m');
+    expect(result).toEqual(new Map([['namespace:metric:rate5m', 'histogram']]));
+  });
+
+  test('skips entries with invalid metric types', () => {
+    const result = parseMetricTypeValues(['invalid-metric', 'counter-valid_metric']);
+    expect(result).toEqual(new Map([['valid_metric', 'counter']]));
+  });
+
+  test('skips entries with no dash, a leading dash, or an empty metric name', () => {
+    const result = parseMetricTypeValues(['no_dash', '-leading', 'counter-', 'gauge-metric']);
+    expect(result).toEqual(new Map([['metric', 'gauge']]));
+  });
+
+  test('accepts all four valid KG metric types', () => {
+    const result = parseMetricTypeValues([
+      'counter-metric_a',
+      'gauge-metric_b',
+      'histogram-metric_c',
+      'summary-metric_d',
+    ]);
+    expect(result).toEqual(
+      new Map([
+        ['metric_a', 'counter'],
+        ['metric_b', 'gauge'],
+        ['metric_c', 'histogram'],
+        ['metric_d', 'summary'],
+      ])
+    );
+  });
+
+  test('last value wins when the same metric appears twice', () => {
+    const result = parseMetricTypeValues(['counter-metric', 'gauge-metric']);
+    expect(result).toEqual(new Map([['metric', 'gauge']]));
+  });
+});
+
+describe('buildSourceMetricsOverride(metric, customRateInterval, customFunctionByMetric, metricTypeByMetric)', () => {
   test('returns undefined when there is no metric and no customFunction entries', () => {
     expect(buildSourceMetricsOverride(undefined, undefined, new Map())).toBeUndefined();
     // a customRateInterval with no active metric still yields nothing, since there is no key to attach it to
@@ -77,5 +137,57 @@ describe('buildSourceMetricsOverride(metric, customRateInterval, customFunctionB
   test('does not duplicate the active metric when it also has a customFunction entry', () => {
     const result = buildSourceMetricsOverride('desired_shards', undefined, new Map([['desired_shards', 'max']]));
     expect(result).toEqual([{ metricName: 'desired_shards', labels: [], customFunction: 'max' }]);
+  });
+
+  test('synthesises a metricType-only metric (#1058 shape)', () => {
+    const result = buildSourceMetricsOverride(undefined, undefined, new Map(), new Map([['desired_shards', 'counter']]));
+    expect(result).toEqual([{ metricName: 'desired_shards', labels: [], metricType: 'counter' }]);
+  });
+
+  test('merges all three overrides on the same active metric', () => {
+    const result = buildSourceMetricsOverride(
+      'desired_shards',
+      '5m',
+      new Map([['desired_shards', 'max_over_time']]),
+      new Map([['desired_shards', 'gauge']])
+    );
+    expect(result).toEqual([
+      {
+        metricName: 'desired_shards',
+        labels: [],
+        customRateInterval: '5m',
+        customFunction: 'max_over_time',
+        metricType: 'gauge',
+      },
+    ]);
+  });
+
+  test('merges multiple metrics with different override combinations', () => {
+    const result = buildSourceMetricsOverride(
+      'active_metric',
+      '5m',
+      new Map([['fn_metric', 'min_over_time']]),
+      new Map([
+        ['active_metric', 'counter'],
+        ['type_only_metric', 'histogram'],
+      ])
+    );
+    expect(result).toEqual([
+      { metricName: 'active_metric', labels: [], customRateInterval: '5m', metricType: 'counter' },
+      { metricName: 'fn_metric', labels: [], customFunction: 'min_over_time' },
+      { metricName: 'type_only_metric', labels: [], metricType: 'histogram' },
+    ]);
+  });
+
+  test('does not duplicate metrics that appear in both customFunction and metricType maps', () => {
+    const result = buildSourceMetricsOverride(
+      undefined,
+      undefined,
+      new Map([['metric', 'max_over_time']]),
+      new Map([['metric', 'gauge']])
+    );
+    expect(result).toEqual([
+      { metricName: 'metric', labels: [], customFunction: 'max_over_time', metricType: 'gauge' },
+    ]);
   });
 });

--- a/src/AppDataTrail/sourceMetricsUrlSync.ts
+++ b/src/AppDataTrail/sourceMetricsUrlSync.ts
@@ -1,6 +1,9 @@
 import { type SceneObjectUrlValues } from '@grafana/scenes';
 
 import { type SourceMetrics } from '../exposedComponents/SourceMetrics/types';
+import { type KgMetricType } from '../shared/GmdVizPanel/matchers/mapKgMetricType';
+
+const VALID_KG_METRIC_TYPES = new Set<KgMetricType>(['counter', 'gauge', 'histogram', 'summary']);
 
 // Multi-value URL value parser for the customFunction key.
 // The scenes URL layer collapses a single-entry array to a bare string and keeps
@@ -33,6 +36,32 @@ export function parseCustomFunctionValues(raw: SceneObjectUrlValues[string]): Ma
   return result;
 }
 
+export function parseMetricTypeValues(raw: SceneObjectUrlValues[string]): Map<string, KgMetricType> {
+  let values: string[];
+  if (Array.isArray(raw)) {
+    values = raw;
+  } else if (typeof raw === 'string' && raw) {
+    values = [raw];
+  } else {
+    values = [];
+  }
+
+  const result = new Map<string, KgMetricType>();
+  for (const item of values) {
+    const dashIdx = item.indexOf('-');
+    if (dashIdx <= 0) {
+      continue;
+    }
+    const type = item.slice(0, dashIdx);
+    const metricName = item.slice(dashIdx + 1);
+    if (!metricName || !VALID_KG_METRIC_TYPES.has(type as KgMetricType)) {
+      continue;
+    }
+    result.set(metricName, type as KgMetricType);
+  }
+  return result;
+}
+
 // Build a synthesised sourceMetrics array from URL-parsed values for standalone
 // hydration. Merges the single-entry customRateInterval payload (active metric
 // only) with the multi-entry customFunction payload. Returns undefined when no
@@ -41,13 +70,17 @@ export function parseCustomFunctionValues(raw: SceneObjectUrlValues[string]): Ma
 export function buildSourceMetricsOverride(
   metric: string | undefined,
   customRateInterval: string | undefined,
-  customFunctionByMetric: Map<string, string>
+  customFunctionByMetric: Map<string, string>,
+  metricTypeByMetric: Map<string, KgMetricType> = new Map()
 ): SourceMetrics | undefined {
   const allMetricNames = new Set<string>();
   if (metric) {
     allMetricNames.add(metric);
   }
   for (const name of customFunctionByMetric.keys()) {
+    allMetricNames.add(name);
+  }
+  for (const name of metricTypeByMetric.keys()) {
     allMetricNames.add(name);
   }
 
@@ -60,5 +93,6 @@ export function buildSourceMetricsOverride(
     labels: [],
     ...(name === metric && customRateInterval ? { customRateInterval } : {}),
     ...(customFunctionByMetric.has(name) ? { customFunction: customFunctionByMetric.get(name) } : {}),
+    ...(metricTypeByMetric.has(name) ? { metricType: metricTypeByMetric.get(name) } : {}),
   }));
 }

--- a/src/MetricScene/Breakdown/LabelBreakdownScene.tsx
+++ b/src/MetricScene/Breakdown/LabelBreakdownScene.tsx
@@ -69,10 +69,12 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
 
   private async updateBody(groupByVariable: QueryVariable) {
     const { metric: name } = this.state;
+    const trail = getTrailFor(this);
+    const entry = trail.state.sourceMetrics?.find((s) => s.metricName === name);
 
     const metric = {
       name,
-      type: await getMetricType(name, getTrailFor(this)),
+      type: await getMetricType(name, trail, entry?.metricType),
     };
 
     const newBody = groupByVariable.hasAllValue()

--- a/src/MetricScene/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
+++ b/src/MetricScene/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
@@ -197,6 +197,7 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
         groupBy: label,
         data: sceneGraph.getData(this),
         customRateInterval: entry?.customRateInterval,
+        kgMetricType: entry?.metricType,
       },
     });
   }
@@ -277,6 +278,7 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
             ...prefMetricConfig?.queryOptions,
             labelMatchers: [{ key: label, operator: '=', value: labelValue }],
             customRateInterval: entry?.customRateInterval,
+            kgMetricType: entry?.metricType,
           },
         });
 

--- a/src/MetricScene/MetricActionBar.tsx
+++ b/src/MetricScene/MetricActionBar.tsx
@@ -72,6 +72,7 @@ export function getActionViewsDefinitions(): ActionViewDefinition[] {
         new QueryResultsScene({
           metric: metricScene.state.metric,
           queryResultsComponent: metricScene.state.queryResultsComponent,
+          kgMetricType: metricScene.state.kgMetricType,
         }),
       description: t('action-bar.tab.query-results-description', 'Instant query data in table format'),
       backgroundTask: () => {},
@@ -108,6 +109,7 @@ export const actionViewsDefinitions: ActionViewDefinition[] = [
       new QueryResultsScene({
         metric: metricScene.state.metric,
         queryResultsComponent: metricScene.state.queryResultsComponent,
+        kgMetricType: metricScene.state.kgMetricType,
       }),
     description: 'Instant query data in table format',
     backgroundTask: () => {},

--- a/src/MetricScene/MetricGraphScene.tsx
+++ b/src/MetricScene/MetricGraphScene.tsx
@@ -26,6 +26,7 @@ import { PANEL_HEIGHT } from 'shared/GmdVizPanel/config/panel-heights';
 import { QUERY_RESOLUTION } from 'shared/GmdVizPanel/config/query-resolutions';
 import { GmdVizPanel } from 'shared/GmdVizPanel/GmdVizPanel';
 import { isClassicHistogramMetric } from 'shared/GmdVizPanel/matchers/isClassicHistogramMetric';
+import { type KgMetricType } from 'shared/GmdVizPanel/matchers/mapKgMetricType';
 import { useResizeObserver } from 'shared/hooks/useResizeObserver';
 
 import { MetricActionBar } from './MetricActionBar';
@@ -50,9 +51,11 @@ export class MetricGraphScene extends SceneObjectBase<MetricGraphSceneState> {
   public constructor({
     metric,
     customRateInterval,
+    kgMetricType,
   }: {
     metric: MetricGraphSceneState['metric'];
     customRateInterval?: string;
+    kgMetricType?: KgMetricType;
   }) {
     super({
       metric,
@@ -88,6 +91,7 @@ export class MetricGraphScene extends SceneObjectBase<MetricGraphSceneState> {
               queryOptions: {
                 resolution: QUERY_RESOLUTION.HIGH,
                 customRateInterval,
+                kgMetricType,
               },
             }),
           }),
@@ -143,13 +147,15 @@ export class MetricGraphScene extends SceneObjectBase<MetricGraphSceneState> {
       return; // Skip the rest of the setup for embeddedMini
     }
 
-    const metadata = await trail.getMetadataForMetric(metric);
-
     const [gmdVizPanel] = sceneGraph.findDescendents(this, GmdVizPanel);
     const { metricType } = gmdVizPanel.state;
 
-    if (metadata) {
-      gmdVizPanel.update({ description: getMetricDescription(metadata) }, {});
+    const entry = trail.state.sourceMetrics?.find((s) => s.metricName === metric);
+    if (!entry?.metricType) {
+      const metadata = await trail.getMetadataForMetric(metric);
+      if (metadata) {
+        gmdVizPanel.update({ description: getMetricDescription(metadata) }, {});
+      }
     }
 
     if (metricType === 'classic-histogram') {

--- a/src/MetricScene/MetricScene.tsx
+++ b/src/MetricScene/MetricScene.tsx
@@ -15,6 +15,8 @@ import { VariableHide } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
 import React, { useEffect } from 'react';
 
+import { type KgMetricType } from 'shared/GmdVizPanel/matchers/mapKgMetricType';
+
 import { RefreshMetricsEvent, VAR_FILTERS, VAR_METRIC, type MakeOptional } from '../shared/shared';
 import { GroupByVariable } from './Breakdown/GroupByVariable';
 import { EventActionViewDataLoadComplete } from './EventActionViewDataLoadComplete';
@@ -29,6 +31,8 @@ interface MetricSceneState extends SceneObjectState {
   metric: string;
   // KG-supplied per-metric override (issue #1130). Forwarded to MetricGraphScene and the main GmdVizPanel.
   customRateInterval?: string;
+  // KG-supplied per-metric type override (issue #1058). Forwarded to MetricGraphScene and the main GmdVizPanel.
+  kgMetricType?: KgMetricType;
   actionView?: ActionViewType;
   relatedLogsCount?: number;
   isQueryResultsAvailable?: boolean;
@@ -57,7 +61,7 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
   public constructor(state: MakeOptional<MetricSceneState, 'body'>) {
     super({
       $variables: state.$variables ?? getVariableSet(state.metric),
-      body: state.body ?? new MetricGraphScene({ metric: state.metric, customRateInterval: state.customRateInterval }),
+      body: state.body ?? new MetricGraphScene({ metric: state.metric, customRateInterval: state.customRateInterval, kgMetricType: state.kgMetricType }),
       ...state,
     });
 

--- a/src/MetricScene/QueryResults/QueryResultsScene.tsx
+++ b/src/MetricScene/QueryResults/QueryResultsScene.tsx
@@ -15,6 +15,7 @@ import React, { createElement, useLayoutEffect, useRef, useState } from 'react';
 import { type DataTrail } from 'AppDataTrail/DataTrail';
 import { buildQueryExpression } from 'shared/GmdVizPanel/buildQueryExpression';
 import { getMetricTypeSync, type MetricType } from 'shared/GmdVizPanel/matchers/getMetricType';
+import { type KgMetricType } from 'shared/GmdVizPanel/matchers/mapKgMetricType';
 import { useResizeObserver } from 'shared/hooks/useResizeObserver';
 import { trailDS } from 'shared/shared';
 
@@ -59,9 +60,11 @@ export class QueryResultsScene extends SceneObjectBase<QueryResultsSceneState> {
   constructor({
     metric,
     queryResultsComponent,
+    kgMetricType,
   }: {
     metric: QueryResultsSceneState['metric'];
     queryResultsComponent?: QueryResultsSceneState['queryResultsComponent'];
+    kgMetricType?: KgMetricType;
   }) {
     super({
       metric,
@@ -72,7 +75,7 @@ export class QueryResultsScene extends SceneObjectBase<QueryResultsSceneState> {
           {
             refId: 'instant-query-results',
             expr: buildQueryExpression({
-              metric: { name: metric, type: getMetricTypeSync(metric) as MetricType },
+              metric: { name: metric, type: getMetricTypeSync(metric, kgMetricType) as MetricType },
               addIgnoreUsageFilter: true,
             }),
             instant: true,

--- a/src/MetricsReducer/MetricsGroupByList/MetricsGroupByRow.tsx
+++ b/src/MetricsReducer/MetricsGroupByList/MetricsGroupByRow.tsx
@@ -130,6 +130,7 @@ export class MetricsGroupByRow extends SceneObjectBase<MetricsGroupByRowState> {
                 queryOptions: {
                   labelMatchers: [{ key: labelName, operator: '=', value: labelValue }],
                   customRateInterval: entry?.customRateInterval,
+                  kgMetricType: entry?.metricType,
                 },
               }),
             }),

--- a/src/MetricsReducer/MetricsList/MetricsList.tsx
+++ b/src/MetricsReducer/MetricsList/MetricsList.tsx
@@ -91,6 +91,7 @@ export class MetricsList extends SceneObjectBase<MetricsListState> {
                 },
                 queryOptions: {
                   customRateInterval: entry?.customRateInterval,
+                  kgMetricType: entry?.metricType,
                 },
               }),
             }),

--- a/src/exposedComponents/SourceMetrics/behaviors/HistogramPercentilesDefaultBehavior.ts
+++ b/src/exposedComponents/SourceMetrics/behaviors/HistogramPercentilesDefaultBehavior.ts
@@ -4,6 +4,7 @@ import { GmdVizPanel } from 'shared/GmdVizPanel/GmdVizPanel';
 import { getMetricTypeSync } from 'shared/GmdVizPanel/matchers/getMetricType';
 import { PREF_KEYS } from 'shared/user-preferences/pref-keys';
 import { userStorage } from 'shared/user-preferences/userStorage';
+import { getTrailFor } from 'shared/utils/utils';
 
 /**
  * Behavior that sets histogram metrics to use percentiles as the default visualization.
@@ -29,7 +30,8 @@ export class HistogramPercentilesDefaultBehavior extends SceneObjectBase<SceneOb
           }
 
           const { metric, panelConfig } = panel.state;
-          const metricType = getMetricTypeSync(metric);
+          const entry = getTrailFor(panel).state.sourceMetrics?.find((s) => s.metricName === metric);
+          const metricType = getMetricTypeSync(metric, entry?.metricType);
 
           // Check if user already has a preference for this metric
           const userPrefs = userStorage.getItem(PREF_KEYS.METRIC_PREFS) || {};

--- a/src/shared/GmdVizPanel/GmdVizPanel.tsx
+++ b/src/shared/GmdVizPanel/GmdVizPanel.tsx
@@ -27,6 +27,7 @@ import { type PrometheusFunction } from './config/promql-functions';
 import { QUERY_RESOLUTION } from './config/query-resolutions';
 import { getMetricType, getMetricTypeSync, type Metric, type MetricType } from './matchers/getMetricType';
 import { getPanelTypeForMetricSync } from './matchers/getPanelTypeForMetric';
+import { type KgMetricType } from './matchers/mapKgMetricType';
 import { type PanelType } from './types/available-panel-types';
 import { panelBuilder } from './types/panelBuilder';
 
@@ -78,6 +79,8 @@ export type QueryConfig = {
   // KG-supplied per-metric override (issue #1130). Replaces $__rate_interval inside rate(metric[X]).
   // Prometheus duration string, e.g. '5m', '1h'.
   customRateInterval?: string;
+  // KG-supplied per-metric type override (issue #1058). Skips name-suffix heuristic and /api/v1/metadata fetch.
+  kgMetricType?: KgMetricType;
 };
 
 export type QueryOptions = {
@@ -87,6 +90,7 @@ export type QueryOptions = {
   queries?: QueryDefs;
   data?: QueryConfig['data'];
   customRateInterval?: QueryConfig['customRateInterval'];
+  kgMetricType?: QueryConfig['kgMetricType'];
 };
 
 /* GmdVizPanelState */
@@ -118,7 +122,7 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
     // we want a metric and panel type now to be able to render the panel as soon as possible after activation
     // so we use sync/fast heuristsics before using a 100% correct async method in onActivate() (fetching the metric metadata)
     // note: when the metric type changes after fetching the metadata, the correct type is cached and is available in getMetricTypeSync()
-    const metricType = getMetricTypeSync(metric) as MetricType;
+    const metricType = getMetricTypeSync(metric, queryOptions?.kgMetricType) as MetricType;
     const prefConfig = discardUserPrefs ? undefined : getPreferredConfigForMetric(metric);
 
     super({
@@ -126,7 +130,7 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
       metric,
       metricType,
       panelConfig: {
-        type: panelOptions?.type || getPanelTypeForMetricSync(metric),
+        type: panelOptions?.type || getPanelTypeForMetricSync(metric, queryOptions?.kgMetricType),
         title: metric,
         height: PANEL_HEIGHT.M,
         headerActions: ({ metric }) => [new SelectAction({ metric: metric.name })],
@@ -158,7 +162,11 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
   }
 
   private async checkMetricMetadata() {
-    const { metric } = this.state;
+    const { metric, queryConfig } = this.state;
+
+    if (queryConfig.kgMetricType) {
+      return;
+    }
 
     const metricTypeFromMetadata = await getMetricType(metric, getTrailFor(this));
 
@@ -179,7 +187,8 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
 
     // in addition to using the metadata fetched in src/helpers/MetricDatasourceHelper.ts to determine if the metric is a native histogram or not,
     // we give another chance to display it properly by looking into the data frame type received
-    if (!['classic-histogram', 'native-histogram'].includes(metricType)) {
+    const isKgHistogramHint = this.state.queryConfig.kgMetricType === 'histogram';
+    if (isKgHistogramHint || !['classic-histogram', 'native-histogram'].includes(metricType)) {
       const bodySub = (body?.state.$data as SceneDataProvider)?.subscribeToState((newState) => {
         if (newState.data?.state !== LoadingState.Done) {
           return;

--- a/src/shared/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm.tsx
+++ b/src/shared/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm.tsx
@@ -76,8 +76,8 @@ export class ConfigurePanelForm extends SceneObjectBase<ConfigurePanelFormState>
     const { metric } = this.state;
     const trail = getTrailFor(this);
     const prefConfig = getPreferredConfigForMetric(metric.name);
-    const presets = await getConfigPresetsForMetric(metric.name, trail);
     const entry = trail.state.sourceMetrics?.find((s) => s.metricName === metric.name);
+    const presets = await getConfigPresetsForMetric(metric.name, trail, entry?.metricType);
 
     // if not found in the user preferences, we use the first preset
     // it always works because the presets are organized to always have the default one as the first element (see GmdVizPanel/config/presets)
@@ -113,8 +113,9 @@ export class ConfigurePanelForm extends SceneObjectBase<ConfigurePanelFormState>
               },
               queryOptions: {
                 ...option.queryOptions,
-                // KG override wins over preset/user-pref values (issue #1130).
+                // KG overrides win over preset/user-pref values (issues #1130, #1058).
                 ...(entry?.customRateInterval !== undefined && { customRateInterval: entry.customRateInterval }),
+                ...(entry?.metricType !== undefined && { kgMetricType: entry.metricType }),
               },
             }),
           }),

--- a/src/shared/GmdVizPanel/config/presets/getConfigPresetsForMetric.ts
+++ b/src/shared/GmdVizPanel/config/presets/getConfigPresetsForMetric.ts
@@ -1,5 +1,6 @@
 import { type DataTrail } from 'AppDataTrail/DataTrail';
 import { getMetricType } from 'shared/GmdVizPanel/matchers/getMetricType';
+import { type KgMetricType } from 'shared/GmdVizPanel/matchers/mapKgMetricType';
 
 import { DEFAULT_TIMESERIES_AGE_PRESETS } from './config-presets-ages';
 import { DEFAULT_HISTOGRAMS_PRESETS } from './config-presets-histograms';
@@ -8,8 +9,8 @@ import { DEFAULT_STATUS_UP_DOWN_PRESETS } from './config-presets-status-updown';
 import { DEFAULT_TIMESERIES_PRESETS, DEFAULT_TIMESERIES_RATE_PRESETS } from './config-presets-timeseries';
 import { type PanelConfigPreset } from './types';
 
-export async function getConfigPresetsForMetric(metric: string, dataTrail: DataTrail): Promise<PanelConfigPreset[]> {
-  const metricType = await getMetricType(metric, dataTrail);
+export async function getConfigPresetsForMetric(metric: string, dataTrail: DataTrail, kgMetricType?: KgMetricType): Promise<PanelConfigPreset[]> {
+  const metricType = await getMetricType(metric, dataTrail, kgMetricType);
 
   switch (metricType) {
     case 'counter':

--- a/src/shared/GmdVizPanel/matchers/__tests__/getMetricType.test.ts
+++ b/src/shared/GmdVizPanel/matchers/__tests__/getMetricType.test.ts
@@ -65,6 +65,24 @@ describe('getMetricTypeSync(metric)', () => {
       expect(getMetricTypeSync('histogram_bucket_sum')).toBe('counter');
     });
   });
+
+  describe('with KG metricType override', () => {
+    it('returns mapped type when kgMetricType is set, skipping heuristic', () => {
+      expect(getMetricTypeSync('my_recording_rule', 'counter')).toBe('counter');
+    });
+
+    it('maps histogram to classic-histogram', () => {
+      expect(getMetricTypeSync('my_recording_rule', 'histogram')).toBe('classic-histogram');
+    });
+
+    it('maps summary to gauge', () => {
+      expect(getMetricTypeSync('my_recording_rule', 'summary')).toBe('gauge');
+    });
+
+    it('overrides heuristic completely — counter metric becomes gauge with KG override', () => {
+      expect(getMetricTypeSync('http_requests_total', 'gauge')).toBe('gauge');
+    });
+  });
 });
 
 describe('getMetricType(metric, dataTrail)', () => {
@@ -170,6 +188,35 @@ describe('getMetricType(metric, dataTrail)', () => {
       const result = await getMetricType('process_start_timestamp_seconds', dataTrail);
 
       expect(result).toBe('age');
+      expect(dataTrail.getMetadataForMetric).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with KG metricType override', () => {
+    it('returns mapped type immediately without metadata fetch', async () => {
+      const dataTrail = createMockDataTrail('gauge');
+
+      const result = await getMetricType('my_recording_rule', dataTrail, 'counter');
+
+      expect(result).toBe('counter');
+      expect(dataTrail.getMetadataForMetric).not.toHaveBeenCalled();
+    });
+
+    it('maps histogram to classic-histogram without metadata fetch', async () => {
+      const dataTrail = createMockDataTrail('histogram');
+
+      const result = await getMetricType('my_recording_rule', dataTrail, 'histogram');
+
+      expect(result).toBe('classic-histogram');
+      expect(dataTrail.getMetadataForMetric).not.toHaveBeenCalled();
+    });
+
+    it('maps summary to gauge without metadata fetch', async () => {
+      const dataTrail = createMockDataTrail('counter');
+
+      const result = await getMetricType('my_recording_rule', dataTrail, 'summary');
+
+      expect(result).toBe('gauge');
       expect(dataTrail.getMetadataForMetric).not.toHaveBeenCalled();
     });
   });

--- a/src/shared/GmdVizPanel/matchers/__tests__/getPanelTypeForMetric.test.ts
+++ b/src/shared/GmdVizPanel/matchers/__tests__/getPanelTypeForMetric.test.ts
@@ -124,4 +124,47 @@ describe('getPanelTypeForMetric(metric, dataTrail)', () => {
       expect(result).toBe('timeseries');
     });
   });
+
+  describe('with KG metricType override', () => {
+    it('returns "heatmap" when KG says histogram', async () => {
+      const dataTrail = createMockDataTrail();
+
+      const result = await getPanelTypeForMetric('my_recording_rule', dataTrail, 'histogram');
+
+      expect(result).toBe('heatmap');
+      expect(dataTrail.getMetadataForMetric).not.toHaveBeenCalled();
+    });
+
+    it('returns "timeseries" when KG says counter', async () => {
+      const dataTrail = createMockDataTrail();
+
+      const result = await getPanelTypeForMetric('my_recording_rule', dataTrail, 'counter');
+
+      expect(result).toBe('timeseries');
+      expect(dataTrail.getMetadataForMetric).not.toHaveBeenCalled();
+    });
+
+    it('returns "timeseries" when KG says gauge', async () => {
+      const dataTrail = createMockDataTrail();
+
+      const result = await getPanelTypeForMetric('my_recording_rule', dataTrail, 'gauge');
+
+      expect(result).toBe('timeseries');
+      expect(dataTrail.getMetadataForMetric).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('getPanelTypeForMetricSync with KG override', () => {
+  it('returns "heatmap" when KG says histogram', () => {
+    expect(getPanelTypeForMetricSync('my_recording_rule', 'histogram')).toBe('heatmap');
+  });
+
+  it('returns "timeseries" when KG says counter', () => {
+    expect(getPanelTypeForMetricSync('my_recording_rule', 'counter')).toBe('timeseries');
+  });
+
+  it('overrides suffix-based detection', () => {
+    expect(getPanelTypeForMetricSync('request_duration_bucket', 'counter')).toBe('timeseries');
+  });
 });

--- a/src/shared/GmdVizPanel/matchers/__tests__/mapKgMetricType.test.ts
+++ b/src/shared/GmdVizPanel/matchers/__tests__/mapKgMetricType.test.ts
@@ -1,0 +1,19 @@
+import { mapKgMetricType } from '../mapKgMetricType';
+
+describe('mapKgMetricType', () => {
+  it('maps counter to counter', () => {
+    expect(mapKgMetricType('counter')).toBe('counter');
+  });
+
+  it('maps gauge to gauge', () => {
+    expect(mapKgMetricType('gauge')).toBe('gauge');
+  });
+
+  it('maps histogram to classic-histogram', () => {
+    expect(mapKgMetricType('histogram')).toBe('classic-histogram');
+  });
+
+  it('maps summary to gauge', () => {
+    expect(mapKgMetricType('summary')).toBe('gauge');
+  });
+});

--- a/src/shared/GmdVizPanel/matchers/getMetricType.ts
+++ b/src/shared/GmdVizPanel/matchers/getMetricType.ts
@@ -5,6 +5,7 @@ import { isClassicHistogramMetric } from './isClassicHistogramMetric';
 import { isCounterMetric } from './isCounterMetric';
 import { isInfoMetric } from './isInfoMetric';
 import { isStatusUpDownMetric } from './isStatusUpDownMetric';
+import { mapKgMetricType, type KgMetricType } from './mapKgMetricType';
 
 export type MetricType =
   | 'info'
@@ -20,7 +21,11 @@ export type Metric = {
   type: MetricType;
 };
 
-export async function getMetricType(metric: string, dataTrail: DataTrail): Promise<MetricType> {
+export async function getMetricType(metric: string, dataTrail: DataTrail, kgMetricType?: KgMetricType): Promise<MetricType> {
+  if (kgMetricType) {
+    return mapKgMetricType(kgMetricType);
+  }
+
   const metricType = getMetricTypeSync(metric);
 
   if (metricType === 'gauge') {
@@ -48,7 +53,11 @@ export async function getMetricType(metric: string, dataTrail: DataTrail): Promi
 /**
  * A sync version to use when performance is more important than correctness. If not, use the async version above.
  */
-export function getMetricTypeSync(metric: string): Omit<MetricType, 'native-histogram'> {
+export function getMetricTypeSync(metric: string, kgMetricType?: KgMetricType): Omit<MetricType, 'native-histogram'> {
+  if (kgMetricType) {
+    return mapKgMetricType(kgMetricType);
+  }
+
   if (isCounterMetric(metric)) {
     return 'counter';
   }

--- a/src/shared/GmdVizPanel/matchers/getPanelTypeForMetric.ts
+++ b/src/shared/GmdVizPanel/matchers/getPanelTypeForMetric.ts
@@ -1,14 +1,15 @@
 import { type DataTrail } from 'AppDataTrail/DataTrail';
 
 import { getMetricType, getMetricTypeSync } from './getMetricType';
+import { type KgMetricType } from './mapKgMetricType';
 import { type PanelType } from '../types/available-panel-types';
 
 /**
  * These are functions that receive a metric name to determine in which panel type they should be displayed.
  * Note that they don't consider user preferences stored in user storage.
  */
-export async function getPanelTypeForMetric(metric: string, dataTrail: DataTrail): Promise<PanelType> {
-  const metricType = await getMetricType(metric, dataTrail);
+export async function getPanelTypeForMetric(metric: string, dataTrail: DataTrail, kgMetricType?: KgMetricType): Promise<PanelType> {
+  const metricType = await getMetricType(metric, dataTrail, kgMetricType);
 
   switch (metricType) {
     case 'classic-histogram':
@@ -30,8 +31,8 @@ export async function getPanelTypeForMetric(metric: string, dataTrail: DataTrail
  * if the type definded in the metric's metadata differs from the heuristics used in getMetricTypeSync().
  * In both case, if correctness is key, use the async version above that fetch the metric metadata for correctness.
  */
-export function getPanelTypeForMetricSync(metric: string): PanelType {
-  const metricType = getMetricTypeSync(metric);
+export function getPanelTypeForMetricSync(metric: string, kgMetricType?: KgMetricType): PanelType {
+  const metricType = getMetricTypeSync(metric, kgMetricType);
 
   switch (metricType) {
     case 'classic-histogram':

--- a/src/shared/GmdVizPanel/matchers/mapKgMetricType.ts
+++ b/src/shared/GmdVizPanel/matchers/mapKgMetricType.ts
@@ -1,0 +1,16 @@
+import { type MetricType } from './getMetricType';
+
+export type KgMetricType = 'counter' | 'gauge' | 'histogram' | 'summary';
+
+export function mapKgMetricType(kgType: KgMetricType): MetricType {
+  switch (kgType) {
+    case 'counter':
+      return 'counter';
+    case 'gauge':
+      return 'gauge';
+    case 'histogram':
+      return 'classic-histogram';
+    case 'summary':
+      return 'gauge';
+  }
+}


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/metrics-drilldown/issues/1058
Resolves https://github.com/grafana/metrics-drilldown/issues/1058

When KG sets `metricType` on a `SourceMetrics` entry, GMD skips its name-suffix heuristic and `/api/v1/metadata` fetch, using the KG hint for all type-driven decisions (rate-wrapping, panel type, aggregation, configurator presets, breakdown). When `metricType` is absent, behavior is unchanged.

**Depends on:** [asserts-app-plugin PR #3278](https://github.com/grafana/asserts-app-plugin/pull/3278) (type declaration, already merged on the asserts side).

### 📖 Summary of the changes

**Type mapping (`mapKgMetricType.ts`):** KG sends 4 Prometheus metadata values (`counter | gauge | histogram | summary`). These are mapped to GMD's 7-value internal `MetricType`:
- `counter` → `counter`, `gauge` → `gauge`, `histogram` → `classic-histogram`, `summary` → `gauge`

**Override model:** Replace — when `metricType` is present, skip both the heuristic and the metadata fetch entirely. KG only populates `metricType` on metrics where the heuristic fails (recording rules, custom metrics without standard suffixes).

**Type resolution helpers** (`getMetricType`, `getMetricTypeSync`, `getPanelTypeForMetric*`, `getConfigPresetsForMetric`): Accept optional `kgMetricType` param. When set, return the mapped type immediately.

**GmdVizPanel:** `kgMetricType` added to `QueryConfig`/`QueryOptions`. Constructor uses it for sync type resolution. `checkMetricMetadata()` skips when override is set. Histogram promotion guard still allows runtime HeatmapCells → `native-histogram` promotion when KG says `'histogram'`.

**5 construction sites** (`MetricsList`, `MetricsGroupByRow`, `MetricLabelValuesList` ×2, `ConfigurePanelForm`): Extract `entry?.metricType` alongside existing `customRateInterval`.

**4 direct call sites** (`LabelBreakdownScene`, `HistogramPercentilesDefaultBehavior`, `QueryResultsScene`/`MetricActionBar`, `getConfigPresetsForMetric`): Look up sourceMetrics entry and pass override to type helpers.

**MetricGraphScene.onActivate():** Skips the `/api/v1/metadata` fetch entirely when KG override is set.

**URL serialization:** `metricType` key added to `_urlSync`. Format: `metricType={kgType}-{metricName}`. Delimiter `-` is safe (KG types are dash-free; Prometheus names can't contain `-`). Split on first `-` to recover parts.

### 🧪 How to test?

**Unit tests (21 new):**
- `mapKgMetricType.test.ts`: all 4 mappings
- `getMetricType.test.ts`: override skips heuristic, override skips metadata fetch
- `getPanelTypeForMetric.test.ts`: override flows through
- `DataTrail.test.tsx`: URL round-trip for `metricType` key

**Manual smoke (embedded):**
1. Temp patch: add `metricType: 'counter'` to a recording-rule entry in `useAssertionSourceMetrics`
2. Open RCA Workbench for that insight
3. Confirm: no `GET /api/v1/metadata?metric=<name>` in network tab, correct `rate()` wrapping, URL contains `metricType=counter-<metricName>`

**Manual smoke (standalone deep-link):**
1. Open URL with `&metricType=counter-<metric>`
2. Confirm panel renders with counter type
3. Refresh — URL round-trips correctly

**Breakdown propagation:**
1. From a single-metric override case, open the Breakdown tab
2. Confirm every breakdown panel uses the overridden type

```
yarn test
```