### PR TITLE
fix(faro): deduplicate InlineBanner error reporting to prevent SLO breach

### DIFF
--- a/src/App/InlineBanner.test.tsx
+++ b/src/App/InlineBanner.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { InlineBanner } from './InlineBanner';
+import { logger } from '../shared/logger/logger';
+
+jest.mock('@grafana/i18n', () => ({
+  ...jest.requireActual('@grafana/i18n'),
+  t: (_key: string, defaultValue: string) => defaultValue,
+}));
+
+const mockLogger = logger as jest.Mocked<typeof logger>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('InlineBanner', () => {
+  it('renders without error prop', () => {
+    render(<InlineBanner severity="info" title="Info" message="All good" />);
+
+    expect(screen.getByText('Info')).toBeInTheDocument();
+    expect(screen.getByText('All good')).toBeInTheDocument();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it('logs error exactly once on initial render', () => {
+    const error = new Error('query failed');
+
+    render(<InlineBanner severity="error" title="Error" error={error} />);
+
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'query failed' }),
+      expect.objectContaining({ bannerTitle: 'Error' })
+    );
+  });
+
+  it('does not log again on re-render with the same error', () => {
+    const error = new Error('query failed');
+
+    const { rerender } = render(<InlineBanner severity="error" title="Error" error={error} />);
+
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+
+    rerender(<InlineBanner severity="error" title="Error" error={error} />);
+    rerender(<InlineBanner severity="error" title="Error" error={error} />);
+
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs again when error changes', () => {
+    const error1 = new Error('first error');
+    const error2 = new Error('second error');
+
+    const { rerender } = render(<InlineBanner severity="error" title="Error" error={error1} />);
+
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+
+    rerender(<InlineBanner severity="error" title="Error" error={error2} />);
+
+    expect(mockLogger.error).toHaveBeenCalledTimes(2);
+    expect(mockLogger.error).toHaveBeenLastCalledWith(
+      expect.objectContaining({ message: 'second error' }),
+      expect.objectContaining({ bannerTitle: 'Error' })
+    );
+  });
+
+  it('displays the formatted error message', () => {
+    const error = new Error('Something broke');
+
+    render(<InlineBanner severity="error" title="Error" error={error} />);
+
+    expect(screen.getByText('Something broke')).toBeInTheDocument();
+  });
+
+  it('displays HTTP status in error message when available', () => {
+    const error = Object.assign(new Error('Request failed'), { status: 500, statusText: 'Internal Server Error' });
+
+    render(<InlineBanner severity="error" title="Error" error={error} />);
+
+    expect(screen.getByText('Request failed (Internal Server Error - HTTP 500)')).toBeInTheDocument();
+  });
+});

--- a/src/App/InlineBanner.tsx
+++ b/src/App/InlineBanner.tsx
@@ -1,6 +1,6 @@
 import { t } from '@grafana/i18n';
 import { Alert, type AlertVariant } from '@grafana/ui';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import { ensureErrorObject } from './errorUtils';
 import { logger, type ErrorContext } from '../shared/logger/logger';
@@ -28,17 +28,21 @@ function formatErrorMessage(error: any) {
 }
 
 export function InlineBanner({ severity, title, message, error, errorContext, children }: Readonly<InlineBannerProps>) {
-  let errorObject;
+  const lastReportedError = useRef<unknown>(null);
 
-  if (error) {
-    errorObject = ensureErrorObject(error, t('inline-banner.unknown-error', 'Unknown error!'));
+  useEffect(() => {
+    if (error && error !== lastReportedError.current) {
+      lastReportedError.current = error;
+      const errorObj = ensureErrorObject(error, t('inline-banner.unknown-error', 'Unknown error!'));
+      logger.error(errorObj, {
+        ...(errorObj.cause || {}),
+        ...errorContext,
+        bannerTitle: title,
+      });
+    }
+  }, [error, errorContext, title]);
 
-    logger.error(errorObject, {
-      ...(errorObject.cause || {}),
-      ...errorContext,
-      bannerTitle: title,
-    });
-  }
+  const errorObject = error ? ensureErrorObject(error, t('inline-banner.unknown-error', 'Unknown error!')) : undefined;
 
   return (
     <Alert title={title} severity={severity}>


### PR DESCRIPTION
## Summary

- Move `logger.error()` from `InlineBanner`'s render body into a `useEffect` with a ref guard, so each unique error is reported to Faro exactly once instead of on every React re-render
- Add test coverage for `InlineBanner` error deduplication behavior

## Root cause

The **Exception-free session rate** SLO is critically breaching at **-49.5%** (objective: 80%). Over the last 28 days: **771k exceptions vs 528k sessions** — a 1.46:1 ratio, with spikes to 3.53x.

The SLO formula is `(sessions - exceptions) / sessions`. The primary amplifier is `InlineBanner`, which calls `logger.error()` → `faro.api.pushError()` directly in the render function body. Every React re-render of a component displaying an error pushes a new Faro exception. A single query failure can generate dozens of exceptions per session as React re-renders.

`InlineBanner` with the `error` prop is used in 7+ locations across the app (MetricsList, MetricLabelsList, MetricLabelValuesList, MetricsGroupByRow, MetricsGroupByList, QueryResultsScene, ErrorView).

## Test plan

- [x] `logger.error` is called exactly once on initial render with an error
- [x] Re-rendering with the same error does NOT call `logger.error` again
- [x] Changing the error prop DOES call `logger.error` with the new error
- [x] Rendering without an error prop does NOT call `logger.error`
- [x] Error message formatting (including HTTP status) renders correctly
- [x] Typecheck passes
- [x] Lint passes

After deploy, monitor the SLO timeline — the exceptions-per-session ratio should drop below 1.0 within 24-48h.

Closes #1348