### PR TITLE
feat(sea-of-metrics): tag metric_selected with the firing-alerts cohort

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -9,13 +9,13 @@ import { AppErrorBoundary } from './AppErrorBoundary';
 import { Onboarding } from './Onboarding';
 import { AppRoutes } from './Routes';
 import { useReportAppInitialized } from './useReportAppInitialized';
-import { initOpenFeatureProvider } from '../shared/featureFlags/openFeature';
+import { evaluateExperimentFlagsEarly, initOpenFeatureProvider } from '../shared/featureFlags/openFeature';
 import { initFaro } from '../shared/logger/faro/faro';
 import { isPrometheusDataSource } from '../shared/utils/utils.datasource';
 import { PluginPropsContext } from '../shared/utils/utils.plugin';
 
 initFaro();
-initOpenFeatureProvider();
+initOpenFeatureProvider().then(evaluateExperimentFlagsEarly);
 
 const prometheusDatasources = Object.values(config.datasources).filter(isPrometheusDataSource);
 

--- a/src/shared/featureFlags/openFeature.ts
+++ b/src/shared/featureFlags/openFeature.ts
@@ -229,3 +229,18 @@ export async function evaluateFeatureFlag<T extends keyof typeof goffFeatureFlag
 export async function isFiringAlertsSortingEnabled(): Promise<boolean> {
   return (await evaluateFeatureFlag('drilldown.metrics.sort_by_firing_alerts')) === 'treatment';
 }
+
+/**
+ * Eagerly evaluates experiment flags at app initialization so their cohort is recorded (via {@link TrackingHook})
+ * before analytics events fire. This matters for A/B experiments whose primary KPI is a general event emitted by
+ * both arms — e.g. `metric_selected` for the sort-by-firing-alerts experiment: the flag must be evaluated for
+ * control users too, otherwise `getTrackedFlagPayload` returns null and the KPI event carries no cohort.
+ *
+ * Evaluating the flag is enough — the OpenFeature TrackingHook stores the cohort as a side effect; the returned
+ * value is intentionally ignored here.
+ */
+export function evaluateExperimentFlagsEarly(): void {
+  // `evaluateFeatureFlag` waits for the provider to be ready and swallows its own errors, so a failed evaluation
+  // just leaves the cohort unset rather than throwing during startup.
+  void evaluateFeatureFlag('drilldown.metrics.sort_by_firing_alerts');
+}

--- a/src/shared/tracking/__tests__/interactions.experiments.test.ts
+++ b/src/shared/tracking/__tests__/interactions.experiments.test.ts
@@ -1,0 +1,73 @@
+import { getTrackedFlagPayload } from '../../featureFlags/tracking';
+
+import type * as InteractionsModule from '../interactions';
+
+// interactions.ts imports reportInteraction and (transitively, via getPluginVersion) reads config at module
+// load; keep both mocked so requiring the real module is cheap and doesn't crash on startup.
+jest.mock('@grafana/runtime', () => ({
+  reportInteraction: jest.fn(),
+  config: { apps: {} },
+}));
+
+jest.mock('../../featureFlags/tracking', () => ({
+  getTrackedFlagPayload: jest.fn(),
+}));
+
+// jest.config.js maps every "*/interactions" import to a no-op mock (regex `^.+/interactions$`). The explicit
+// `.ts` extension dodges that mapper so we load the real module and exercise the real enrichment logic.
+// getExperimentPayloads is a pure function, so we can assert on its return directly without going through
+// reportInteraction (which would pull in the real @grafana/runtime).
+const { getExperimentPayloads } = jest.requireActual('../interactions.ts') as typeof InteractionsModule;
+
+const mockGetTrackedFlagPayload = getTrackedFlagPayload as jest.Mock;
+
+const FIRING_ALERTS_KEY = 'experiment_sort_by_firing_alerts';
+const COHORT = { [FIRING_ALERTS_KEY]: 'control' };
+
+describe('getExperimentPayloads — sort-by-firing-alerts experiment enrichment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Simulate the flag having been evaluated: the cohort is available for the firing-alerts tracking key only.
+    mockGetTrackedFlagPayload.mockImplementation((key: string) => (key === FIRING_ALERTS_KEY ? COHORT : null));
+  });
+
+  it('enriches metric_selected (the both-arms primary KPI) with the cohort', () => {
+    const payload = getExperimentPayloads('metric_selected', { from: 'metric_list', searchTermCount: null });
+
+    expect(payload).toMatchObject(COHORT);
+    expect(mockGetTrackedFlagPayload).toHaveBeenCalledWith(FIRING_ALERTS_KEY, true);
+  });
+
+  it('enriches the firing-alert adoption/guardrail events with the cohort', () => {
+    expect(getExperimentPayloads('firing_alert_filter_toggled', { action: 'activated', matching_count: 3 })).toMatchObject(
+      COHORT
+    );
+    expect(
+      getExperimentPayloads('firing_alert_metrics_fetched', {
+        status: 'success',
+        duration_ms: 10,
+        metric_count: 2,
+        rule_count: 4,
+      })
+    ).toMatchObject(COHORT);
+  });
+
+  it('enriches sorting_changed only when the firing-alerts sort is selected from the metrics reducer', () => {
+    expect(getExperimentPayloads('sorting_changed', { from: 'metrics-reducer', sortBy: 'firing-alerts' })).toMatchObject(
+      COHORT
+    );
+
+    const otherSort = getExperimentPayloads('sorting_changed', { from: 'metrics-reducer', sortBy: 'alphabetical' });
+    expect(otherSort[FIRING_ALERTS_KEY]).toBeUndefined();
+  });
+
+  it('does not enrich unrelated events with the cohort', () => {
+    expect(getExperimentPayloads('quick_search_used', {})[FIRING_ALERTS_KEY]).toBeUndefined();
+  });
+
+  it('omits the cohort when it has not been recorded yet (null payload)', () => {
+    mockGetTrackedFlagPayload.mockReturnValue(null);
+
+    expect(getExperimentPayloads('metric_selected', { from: 'metric_list', searchTermCount: null })[FIRING_ALERTS_KEY]).toBeUndefined();
+  });
+});

