### PR TITLE
docs: Add GenAI policy, contributor guide updates and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[BUG]:'
+labels: bug, needs-triage
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment**
+Grafana version, Prometheus/Mimir version, Metrics Drilldown plugin version, and browser (if relevant).
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**AI disclosure** (optional)
+See the [Generative AI Contribution Policy](https://github.com/grafana/metrics-drilldown/blob/main/docs/genai.md).
+
+- [ ] This issue was substantially generated with AI assistance.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[FEAT]:'
+labels: enhancement
+assignees: ''
+---
+
+**Description of the new feature**
+What problem does this feature solve? What are the pain points or missing capabilities?
+
+**Acceptance Criteria**
+A concise description of requirements.
+
+**AI disclosure** (optional)
+See the [Generative AI Contribution Policy](https://github.com/grafana/metrics-drilldown/blob/main/docs/genai.md).
+
+- [ ] This feature request was substantially generated with AI assistance.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,8 @@ Resolves <!-- Paste Github issue that is resolved by this pull request -->
 
 <!-- Summary of the most important changes in the code that will help your reviewers, the choices made and why -->
 
+- [ ] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/metrics-drilldown/blob/main/docs/genai.md))
+
 ### 🧪 How to test?
 
 <!-- Steps required to test the PR or a pointer to the relevant automated tests -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,11 @@
 
 - [Engineering Intent & Philosophy](./docs/project-intent.md): Read this to understand the "Why" behind our code decisions and our stance on abstraction vs. performance.
 - [Application Structure](./docs/application-structure.md): Read this to understand the overall application structure and how the different parts of the application are related.
+- [Contributing](./docs/contributing.md): Dev setup, issues vs PRs, i18n, PR checklist, and link to GenAI policy.
+- [Generative AI Contribution Policy](./docs/genai.md): Disclosure, acceptable use, and Metrics Drilldown-specific pitfalls for AI-assisted contributions.
 
 ## Usage
 
 This file is an index. Please read the linked files above for specific context during generation.
