### PR TITLE
test(e2e): force queryLibrary off so saved-queries specs run on nightly

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,10 @@ services:
     environment:
       GF_SERVER_ROOT_URL: 'http://localhost:${GRAFANA_PORT:-3001}'
       GF_FEATURE_TOGGLES_ENABLE: exploreMetricsUseExternalAppPlugin,localizationForPlugins${GF_FEATURE_TOGGLES_ENABLE:+,${GF_FEATURE_TOGGLES_ENABLE}}
+      # Force Query Library off so the Playwright e2e suite deterministically exercises the in-plugin
+      # saved-queries UI across all Grafana versions. Nightly ships queryLibrary enabled by default,
+      # which swaps in Grafana's Query Library UI and breaks the saved-queries tests.
+      GF_FEATURE_TOGGLES_queryLibrary: 'false'
       # prevents a Grafana startup error in case a newer plugin version (set in package.json) is used compared to the latest one published in the catalog
       GF_PLUGINS_PREINSTALL_DISABLED: true
     volumes:
@@ -40,6 +44,8 @@ services:
     environment:
       GF_SERVER_ROOT_URL: 'http://localhost:${GRAFANA_SCOPES_PORT:-3002}'
       GF_FEATURE_TOGGLES_ENABLE: exploreMetricsUseExternalAppPlugin,grafanaAPIServer,grafanaAPIServerWithExperimentalAPIs,scopeFilters,promQLScope,enableScopesInMetricsExplore,localizationForPlugins${GF_FEATURE_TOGGLES_ENABLE:+,${GF_FEATURE_TOGGLES_ENABLE}}
+      # see the note on grafana-gmd above ("environment:" is overridden wholesale, so this must be repeated)
+      GF_FEATURE_TOGGLES_queryLibrary: 'false'
     extra_hosts:
       # This allows us to connect to other services running on the host machine.
       # Linux CI: Uses 172.17.0.1 (default)

--- a/e2e/tests/saved-queries.spec.ts
+++ b/e2e/tests/saved-queries.spec.ts
@@ -34,6 +34,18 @@ const SEED_QUERY_2: SavedQuery = {
 };
 
 test.describe('Saved queries', () => {
+  // When Grafana's Query Library is enabled, the plugin renders the "grafana/query-library-context/v1"
+  // exposed component instead of the in-plugin buttons and modals exercised below (see
+  // isQueryLibrarySupported() in src/shared/savedQueries/savedQuery.ts). The toggle became default-on
+  // in Grafana 13.2, which is why this only affects the nightly job.
+  test.beforeEach(async ({ isLegacyFeatureToggleEnabled }) => {
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      await isLegacyFeatureToggleEnabled<{ queryLibrary: boolean }>('queryLibrary'),
+      "Grafana's Query Library replaces the in-plugin saved-queries UI on this instance."
+    );
+  });
+
   test.describe('Save', () => {
     test('Buttons are visible; load button disabled when no queries exist', async ({ metricSceneView }) => {
       await metricSceneView.goto(URL_SEARCH_PARAMS_WITH_METRIC_NAME);

--- a/e2e/tests/saved-queries.spec.ts
+++ b/e2e/tests/saved-queries.spec.ts
@@ -33,11 +33,6 @@ const SEED_QUERY_2: SavedQuery = {
   uid: '22222222-2222-2222-2222-222222222222',
 };
 
-// When Grafana's Query Library is enabled, the plugin renders the "grafana/query-library-context/v1"
-// exposed component instead of the in-plugin buttons and modals exercised below (see
-// isQueryLibrarySupported() in src/shared/savedQueries/savedQuery.ts). The toggle became default-on in
-// Grafana 13.2, so docker-compose.yaml forces queryLibrary=false to keep these specs running on every
-// version rather than silently skipping them on nightly.
 test.describe('Saved queries', () => {
   test.describe('Save', () => {
     test('Buttons are visible; load button disabled when no queries exist', async ({ metricSceneView }) => {

--- a/e2e/tests/saved-queries.spec.ts
+++ b/e2e/tests/saved-queries.spec.ts
@@ -33,19 +33,12 @@ const SEED_QUERY_2: SavedQuery = {
   uid: '22222222-2222-2222-2222-222222222222',
 };
 
+// When Grafana's Query Library is enabled, the plugin renders the "grafana/query-library-context/v1"
+// exposed component instead of the in-plugin buttons and modals exercised below (see
+// isQueryLibrarySupported() in src/shared/savedQueries/savedQuery.ts). The toggle became default-on in
+// Grafana 13.2, so docker-compose.yaml forces queryLibrary=false to keep these specs running on every
+// version rather than silently skipping them on nightly.
 test.describe('Saved queries', () => {
-  // When Grafana's Query Library is enabled, the plugin renders the "grafana/query-library-context/v1"
-  // exposed component instead of the in-plugin buttons and modals exercised below (see
-  // isQueryLibrarySupported() in src/shared/savedQueries/savedQuery.ts). The toggle became default-on
-  // in Grafana 13.2, which is why this only affects the nightly job.
-  test.beforeEach(async ({ isLegacyFeatureToggleEnabled }) => {
-    // eslint-disable-next-line playwright/no-skipped-test
-    test.skip(
-      await isLegacyFeatureToggleEnabled<{ queryLibrary: boolean }>('queryLibrary'),
-      "Grafana's Query Library replaces the in-plugin saved-queries UI on this instance."
-    );
-  });
-
   test.describe('Save', () => {
     test('Buttons are visible; load button disabled when no queries exist', async ({ metricSceneView }) => {
       await metricSceneView.goto(URL_SEARCH_PARAMS_WITH_METRIC_NAME);


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** Fixes the red `e2e grafana-enterprise@nightly` job, e.g. [run 30644258327](https://github.com/grafana/metrics-drilldown/actions/runs/30644258327/job/91212682292).

Following: https://github.com/grafana/logs-drilldown/pull/2019/changes#diff-7fbfca66a3aa251082a935adc90ac393956e16f2ccc23c72642e83fadaca2a97
