### PR TITLE
fix(deps): resolve pnpm audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,21 +26,22 @@ overrides:
   '@babel/core': ^7.29.1
   '@lezer/common': ^1.5.2
   brace-expansion@^1: ^5.0.7
-  brace-expansion@^5: ^5.0.8
+  brace-expansion@^5: ^5.0.9
   yaml: ^2.8.3
   '@grafana/data': ^13.0.0
   '@grafana/i18n': ^13.0.0
   '@grafana/schema': ^13.0.0
   uuid: ^14.0.0
   postcss: ^8.5.18
-  fast-uri: ^3.1.4
+  fast-uri: ^3.1.5
   ws: ^8.20.1
   js-cookie: ^3.0.7
   qs: ^6.15.2
   react-data-grid: 7.0.0-beta.56
   websocket-driver: '>=0.7.5'
-  brace-expansion: ^5.0.8
+  brace-expansion: ^5.0.9
   webpack-dev-server: '>=5.2.6'
+  ip-address: '>=10.3.1'
 
 importers:
 
@@ -3125,8 +3126,8 @@ packages:
   bonjour-service@1.4.3:
     resolution: {integrity: sha512-2Kd5UYlFUVgAKMTyuBLl6w49wqfOnbxHqmuH0oCl/n7TfAikR0zoowNOP5BU4dfXmm+Vr9JyEN370auSMx+CNg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -3990,8 +3991,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -4476,8 +4477,8 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -10373,7 +10374,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10588,7 +10589,7 @@ snapshots:
       fast-deep-equal: 3.1.3
       multicast-dns: 7.2.5
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -11583,7 +11584,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -12124,7 +12125,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -13023,11 +13024,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -14244,7 +14245,7 @@ snapshots:
 
   socks@2.8.9:
     dependencies:
-      ip-address: 10.2.0
+      ip-address: 10.4.0
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,18 +37,19 @@ overrides:
   '@babel/core': ^7.29.1
   '@lezer/common': ^1.5.2
   brace-expansion@^1: ^5.0.7
-  brace-expansion@^5: ^5.0.8
+  brace-expansion@^5: ^5.0.9
   yaml: ^2.8.3
   '@grafana/data': ^13.0.0
   '@grafana/i18n': ^13.0.0
   '@grafana/schema': ^13.0.0
   uuid: ^14.0.0
   postcss: ^8.5.18
-  fast-uri: ^3.1.4
+  fast-uri: ^3.1.5
   ws: ^8.20.1
   js-cookie: ^3.0.7
   qs: ^6.15.2
   react-data-grid: 7.0.0-beta.56
   websocket-driver: '>=0.7.5'
-  brace-expansion: ^5.0.8
+  brace-expansion: ^5.0.9
   webpack-dev-server: '>=5.2.6'
+  ip-address: '>=10.3.1'


### PR DESCRIPTION
## Summary

Bumps pnpm overrides to patched versions, clearing all 5 outstanding `pnpm audit` advisories. Baseline on `main` was **5 vulnerabilities (3 high, 2 moderate)**; `pnpm audit` now reports **no known vulnerabilities** and exits 0.

| Package | Before | After (resolved) | Advisories |
|---|---|---|---|
| `brace-expansion@^5` | `^5.0.8` | `^5.0.9` (5.0.9) | GHSA-rgw5-rvv9-x895 |
| `brace-expansion` (bare) | `^5.0.8` | `^5.0.9` (5.0.9) | same |
| `fast-uri` | `^3.1.4` | `^3.1.5` (3.1.5) | GHSA-7p8r-x3mc-p8w7 |
| `ip-address` | *(none)* | `>=10.3.1` (10.4.0) | GHSA-mwp4-54f8-5fhr, GHSA-4xrf-jv44-h6hh, GHSA-22jq-vg5j-6vgg |

Notes on the two less obvious entries:

- **`brace-expansion` appears twice.** This file carries both a ranged key (`brace-expansion@^5`) and a bare key. Both pinned `^5.0.8`, so bumping only one leaves a reachable 5.0.8 copy and the advisory stands. Both moved to `^5.0.9`. `brace-expansion@^1: ^5.0.7` is deliberately left untouched — audit does not flag it.
- **`ip-address` covers three advisories with one bump.** 10.3.1 is above the ceiling of all three. Only one copy exists in the tree, so a bare key is correct. It is dev-only: `@grafana/sign-plugin > proxy-agent > socks-proxy-agent > socks > ip-address`.

Scope is deliberately limited to the flagged packages — no unrelated override lines were reformatted, deduped, or tidied, and no audit suppressions were added.

## Known remaining

**None.** `pnpm audit` is clean.

Worth recording for context, since previous rounds deferred these: the three react-router advisories are **already resolved on `main`** by #1360, which moved `react-router` to v8.3.0 as a direct dependency. The tree now resolves react-router 8.3.0 / react-router-dom 7.18.1, and no react-router advisory appeared in this run's baseline. The `react-router: ^8.3.0` override is **not** inert — it is load-bearing alongside the package.json dependency, the `src/App` import changes, `moduleResolution: bundler`, and the jest ESM allowlist from that PR. No cleanup is needed there.

## Test plan

`brace-expansion` 5.x is a major line whose known failure mode is minimatch throwing `expand is not a function` at **runtime**, which `tsc` cannot detect. So verification went past typecheck:

- [x] `pnpm install --no-frozen-lockfile` — exit 0, no supply-chain policy or peer blocks
- [x] `pnpm audit` — exit 0, no known vulnerabilities (from 5)
- [x] `pnpm run typecheck` — exit 0
- [x] `pnpm run test` — **734/734 passing** across 73 suites
- [x] `pnpm run build` — production rspack build succeeds (only pre-existing asset-size warnings)
- [x] `pnpm why` confirms the overrides actually resolved rather than sitting inert in the lockfile: brace-expansion 5.0.9, fast-uri 3.1.5, ip-address 10.4.0 are the only reachable copies

Older `brace-expansion` / `fast-uri` / `ip-address` directories still present under `node_modules/.pnpm` are unreferenced store leftovers, not part of the dependency graph — `pnpm why` reports a single reachable version for each.