--- a/src/shared/tracking/interactions.ts
+++ b/src/shared/tracking/interactions.ts
@@ -238,7 +238,8 @@ getPluginVersion().then((v) => {
   cachedAppVersion = v;
 });
 
-function getExperimentPayloads<E extends keyof AllEvents, P extends AllEvents[E]>(
+/** @internal Exported for unit testing. Returns the experiment-cohort enrichment for a given event/payload. */
+export function getExperimentPayloads<E extends keyof AllEvents, P extends AllEvents[E]>(
   event: E,
   payload: P
 ): Record<string, unknown> {
@@ -259,15 +260,21 @@ function getExperimentPayloads<E extends keyof AllEvents, P extends AllEvents[E]
     Object.assign(payloads, getTrackedFlagPayload('experiment_grafana_assistant_quick_search_tab_test', true));
   }
 
-  // Enrich firing-alerts KPI events with the experiment cohort so Odin can correlate KPIs and cohort in a
-  // single query. `sorting_changed` is only enriched when the firing-alerts sort is the one being selected,
-  // to avoid polluting the generic sort KPI.
+  // Enrich events with the sort-by-firing-alerts experiment cohort so Odin can correlate KPIs and cohort in a
+  // single query.
+  //
+  // `metric_selected` is the primary KPI: it fires in BOTH arms (treatment and control), so it gives Odin a
+  // comparable measure of engagement. The firing-alert-specific events below only fire when the feature is
+  // visible (treatment only), so they serve as adoption/guardrail metrics, not the primary A/B comparison.
+  // `sorting_changed` is only enriched when the firing-alerts sort is the one being selected, to avoid
+  // polluting the generic sort KPI.
   const isFiringAlertsSortSelected =
     event === 'sorting_changed' &&
     (payload as Interactions['sorting_changed']).from === 'metrics-reducer' &&
     (payload as { sortBy?: string }).sortBy === 'firing-alerts';
 
   if (
+    event === 'metric_selected' ||
     event === 'firing_alert_filter_toggled' ||
     event === 'firing_alert_metrics_fetched' ||
     isFiringAlertsSortSelected


### PR DESCRIPTION
### ✨ Description

Makes the sort-by-firing-alerts Odin A/B test measurable: tags `metric_selected` (the primary KPI, fired by both arms) with the experiment cohort, and evaluates the flag at app init so control users are recorded too. The firing-alert-specific events stay as treatment-only guardrail metrics.

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/metrics-drilldown/blob/main/docs/genai.md))

### 🧪 How to test?

`pnpm test` (739 pass; 5 new in `interactions.experiments.test.ts`). Post-deploy, `metric_selected` in BigQuery should show both `treatment` and `control` cohorts.