+
+**Human contributors:** follow [docs/contributing.md](docs/contributing.md) for how to file issues, open pull requests, run local checks, and use AI tools responsibly. The full GenAI policy is in [docs/genai.md](docs/genai.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,10 +2,11 @@
 
 Welcome! We're excited that you're interested in contributing. Below are some basic guidelines.
 
-## Workflow
+We love accepting contributions! To help us create a safe and positive community experience, we require all participants to adhere to the [Grafana Code of Conduct](https://github.com/grafana/grafana/blob/main/CODE_OF_CONDUCT.md).
 
-Grafana Metrics Drilldown follows a standard GitHub pull request workflow. If you're unfamiliar with this workflow, read the very helpful [Understanding the GitHub flow](https://guides.github.com/introduction/flow/) guide from GitHub.
+If your change is minor, please feel free to submit a [pull request](https://help.github.com/articles/about-pull-requests/). If your change is larger, or adds a feature, please file an issue beforehand so that we can discuss the change. You're welcome to file an implementation pull request immediately as well, although we generally lean towards discussing the change and then reviewing the implementation separately.
 
+## Filing issues
 You are welcome to create draft PRs at any stage of readiness - this
 can be helpful to ask for assistance or to develop an idea.
 Before a piece of work is finished, it should:
@@ -14,7 +15,36 @@ Before a piece of work is finished, it should:
 - Each commit should build towards the whole - don't leave in back-tracks and mistakes that you later corrected.
 - Have unit for new functionality or tests that would have caught the bug being fixed.
 
-## Requirements
+Use [GitHub Issues](https://github.com/grafana/metrics-drilldown/issues/new) to report bugs, ask questions, or propose larger changes.
+
+| Situation | What to do |
+|-----------|------------|
+| **Bug** — something is broken or regressed | [Open a bug report](https://github.com/grafana/metrics-drilldown/issues/new?template=bug_report.md) with reproduction steps, expected vs actual behavior, Grafana/Prometheus versions, and screenshots or recordings if helpful. |
+| **Small fix** — typo, clear one-file change, docs tweak | Open a pull request directly; link a related issue if one exists. |
+| **Feature or larger change** — new UI, behavior change, refactor | [Open a feature request](https://github.com/grafana/metrics-drilldown/issues/new?template=feature_request.md) to discuss scope, or open a draft PR with context in the description. |
+| **Documentation only** | Open a PR and add the `type/doc` label. |
+
+For bugs, check [Prometheus](https://prometheus.io/docs/) and [PromQL](https://prometheus.io/docs/prometheus/latest/querying/basics/) behavior first — a metric missing outside the selected time window may be expected, not a plugin bug.
+
+## Contribute to documentation
+
+Have a great new feature you want to contribute? Add docs for it!
+Find something missing in the docs? Update the docs!
+
+Use the [Writer's Toolkit](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-documentation/) for information on creating good documentation.
+The toolkit also provides [document templates](https://github.com/grafana/writers-toolkit/tree/main/docs/static/templates) to help get started.
+
+When you create a PR for documentation, add the `type/doc` label to identify the PR as contributing documentation.
+
+To preview the documentation locally, run `make docs` from the `docs/` directory. This uses the `grafana/docs` image which internally uses Hugo to generate the static site. The site is available on `localhost:3002/docs/`.
+
+> **Note** The `make docs` command uses a lot of memory. If it is crashing, make sure to increase the memory allocated to Docker and try again.
+
+## Contribute code
+
+### Development environment
+
+**Requirements:**
 
 - [Git](https://git-scm.com/downloads)
 - [Node.js](https://nodejs.org/en) v22
@@ -22,33 +52,48 @@ Before a piece of work is finished, it should:
 
 ## Get started
 
-1. Clone the repository `git clone git@github.com:grafana/metrics-drilldown.git`
-2. Install the dependencies: `pnpm install`
-3. Build the plugin in dev mode: `pnpm run dev`
-4. Start the Grafana server (with static data): `pnpm run server`
+1. Clone the repository: `git clone git@github.com:grafana/metrics-drilldown.git`
+2. Install dependencies: `pnpm install --frozen-lockfile --ignore-scripts`
+3. Start the dev build: `pnpm dev`
+4. Start Grafana locally: `pnpm server` (Grafana at http://localhost:3001)
 
 Then visit http://localhost:3001/a/grafana-metricsdrilldown-app/
 
-## Contribution guidelines
+See [AGENTS.md](../AGENTS.md) for architecture, Scenes patterns, and project conventions.
 
-For developing in this repo, requirements are generally managed by lint rules and pre-commit hooks. However, for other things, like code organization, please follow the pattern established by the rest of the repo.
+### Workflow
 
-### Lint and format your code
+Grafana Metrics Drilldown follows a standard GitHub pull request workflow. If you're unfamiliar with this workflow, read the [Understanding the GitHub flow](https://guides.github.com/introduction/flow/) guide from GitHub.
 
-We use [ESLint](https://eslint.org/) and [Prettier](https://prettier.io/) to lint and format our code. These will be run in a pre-commit hook, but you can also setup your IDE to run them on save.
+You are welcome to create draft PRs at any stage of readiness. Before a piece of work is finished, it should:
 
-### Commit messages and PR titles
+- Be organised into one or more commits, each with a commit message that describes all changes made in that commit ('why' more than 'what').
+- Each commit should build towards the whole — don't leave in back-tracks and mistakes that you later corrected.
+- Include unit tests for new functionality or tests that would have caught the bug being fixed.
 
-We use [conventional commits](https://www.conventionalcommits.org/) to format our commit messages. This allows us to automatically generate changelogs and version bumps.
+### Before you open a pull request
 
-When opening a Pull Request (PR), please make sure that the title is properly prefixed with one of the following type: `feat`, `fix`, `docs`, `test`, `ci`, `refactor`, `perf`, `chore` or `revert`.
+- Fill out the [pull request template](../.github/pull_request_template.md) with a clear summary and test steps.
+- Use a [conventional commit](https://www.conventionalcommits.org/) style PR title (enforced by CI).
+- Run `pnpm lint`, `pnpm typecheck`, and `pnpm test:ci` locally.
+- Add or update tests when behavior changes. Prefer focused unit tests (Jest) or Playwright E2E when UI flows are affected — see [E2E testing documentation](./end-to-end-testing.md).
+- Follow the pattern established by the rest of the repo for code organization. Lint and format are enforced by ESLint, Prettier, and pre-commit hooks; you can also configure your IDE to run them on save.
 
-### Test your code
+### Internationalization (i18n)
 
-We encourage you to write tests, whether they are unit tests or end-to-end tests. They will give us the confidence that the plugin behaves as intended and help us capture any regression early.
+User-facing strings must use Grafana i18n APIs — `t` or `Trans` from `@grafana/i18n` with a stable `i18nKey`, not hard-coded text in components.
 
-For end-to-end testing (E2E), please have a look at our [E2E testing documentation](./end-to-end-testing.md).
+After adding or changing copy:
 
-## Common problems & solutions
+1. Run `pnpm i18n-extract` to update `src/locales/en-US/grafana-metricsdrilldown-app.json`.
+2. Commit the extracted English locale file with your PR.
 
-...
+CI runs an i18n verification workflow on pull requests. Translations for other locales are managed via Crowdin and synced after changes merge to `main`; you do not need to hand-edit non-English locale files in most PRs.
+
+## Using AI and coding assistants
+
+Generative AI tools can help you explore the codebase, draft code, and write documentation. **You are always responsible for what you submit.**
+
+Read the full [Generative AI Contribution Policy](./genai.md) for acceptable use, disclosure, Metrics Drilldown-specific guidance (PromQL, Scenes, tests), and rules for agentic tools. Point coding assistants at [AGENTS.md](../AGENTS.md) for technical conventions.
+
+When AI generated the bulk of a pull request, check the disclosure box in the pull request template.

--- a/docs/genai.md
+++ b/docs/genai.md
@@ -1,0 +1,75 @@
+# Generative AI Contribution Policy
+
+Generative AI (GenAI) tools such as large language model (LLM) assistants can help you write code, documentation, and proposals for Grafana Metrics Drilldown. This policy explains what is an acceptable use of GenAI tools when contributing to the project.
+
+## Core principle
+
+**The human contributor is always in control and fully responsible for their contribution.**
+
+GenAI is a tool that assists you. It is not a substitute for your own understanding, judgment, or accountability. By submitting a contribution, you vouch for it as your own work, regardless of which tools helped you produce it. You are expected to understand, review, and provide rationale for everything you submit.
+
+## Acceptable use
+
+You are welcome to use GenAI tools to:
+
+- Write or refactor code and documentation, as long as you actively review and refine the output.
+- Understand the Metrics Drilldown codebase, Grafana Scenes, Prometheus, or PromQL before contributing or reviewing.
+- Draft issues, proposals, or design documents that you then verify and shape into your own reasoning.
+- Suggest tests, formatting, or lint fixes that you verify locally with `pnpm lint`, `pnpm typecheck`, and `pnpm test:ci`.
+
+In all cases, you remain the author. You read the output, you correct it, and you ensure your contribution meets the project's standards before submitting an issue, pull request, or comment.
+
+## Not acceptable
+
+Do not:
+
+- Submit unreviewed, bulk AI-generated content to pull requests, issues, or proposals. If you did not read and understand it, do not submit it.
+- Use GenAI as a substitute for human judgment in code review. An AI tool may help you understand a change, but the review and its conclusions must be yours.
+- File automated, bot-driven issues or pull requests from tools that have not been approved by the Metrics Drilldown team. This policy covers humans using AI assistance, not autonomous agents acting on their own, including agentic IDE tools that file pull requests without human review.
+- Paste generated text into a discussion without adding your own analysis and context.
+- Wire up an AI agent to respond automatically to reviewers or other community members on your behalf. If you want help from GenAI in a discussion, use it yourself and post in your own words, rather than connecting it directly to maintainers.
+- Submit pull requests without using the [pull request template](../.github/pull_request_template.md), or file bugs without reproduction steps and expected vs actual behavior.
+
+Maintainers may close low-effort AI-generated contributions. When they do, they should explain why and, where appropriate, offer guidance on how to improve the contribution. Repeated low-effort submissions will trigger stricter review, and maintainers may block repeat offenders from contributing.
+
+## Approved automation
+
+Some automated tools are explicitly approved and are an acceptable exception to the rule against bot-driven contributions. Examples include Dependabot, Copilot, release-please, and other repository automation maintained by the team. The team may approve more over time. Contributions from these tools are clearly marked as bot-generated so that reviewers can tell them apart from human contributions.
+
+## Disclosure
+
+When GenAI generates the **bulk** of a contribution, disclose it. For pull requests, check the **"This pull request was substantially generated with AI assistance"** box in the [pull request template](../.github/pull_request_template.md). For issues, use the optional AI disclosure in the [bug](../.github/ISSUE_TEMPLATE/bug_report.md) or [feature](../.github/ISSUE_TEMPLATE/feature_request.md) template. Minor, incidental help such as autocomplete or small edits does not need to be disclosed.
+
+Disclosure is not a mark against your contribution. It helps reviewers know where to focus, and it keeps expectations clear for everyone.
+
+## Metrics Drilldown-specific guidance
+
+LLMs frequently hallucinate PromQL syntax, Grafana Scenes APIs, Prometheus label lookup behavior, and metrics aggregation semantics. To reduce these errors, point the tool at authoritative sources rather than relying on its training data:
+
+- [AGENTS.md][agents] for architecture, Scenes patterns, and project conventions.
+- [docs/application-structure.md][application-structure] for UI layout, tabs, and URL state.
+- [Prometheus documentation][prometheus-docs] and [PromQL][promql-docs] for metrics query semantics.
+
+Always validate AI-generated code against the real component definitions and the project's checks before submitting. Run `pnpm lint`, `pnpm typecheck`, and `pnpm test:ci` locally. Use `pnpm lint:fix` for formatting when appropriate; do not commit unrelated drive-by changes.
+
+### Tests and formatting
+
+- Add tests that cover behavior you changed. Do not paste large blocks of shallow or incorrect AI-generated tests just to increase coverage.
+- Prefer focused Jest unit tests or Playwright E2E when UI flows are affected.
+- Match existing conventions in surrounding code. Keep scope tight — avoid unrelated refactors or new dependencies unless required and agreed.
+
+### User-facing strings
+
+New or changed UI copy must use translation keys (`t`, `Trans` from `@grafana/i18n`), not hard-coded strings. After editing copy, run `pnpm i18n-extract` and commit the updated `src/locales/en-US/grafana-metricsdrilldown-app.json`. CI verifies i18n markup; other locales are synced via Crowdin after merge to `main`.
+
+For larger changes or new features, file an [issue][new-issue] first so we can discuss scope. A proposal must reflect your own reasoning. AI may help you draft it, but you own the argument in the discussion.
+
+### Guidance for AI agents
+
+If you use an agentic tool, point it at [AGENTS.md][agents] first. Agents should prefer small, focused diffs; grep before reading entire large files; and respect frontend security practices (sanitized HTML/URLs, no unsafe DOM APIs).
+
+[agents]: ../AGENTS.md
+[application-structure]: application-structure.md
+[prometheus-docs]: https://grafana.com/docs/grafana/latest/datasources/prometheus/
+[promql-docs]: https://prometheus.io/docs/prometheus/latest/querying/basics/
+[new-issue]: https://github.com/grafana/metrics-drilldown/issues/new

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -67,7 +67,7 @@
       },
       {
         "name": "Report a bug",
-        "url": "https://github.com/grafana/metrics-drilldown/issues/new"
+        "url": "https://github.com/grafana/metrics-drilldown/issues/new?template=bug_report.md"
       }
     ]
   },


### PR DESCRIPTION
### ✨ Description

Expands docs/contributing.md with the Grafana Code of Conduct, when to file issues vs open PRs, local dev setup, PR checklist, and i18n workflow.

Adds docs/genai.md for AI-assisted contributions (disclosure, acceptable use, PromQL/Scenes guidance) and links it from AGENTS.md and the PR template.

Adds .github/ISSUE_TEMPLATE/ bug and feature templates with optional AI disclosure. Updates src/plugin.json bug report link to use the new template.
