### PR TITLE
chore(ci): bump plugin-ci-workflows to v10.1.0 and disable attestation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
         github.event_name == 'push' &&
         contains(github.event.head_commit.message, 'pnpm version')
       )
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v9.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v10.1.0
     permissions:
       contents: write
       id-token: write
@@ -25,7 +25,7 @@ jobs:
     with:
       branch: ${{ github.event_name == 'push' && github.ref_name || github.ref }}
       environment: ${{ (github.event_name == 'push' && github.ref_name == 'main') && 'dev,ops' || 'none' }}
-      attestation: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+      attestation: false
       grafana-cloud-deployment-type: provisioned
       auto-merge-environments: dev,ops
       argo-workflow-slack-channel: '#proj-metricsdrilldown-cd'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,10 +41,10 @@ jobs:
         (github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'pnpm version')) ||
         (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
       )
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v9.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v10.1.0
     with:
       environment: 'prod' # publishing to 'prod' will also deploy to 'ops' and 'dev'
-      attestation: true # this guarantees that the plugin was built from the source code provided in the release
+      attestation: false
       run-playwright: true
       run-playwright-docker: false
       run-playwright-with-skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image || false }}


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/metrics-drilldown/actions/runs/28133400212/job/83315659725

The publish-to-catalog CI job is failing because the GCOM API now rejects the `provenanceAttestation` parameter.

### 📖 Summary of the changes

- Bump `plugin-ci-workflows` from `ci-cd-workflows/v9.0.0` to `ci-cd-workflows/v10.1.0` in both `ci-cd.yml` and `publish.yml`
- Disable `attestation` in both workflows to prevent the rejected `provenanceAttestation` field from being sent to GCOM

The upstream fix (commit `29b0fee` in `plugin-ci-workflows`) removes provenance attestation entirely but hasn't been tagged/released yet. Once it is, attestation can be re-enabled.

### 🧪 How to test?

1. Confirm CI passes on this PR
2. After merge, verify the publish workflow succeeds on `main`