### PR TITLE
fix: show native histogram label breakdown correctly

### DIFF
--- a/docs/application-structure.md
+++ b/docs/application-structure.md
@@ -116,6 +116,10 @@ The Breakdown tab helps users understand how a metric is composed across differe
 
 A dropdown lets users select which label to break down by. Choosing "All" shows a panel for each available label name (showing the metric aggregated by that label), while selecting a specific label (like `instance` or `pod`) shows a panel for each value of that label.
 
+##### Histogram breakdown function
+
+For histogram metrics, a "Function" selector controls how each label's breakdown is aggregated: sum (the default, total accumulated value) or a percentile (p99, p95, p75, p50).
+
 ##### Visual Interaction
 
 - Clicking a panel applies that label or value as a filter, narrowing the focus

--- a/docs/application-structure.md
+++ b/docs/application-structure.md
@@ -118,7 +118,7 @@ A dropdown lets users select which label to break down by. Choosing "All" shows 
 
 ##### Histogram breakdown function
 
-For histogram metrics, a "Function" selector controls how each label's breakdown is aggregated: sum (the default, total accumulated value) or a percentile (p99, p95, p75, p50).
+For histogram metrics, a "Function" selector controls how each label's breakdown is aggregated: sum (the default, each label's total value per second) or a percentile (p99, p95, p75, p50).
 
 ##### Visual Interaction
 

--- a/src/MetricScene/Breakdown/HistogramBreakdownFnVariable.tsx
+++ b/src/MetricScene/Breakdown/HistogramBreakdownFnVariable.tsx
@@ -1,0 +1,29 @@
+import { t } from '@grafana/i18n';
+import { CustomVariable } from '@grafana/scenes';
+import { VariableHide } from '@grafana/schema';
+
+import { type HistogramBreakdownFn } from 'shared/GmdVizPanel/GmdVizPanel';
+import { VAR_HISTOGRAM_BREAKDOWN_FN } from 'shared/shared';
+
+export const HISTOGRAM_BREAKDOWN_FN_OPTIONS: Array<{ label: string; value: HistogramBreakdownFn }> = [
+  { label: 'Sum', value: 'sum' },
+  { label: 'p99', value: 'p99' },
+  { label: 'p95', value: 'p95' },
+  { label: 'p75', value: 'p75' },
+  { label: 'p50', value: 'p50' },
+];
+
+// Visibility is decided by LabelBreakdownScene (which already tracks metric type), not by this
+// variable itself: rendering is gated there, so this stays a plain static-options variable.
+export class HistogramBreakdownFnVariable extends CustomVariable {
+  constructor() {
+    super({
+      name: VAR_HISTOGRAM_BREAKDOWN_FN,
+      label: t('breakdown.histogram-fn.label', 'Histogram breakdown function'),
+      query: HISTOGRAM_BREAKDOWN_FN_OPTIONS.map(({ label, value }) => `${label} : ${value}`).join(','),
+      value: 'sum',
+      text: t('breakdown.histogram-fn.default-text', 'Sum'),
+      hide: VariableHide.hideVariable,
+    });
+  }
+}

--- a/src/MetricScene/Breakdown/LabelBreakdownScene.tsx
+++ b/src/MetricScene/Breakdown/LabelBreakdownScene.tsx
@@ -10,7 +10,7 @@ import {
   type SceneComponentProps,
   type SceneObjectState,
 } from '@grafana/scenes';
-import { useStyles2 } from '@grafana/ui';
+import { Field, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { type DataTrail } from 'AppDataTrail/DataTrail';
@@ -19,16 +19,18 @@ import { type MetricType } from 'shared/GmdVizPanel/matchers/getMetricType';
 import { getTrailFor } from 'shared/utils/utils';
 import { getAppBackgroundColor } from 'shared/utils/utils.styles';
 
+import { type HistogramBreakdownFnVariable } from './HistogramBreakdownFnVariable';
 import { MetricLabelsList } from './MetricLabelsList/MetricLabelsList';
 import { MetricLabelValuesList } from './MetricLabelValuesList/MetricLabelValuesList';
 import { actionViews } from '../../MetricScene/MetricActionBar';
-import { RefreshMetricsEvent, VAR_GROUP_BY } from '../../shared/shared';
+import { RefreshMetricsEvent, VAR_GROUP_BY, VAR_HISTOGRAM_BREAKDOWN_FN } from '../../shared/shared';
 import { isQueryVariable } from '../../shared/utils/utils.variables';
 import { MetricScene } from '../MetricScene';
 import { signalOnQueryComplete } from '../utils/signalOnQueryComplete';
 
 interface LabelBreakdownSceneState extends SceneObjectState {
   metric: string;
+  metricType: MetricType;
   body?: MetricLabelsList | MetricLabelValuesList;
 }
 
@@ -36,6 +38,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
   constructor({ metric }: { metric: LabelBreakdownSceneState['metric'] }) {
     super({
       metric,
+      metricType: 'gauge',
       body: undefined,
       $behaviors: [new behaviors.SceneQueryController()],
     });
@@ -47,6 +50,12 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     const groupByVariable = this.getVariable();
 
     groupByVariable.subscribeToState((newState, oldState) => {
+      if (newState.value !== oldState.value) {
+        this.updateBody(groupByVariable);
+      }
+    });
+
+    this.getHistogramBreakdownFnVariable().subscribeToState((newState, oldState) => {
       if (newState.value !== oldState.value) {
         this.updateBody(groupByVariable);
       }
@@ -70,9 +79,11 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     return groupByVariable;
   }
 
-  // Reuses the main graph panel's own resolved metric type (GmdVizPanel), rather than re-deriving it
-  // from metadata alone: GmdVizPanel also runs a probe query for metrics with no metadata (adaptive/
-  // aggregated native histograms), a correction this scene doesn't otherwise have access to.
+  private getHistogramBreakdownFnVariable(): HistogramBreakdownFnVariable {
+    return sceneGraph.lookupVariable(VAR_HISTOGRAM_BREAKDOWN_FN, this) as HistogramBreakdownFnVariable;
+  }
+
+  // Reuses the main graph panel's own resolved metric type instead of re-deriving it from metadata alone.
   private getMainPanel(): GmdVizPanel | undefined {
     const metricScene = sceneGraph.getAncestor(this, MetricScene);
     return sceneGraph.findDescendents(metricScene.state.body, GmdVizPanel)[0];
@@ -108,7 +119,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
           binaryQuery: trail.state.binaryQuery,
         });
 
-    this.setState({ body: newBody });
+    this.setState({ body: newBody, metricType: type });
 
     // Wait for body activation, then signal when queries complete
     if (newBody.isActive) {
@@ -125,15 +136,24 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     const trail = getTrailFor(model);
     const { embeddedMini } = trail.state;
     const styles = useStyles2(getStyles, trail.state.embedded ? 0 : (chromeHeaderHeight ?? 0), trail);
-    const { body } = model.useState();
+    const { body, metricType } = model.useState();
     const groupByVariable = model.getVariable();
+    const histogramBreakdownFnVariable = model.getHistogramBreakdownFnVariable();
+    const isHistogram = metricType === 'classic-histogram' || metricType === 'native-histogram';
 
     return (
       <div className={styles.container}>
         {!embeddedMini && (
           <div className={styles.stickyControls} data-testid="breakdown-controls">
             <div className={styles.controls}>
-              <groupByVariable.Component model={groupByVariable} />
+              <div className={styles.leftControls}>
+                <groupByVariable.Component model={groupByVariable} />
+                {isHistogram && (
+                  <Field label={t('breakdown.histogram-fn.label', 'Histogram breakdown function')} className={styles.field}>
+                    <histogramBreakdownFnVariable.Component model={histogramBreakdownFnVariable} />
+                  </Field>
+                )}
+              </div>
               {body instanceof MetricLabelsList && <body.Controls model={body} />}
               {body instanceof MetricLabelValuesList && <body.Controls model={body} />}
             </div>
@@ -172,6 +192,16 @@ function getStyles(theme: GrafanaTheme2, headerHeight: number, trail: DataTrail)
       alignItems: 'end',
       flexWrap: 'wrap',
       gap: theme.spacing(1),
+    }),
+    leftControls: css({
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'end',
+      flexWrap: 'wrap',
+      gap: theme.spacing(1),
+    }),
+    field: css({
+      marginBottom: 0,
     }),
     searchField: css({
       flexGrow: 1,

--- a/src/MetricScene/Breakdown/LabelBreakdownScene.tsx
+++ b/src/MetricScene/Breakdown/LabelBreakdownScene.tsx
@@ -14,7 +14,8 @@ import { useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { type DataTrail } from 'AppDataTrail/DataTrail';
-import { getMetricType } from 'shared/GmdVizPanel/matchers/getMetricType';
+import { GmdVizPanel } from 'shared/GmdVizPanel/GmdVizPanel';
+import { type MetricType } from 'shared/GmdVizPanel/matchers/getMetricType';
 import { getTrailFor } from 'shared/utils/utils';
 import { getAppBackgroundColor } from 'shared/utils/utils.styles';
 
@@ -23,6 +24,7 @@ import { MetricLabelValuesList } from './MetricLabelValuesList/MetricLabelValues
 import { actionViews } from '../../MetricScene/MetricActionBar';
 import { RefreshMetricsEvent, VAR_GROUP_BY } from '../../shared/shared';
 import { isQueryVariable } from '../../shared/utils/utils.variables';
+import { MetricScene } from '../MetricScene';
 import { signalOnQueryComplete } from '../utils/signalOnQueryComplete';
 
 interface LabelBreakdownSceneState extends SceneObjectState {
@@ -56,6 +58,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
       });
     }
 
+    this.subscribeToMainPanelMetricType();
     this.updateBody(groupByVariable);
   }
 
@@ -67,15 +70,35 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     return groupByVariable;
   }
 
-  private async updateBody(groupByVariable: QueryVariable) {
+  // Reuses the main graph panel's own resolved metric type (GmdVizPanel), rather than re-deriving it
+  // from metadata alone: GmdVizPanel also runs a probe query for metrics with no metadata (adaptive/
+  // aggregated native histograms), a correction this scene doesn't otherwise have access to.
+  private getMainPanel(): GmdVizPanel | undefined {
+    const metricScene = sceneGraph.getAncestor(this, MetricScene);
+    return sceneGraph.findDescendents(metricScene.state.body, GmdVizPanel)[0];
+  }
+
+  private subscribeToMainPanelMetricType() {
+    const mainPanel = this.getMainPanel();
+    if (!mainPanel) {
+      return;
+    }
+
+    this._subs.add(
+      mainPanel.subscribeToState((newState, prevState) => {
+        if (newState.metricType !== prevState.metricType) {
+          this.updateBody(this.getVariable());
+        }
+      })
+    );
+  }
+
+  private updateBody(groupByVariable: QueryVariable) {
     const { metric: name } = this.state;
     const trail = getTrailFor(this);
-    const entry = trail.state.sourceMetrics?.find((s) => s.metricName === name);
+    const type: MetricType = this.getMainPanel()?.state.metricType ?? 'gauge';
 
-    const metric = {
-      name,
-      type: await getMetricType(name, trail, entry?.metricType),
-    };
+    const metric = { name, type };
 
     const newBody = groupByVariable.hasAllValue()
       ? new MetricLabelsList({ metric })

--- a/src/MetricScene/Breakdown/LabelBreakdownScene.tsx
+++ b/src/MetricScene/Breakdown/LabelBreakdownScene.tsx
@@ -14,8 +14,9 @@ import { Field, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { type DataTrail } from 'AppDataTrail/DataTrail';
-import { GmdVizPanel } from 'shared/GmdVizPanel/GmdVizPanel';
+import { GmdVizPanel, type HistogramBreakdownFn } from 'shared/GmdVizPanel/GmdVizPanel';
 import { type MetricType } from 'shared/GmdVizPanel/matchers/getMetricType';
+import { reportExploreMetrics } from 'shared/tracking/interactions';
 import { getTrailFor } from 'shared/utils/utils';
 import { getAppBackgroundColor } from 'shared/utils/utils.styles';
 
@@ -57,6 +58,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
 
     this.getHistogramBreakdownFnVariable().subscribeToState((newState, oldState) => {
       if (newState.value !== oldState.value) {
+        reportExploreMetrics('histogram_breakdown_fn_changed', { fn: newState.value as HistogramBreakdownFn });
         this.updateBody(groupByVariable);
       }
     });

--- a/src/MetricScene/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
+++ b/src/MetricScene/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
@@ -25,12 +25,12 @@ import { GRID_TEMPLATE_COLUMNS, GRID_TEMPLATE_ROWS } from 'MetricsReducer/Metric
 import { getPreferredConfigForMetric } from 'shared/GmdVizPanel/config/getPreferredConfigForMetric';
 import { PANEL_HEIGHT } from 'shared/GmdVizPanel/config/panel-heights';
 import { QUERY_RESOLUTION } from 'shared/GmdVizPanel/config/query-resolutions';
-import { GmdVizPanel } from 'shared/GmdVizPanel/GmdVizPanel';
+import { GmdVizPanel, type HistogramBreakdownFn } from 'shared/GmdVizPanel/GmdVizPanel';
 import { type Metric } from 'shared/GmdVizPanel/matchers/getMetricType';
 import { addCardinalityInfo } from 'shared/GmdVizPanel/types/timeseries/behaviors/addCardinalityInfo';
 import { getTimeseriesQueryRunnerParams } from 'shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams';
 import { addUnspecifiedLabel } from 'shared/GmdVizPanel/types/timeseries/transformations/addUnspecifiedLabel';
-import { trailDS } from 'shared/shared';
+import { trailDS, VAR_HISTOGRAM_BREAKDOWN_FN } from 'shared/shared';
 import { injectLabelMatcher } from 'shared/utils/injectLabelMatcher';
 import { getTrailFor } from 'shared/utils/utils';
 
@@ -193,6 +193,9 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
   private buildSinglePanel() {
     const { metric, label } = this.state;
     const entry = getTrailFor(this).state.sourceMetrics?.find((s) => s.metricName === metric.name);
+    const histogramBreakdownFn = sceneGraph.lookupVariable(VAR_HISTOGRAM_BREAKDOWN_FN, this)?.getValue() as
+      | HistogramBreakdownFn
+      | undefined;
 
     return new GmdVizPanel({
       metric: metric.name,
@@ -209,6 +212,7 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
         customRateInterval: entry?.customRateInterval,
         customFunction: entry?.customFunction,
         kgMetricType: entry?.metricType,
+        histogramBreakdownFn,
       },
     });
   }

--- a/src/MetricScene/Breakdown/MetricLabelsList/MetricLabelsList.tsx
+++ b/src/MetricScene/Breakdown/MetricLabelsList/MetricLabelsList.tsx
@@ -25,10 +25,11 @@ import { LayoutSwitcher, LayoutType, type LayoutSwitcherState } from 'MetricsRed
 import { GRID_TEMPLATE_COLUMNS, GRID_TEMPLATE_ROWS } from 'MetricsReducer/MetricsList/MetricsList';
 import { PANEL_HEIGHT } from 'shared/GmdVizPanel/config/panel-heights';
 import { QUERY_RESOLUTION } from 'shared/GmdVizPanel/config/query-resolutions';
+import { type HistogramBreakdownFn } from 'shared/GmdVizPanel/GmdVizPanel';
 import { type Metric } from 'shared/GmdVizPanel/matchers/getMetricType';
 import { addCardinalityInfo } from 'shared/GmdVizPanel/types/timeseries/behaviors/addCardinalityInfo';
 import { buildTimeseriesPanel } from 'shared/GmdVizPanel/types/timeseries/buildTimeseriesPanel';
-import { VAR_GROUP_BY } from 'shared/shared';
+import { VAR_GROUP_BY, VAR_HISTOGRAM_BREAKDOWN_FN } from 'shared/shared';
 import { getTrailFor } from 'shared/utils/utils';
 
 import { publishTimeseriesData } from './behaviors/publishTimeseriesData';
@@ -136,6 +137,10 @@ export class MetricLabelsList extends SceneObjectBase<MetricLabelsListState> {
             // Not in scene graph yet, use default
           }
 
+          const histogramBreakdownFn = sceneGraph.lookupVariable(VAR_HISTOGRAM_BREAKDOWN_FN, this)?.getValue() as
+            | HistogramBreakdownFn
+            | undefined;
+
           const panel = buildTimeseriesPanel({
             metric,
             panelConfig: getLabelPanelConfig(label, labelIndex, embeddedMini),
@@ -147,6 +152,7 @@ export class MetricLabelsList extends SceneObjectBase<MetricLabelsListState> {
               // For a KG binary (ratio) insight, break down the full ratio expression rather than the
               // anchor metric selector. Undefined for normal metrics, so the standard path is unchanged.
               binaryExpr: trail?.state.binaryQuery,
+              histogramBreakdownFn,
             },
           });
 

--- a/src/MetricScene/MetricScene.tsx
+++ b/src/MetricScene/MetricScene.tsx
@@ -19,6 +19,7 @@ import { type KgMetricType } from 'shared/GmdVizPanel/matchers/mapKgMetricType';
 
 import { RefreshMetricsEvent, VAR_FILTERS, VAR_METRIC, type MakeOptional } from '../shared/shared';
 import { GroupByVariable } from './Breakdown/GroupByVariable';
+import { HistogramBreakdownFnVariable } from './Breakdown/HistogramBreakdownFnVariable';
 import { EventActionViewDataLoadComplete } from './EventActionViewDataLoadComplete';
 import { actionViews, defaultActionView, getActionViewsDefinitions, type ActionViewType } from './MetricActionBar';
 import { MetricGraphScene } from './MetricGraphScene';
@@ -201,6 +202,7 @@ function getVariableSet(metric: string, binaryQuery?: string) {
         hide: VariableHide.hideVariable,
       }),
       new GroupByVariable(binaryQuery),
+      new HistogramBreakdownFnVariable(),
     ],
   });
 }

--- a/src/locales/en-US/grafana-metricsdrilldown-app.json
+++ b/src/locales/en-US/grafana-metricsdrilldown-app.json
@@ -19,6 +19,10 @@
     "group-by": {
       "label": "Group by"
     },
+    "histogram-fn": {
+      "default-text": "Sum",
+      "label": "Histogram breakdown function"
+    },
     "label-values-list": {
       "error-title": "Error while loading metrics!",
       "no-values": "No label values found for the current filters and time range.",

--- a/src/shared/GmdVizPanel/GmdVizPanel.tsx
+++ b/src/shared/GmdVizPanel/GmdVizPanel.tsx
@@ -70,6 +70,9 @@ export type QueryDefs = Array<{
   params?: Record<string, any>;
 }>;
 
+// Only used by the histogram by-label group-by query (getTimeseriesQueryRunnerParams.ts).
+export type HistogramBreakdownFn = 'sum' | 'p99' | 'p95' | 'p75' | 'p50';
+
 export type QueryConfig = {
   resolution: QUERY_RESOLUTION;
   labelMatchers: LabelMatcher[];
@@ -89,6 +92,7 @@ export type QueryConfig = {
   // Legend for a non-grouped binaryExpr query. Defaults to "binary query" (main panel); the per-value
   // breakdown passes the label value so each value panel legends with its value, not "binary query".
   binaryLegend?: string;
+  histogramBreakdownFn?: HistogramBreakdownFn;
 };
 
 export type QueryOptions = {
@@ -102,6 +106,7 @@ export type QueryOptions = {
   kgMetricType?: NonNullable<QueryConfig['kgMetricType']>;
   binaryExpr?: NonNullable<QueryConfig['binaryExpr']>;
   binaryLegend?: NonNullable<QueryConfig['binaryLegend']>;
+  histogramBreakdownFn?: NonNullable<QueryConfig['histogramBreakdownFn']>;
 };
 
 /* GmdVizPanelState */

--- a/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
@@ -309,6 +309,45 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
       );
     });
 
+    test('handles native-histogram metrics with a p99-by-label query, not avg', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'http_request_duration_seconds', type: 'native-histogram' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [],
+          addIgnoreUsageFilter: true,
+          groupBy: 'cluster',
+        },
+      });
+
+      expect(result.isRateQuery).toBe(false);
+      expect(result.queries).toStrictEqual([
+        {
+          refId: 'http_request_duration_seconds-by-cluster',
+          expr: 'histogram_quantile(0.99,sum by (cluster) (rate(http_request_duration_seconds{__ignore_usage__="", ${filters:raw}}[$__rate_interval])))',
+          legendFormat: '{{cluster}}',
+          fromExploreMetrics: true,
+        },
+      ]);
+    });
+
+    test('applies customRateInterval override to native-histogram by-label rate window', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'http_request_duration_seconds', type: 'native-histogram' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [],
+          addIgnoreUsageFilter: true,
+          groupBy: 'cluster',
+          customRateInterval: '1h',
+        },
+      });
+
+      expect(result.queries[0].expr).toBe(
+        'histogram_quantile(0.99,sum by (cluster) (rate(http_request_duration_seconds{__ignore_usage__="", ${filters:raw}}[1h])))'
+      );
+    });
+
     describe('with UTF-8 labels', () => {
       test('wraps UTF-8 label in quotes for by clause and legendFormat', () => {
         const result = getTimeseriesQueryRunnerParams({

--- a/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/__tests__/getTimeseriesQueryRunnerParams.test.ts
@@ -309,7 +309,7 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
       );
     });
 
-    test('handles native-histogram metrics with a p99-by-label query, not avg', () => {
+    test('defaults native-histogram metrics to a sum-by-label query via histogram_sum, not avg', () => {
       const result = getTimeseriesQueryRunnerParams({
         metric: { name: 'http_request_duration_seconds', type: 'native-histogram' },
         queryConfig: {
@@ -324,14 +324,35 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
       expect(result.queries).toStrictEqual([
         {
           refId: 'http_request_duration_seconds-by-cluster',
-          expr: 'histogram_quantile(0.99,sum by (cluster) (rate(http_request_duration_seconds{__ignore_usage__="", ${filters:raw}}[$__rate_interval])))',
+          expr: 'histogram_sum(sum by (cluster) (rate(http_request_duration_seconds{__ignore_usage__="", ${filters:raw}}[$__rate_interval])))',
           legendFormat: '{{cluster}}',
           fromExploreMetrics: true,
         },
       ]);
     });
 
-    test('applies customRateInterval override to native-histogram by-label rate window', () => {
+    test('defaults classic-histogram metrics to a sum-by-label query using the _sum sibling series', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'http_request_duration_seconds_bucket', type: 'classic-histogram' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [],
+          addIgnoreUsageFilter: true,
+          groupBy: 'cluster',
+        },
+      });
+
+      expect(result.queries).toStrictEqual([
+        {
+          refId: 'http_request_duration_seconds_bucket-by-cluster',
+          expr: 'sum by (cluster) (rate(http_request_duration_seconds_sum{__ignore_usage__="", ${filters:raw}}[$__rate_interval]))',
+          legendFormat: '{{cluster}}',
+          fromExploreMetrics: true,
+        },
+      ]);
+    });
+
+    test('applies customRateInterval override to histogram sum-by-label rate window', () => {
       const result = getTimeseriesQueryRunnerParams({
         metric: { name: 'http_request_duration_seconds', type: 'native-histogram' },
         queryConfig: {
@@ -344,7 +365,46 @@ describe('getTimeseriesQueryRunnerParams(options)', () => {
       });
 
       expect(result.queries[0].expr).toBe(
-        'histogram_quantile(0.99,sum by (cluster) (rate(http_request_duration_seconds{__ignore_usage__="", ${filters:raw}}[1h])))'
+        'histogram_sum(sum by (cluster) (rate(http_request_duration_seconds{__ignore_usage__="", ${filters:raw}}[1h])))'
+      );
+    });
+
+    test.each([
+      ['p99', 0.99],
+      ['p95', 0.95],
+      ['p75', 0.75],
+      ['p50', 0.5],
+    ] as const)('native-histogram with histogramBreakdownFn=%s builds a histogram_quantile(%s) query', (fn, parameter) => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'http_request_duration_seconds', type: 'native-histogram' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [],
+          addIgnoreUsageFilter: true,
+          groupBy: 'cluster',
+          histogramBreakdownFn: fn,
+        },
+      });
+
+      expect(result.queries[0].expr).toBe(
+        `histogram_quantile(${parameter},sum by (cluster) (rate(http_request_duration_seconds{__ignore_usage__="", \${filters:raw}}[$__rate_interval])))`
+      );
+    });
+
+    test('classic-histogram with histogramBreakdownFn=p99 keeps le in the inner sum', () => {
+      const result = getTimeseriesQueryRunnerParams({
+        metric: { name: 'http_request_duration_seconds_bucket', type: 'classic-histogram' },
+        queryConfig: {
+          resolution: QUERY_RESOLUTION.MEDIUM,
+          labelMatchers: [],
+          addIgnoreUsageFilter: true,
+          groupBy: 'cluster',
+          histogramBreakdownFn: 'p99',
+        },
+      });
+
+      expect(result.queries[0].expr).toBe(
+        'histogram_quantile(0.99,sum by (cluster, le) (rate(http_request_duration_seconds_bucket{__ignore_usage__="", ${filters:raw}}[$__rate_interval])))'
       );
     });
 

--- a/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
@@ -6,7 +6,7 @@ import { buildCustomFunctionQuery, buildPresetFunctionQuery } from 'shared/GmdVi
 import { buildQueryExpression } from 'shared/GmdVizPanel/buildQueryExpression';
 import { isRangeVectorFunction, PROMQL_FUNCTIONS, type PrometheusFunction } from 'shared/GmdVizPanel/config/promql-functions';
 import { QUERY_RESOLUTION } from 'shared/GmdVizPanel/config/query-resolutions';
-import { type QueryConfig, type QueryDefs } from 'shared/GmdVizPanel/GmdVizPanel';
+import { type HistogramBreakdownFn, type QueryConfig, type QueryDefs } from 'shared/GmdVizPanel/GmdVizPanel';
 import { type Metric } from 'shared/GmdVizPanel/matchers/getMetricType';
 import { logger } from 'shared/logger/logger';
 import { groupBinaryByLabel } from 'shared/utils/groupBinaryByLabel';
@@ -61,23 +61,28 @@ export function getTimeseriesQueryRunnerParams(options: GetQueryRunnerParamsOpti
   };
 }
 
-const DEFAULT_HISTOGRAM_BY_LABEL_PERCENTILE = 99;
+const HISTOGRAM_BY_LABEL_PERCENTILES: Record<Exclude<HistogramBreakdownFn, 'sum'>, number> = {
+  p99: 99,
+  p95: 95,
+  p75: 75,
+  p50: 50,
+};
 
-// Aggregating a native histogram preserves its sample type instead of collapsing to a plain float, so
-// the usual avg-by-label query below would return a heatmap-shaped frame (yMin/yMax/count fields) that
-// a timeseries panel can't render. Reduce each label value to its own p99 line instead, the same
-// "which value is worst" comparison every other metric type's by-label panel gives.
-function buildNativeHistogramByLabelQuery(metric: Metric, queryConfig: QueryConfig, expr: string, groupByLabel: string): SceneDataQuery[] {
+// Classic histograms expose the total as the _sum sibling series (_bucket/_sum/_count convention).
+function toSumMetricSelector(bucketSelector: string): string {
+  const openBrace = bucketSelector.indexOf('{');
+  const metricName = openBrace === -1 ? bucketSelector : bucketSelector.slice(0, openBrace);
+  const rest = openBrace === -1 ? '' : bucketSelector.slice(openBrace);
+  return `${metricName.replace(/_bucket$/, '_sum')}${rest}`;
+}
+
+function buildHistogramSumByLabelQuery(metric: Metric, queryConfig: QueryConfig, expr: string, groupByLabel: string): SceneDataQuery[] {
   const interval = queryConfig.customRateInterval ?? '$__rate_interval';
-  const innerVector = promql.sum({ expr: promql.rate({ expr, interval }), by: [groupByLabel] });
-
-  const entry = PROMQL_FUNCTIONS.get('histogram_quantile');
-  if (!entry) {
-    logger.warn('[getTimeseriesQueryRunnerParams] Unknown PromQL function "histogram_quantile", skipping query.');
-    return [];
-  }
-
-  const queryExpr = entry.fn({ expr: innerVector, parameter: DEFAULT_HISTOGRAM_BY_LABEL_PERCENTILE / 100 });
+  const isClassic = metric.type === 'classic-histogram';
+  const sumExpr = isClassic ? toSumMetricSelector(expr) : expr;
+  const innerVector = promql.sum({ expr: promql.rate({ expr: sumExpr, interval }), by: [groupByLabel] });
+  // histogram_sum() only accepts native-histogram-typed samples; the _sum sibling is already a plain float.
+  const queryExpr = isClassic ? innerVector : `histogram_sum(${innerVector})`;
 
   return [
     {
@@ -87,6 +92,43 @@ function buildNativeHistogramByLabelQuery(metric: Metric, queryConfig: QueryConf
       fromExploreMetrics: true,
     },
   ];
+}
+
+function buildHistogramPercentileByLabelQuery(
+  metric: Metric,
+  queryConfig: QueryConfig,
+  expr: string,
+  groupByLabel: string,
+  fn: Exclude<HistogramBreakdownFn, 'sum'>
+): SceneDataQuery[] {
+  const interval = queryConfig.customRateInterval ?? '$__rate_interval';
+  const by = metric.type === 'classic-histogram' ? [groupByLabel, 'le'] : [groupByLabel];
+  const innerVector = promql.sum({ expr: promql.rate({ expr, interval }), by });
+
+  const entry = PROMQL_FUNCTIONS.get('histogram_quantile');
+  if (!entry) {
+    logger.warn('[getTimeseriesQueryRunnerParams] Unknown PromQL function "histogram_quantile", skipping query.');
+    return [];
+  }
+
+  const queryExpr = entry.fn({ expr: innerVector, parameter: HISTOGRAM_BY_LABEL_PERCENTILES[fn] / 100 });
+
+  return [
+    {
+      refId: `${metric.name}-by-${queryConfig.groupBy}`,
+      expr: queryExpr,
+      legendFormat: `{{${groupByLabel}}}`,
+      fromExploreMetrics: true,
+    },
+  ];
+}
+
+function buildHistogramByLabelQuery(metric: Metric, queryConfig: QueryConfig, expr: string, groupByLabel: string): SceneDataQuery[] {
+  const fn = queryConfig.histogramBreakdownFn ?? 'sum';
+  if (fn === 'sum') {
+    return buildHistogramSumByLabelQuery(metric, queryConfig, expr, groupByLabel);
+  }
+  return buildHistogramPercentileByLabelQuery(metric, queryConfig, expr, groupByLabel, fn);
 }
 
 // if grouped by, we don't provide support for preset functions
@@ -119,8 +161,8 @@ function buildGroupByQueries({
     ];
   }
 
-  if (metric.type === 'native-histogram') {
-    return buildNativeHistogramByLabelQuery(metric, queryConfig, expr, groupByLabel);
+  if (metric.type === 'classic-histogram' || metric.type === 'native-histogram') {
+    return buildHistogramByLabelQuery(metric, queryConfig, expr, groupByLabel);
   }
 
   return buildDefaultByLabelQuery(metric, queryConfig, expr, groupByLabel);

--- a/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
@@ -123,12 +123,15 @@ function buildHistogramPercentileByLabelQuery(
   ];
 }
 
+// queryConfig.histogramBreakdownFn ultimately comes from a scene variable (URL-settable), not a
+// closed type at runtime: an unexpected value must fall back to sum, not reach the percentile lookup
+// (a missing entry there divides by undefined, producing histogram_quantile(NaN, ...)).
 function buildHistogramByLabelQuery(metric: Metric, queryConfig: QueryConfig, expr: string, groupByLabel: string): SceneDataQuery[] {
-  const fn = queryConfig.histogramBreakdownFn ?? 'sum';
-  if (fn === 'sum') {
-    return buildHistogramSumByLabelQuery(metric, queryConfig, expr, groupByLabel);
+  const fn = queryConfig.histogramBreakdownFn;
+  if (fn && fn in HISTOGRAM_BY_LABEL_PERCENTILES) {
+    return buildHistogramPercentileByLabelQuery(metric, queryConfig, expr, groupByLabel, fn as Exclude<HistogramBreakdownFn, 'sum'>);
   }
-  return buildHistogramPercentileByLabelQuery(metric, queryConfig, expr, groupByLabel, fn);
+  return buildHistogramSumByLabelQuery(metric, queryConfig, expr, groupByLabel);
 }
 
 // if grouped by, we don't provide support for preset functions

--- a/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams.ts
@@ -61,6 +61,34 @@ export function getTimeseriesQueryRunnerParams(options: GetQueryRunnerParamsOpti
   };
 }
 
+const DEFAULT_HISTOGRAM_BY_LABEL_PERCENTILE = 99;
+
+// Aggregating a native histogram preserves its sample type instead of collapsing to a plain float, so
+// the usual avg-by-label query below would return a heatmap-shaped frame (yMin/yMax/count fields) that
+// a timeseries panel can't render. Reduce each label value to its own p99 line instead, the same
+// "which value is worst" comparison every other metric type's by-label panel gives.
+function buildNativeHistogramByLabelQuery(metric: Metric, queryConfig: QueryConfig, expr: string, groupByLabel: string): SceneDataQuery[] {
+  const interval = queryConfig.customRateInterval ?? '$__rate_interval';
+  const innerVector = promql.sum({ expr: promql.rate({ expr, interval }), by: [groupByLabel] });
+
+  const entry = PROMQL_FUNCTIONS.get('histogram_quantile');
+  if (!entry) {
+    logger.warn('[getTimeseriesQueryRunnerParams] Unknown PromQL function "histogram_quantile", skipping query.');
+    return [];
+  }
+
+  const queryExpr = entry.fn({ expr: innerVector, parameter: DEFAULT_HISTOGRAM_BY_LABEL_PERCENTILE / 100 });
+
+  return [
+    {
+      refId: `${metric.name}-by-${queryConfig.groupBy}`,
+      expr: queryExpr,
+      legendFormat: `{{${groupByLabel}}}`,
+      fromExploreMetrics: true,
+    },
+  ];
+}
+
 // if grouped by, we don't provide support for preset functions
 function buildGroupByQueries({
   metric,
@@ -91,6 +119,14 @@ function buildGroupByQueries({
     ];
   }
 
+  if (metric.type === 'native-histogram') {
+    return buildNativeHistogramByLabelQuery(metric, queryConfig, expr, groupByLabel);
+  }
+
+  return buildDefaultByLabelQuery(metric, queryConfig, expr, groupByLabel);
+}
+
+function buildDefaultByLabelQuery(metric: Metric, queryConfig: QueryConfig, expr: string, groupByLabel: string): SceneDataQuery[] {
   let typeDefault: PrometheusFunction = 'avg';
   if (metric.type === 'counter') {
     typeDefault = 'sum';

--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -6,6 +6,7 @@ export const VAR_FILTERS_EXPR = '${filters}';
 export const VAR_METRIC = 'metric';
 export const VAR_METRIC_EXPR = '${metric}';
 export const VAR_GROUP_BY = 'groupby';
+export const VAR_HISTOGRAM_BREAKDOWN_FN = 'histogramBreakdownFn';
 export const VAR_DATASOURCE = 'ds';
 export const VAR_DATASOURCE_EXPR = '${ds}';
 export const VAR_LOGS_DATASOURCE = 'logsDs';

--- a/src/shared/tracking/interactions.ts
+++ b/src/shared/tracking/interactions.ts
@@ -4,6 +4,7 @@ import { reportInteraction } from '@grafana/runtime';
 import { type ExposedComponentName } from 'exposedComponents/components';
 import { getTrackedFlagPayload } from 'shared/featureFlags/tracking';
 import { type PanelConfigPreset } from 'shared/GmdVizPanel/config/presets/types';
+import { type HistogramBreakdownFn } from 'shared/GmdVizPanel/GmdVizPanel';
 import { type MetricType } from 'shared/GmdVizPanel/matchers/getMetricType';
 import { type PanelType } from 'shared/GmdVizPanel/types/available-panel-types';
 import { type SortSeriesByOption } from 'shared/services/sorting';
@@ -33,6 +34,8 @@ type Interactions = {
   };
   // User changed the breakdown layout
   breakdown_layout_changed: { layout: LayoutType };
+  // User changed the by-label breakdown aggregation function for a histogram metric
+  histogram_breakdown_fn_changed: { fn: HistogramBreakdownFn };
   // A metric exploration has started due to one of the following causes
   exploration_started: {
     cause: 'bookmark_clicked';


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** <!-- Paste a GitHub issue URL or another pull request URL -->
Resolves https://github.com/grafana/metrics-drilldown/issues/887
Resolves https://github.com/grafana/metrics-drilldown/issues/829

Histograms label breakdown was broken, not applying rate correctly, and for native histograms showing heatmap responses in the timeseries panel. See yMax and other incorrect labels.
<img width="1502" height="919" alt="Screenshot 2026-08-18 at 4 24 01 PM" src="https://github.com/user-attachments/assets/381e4d5c-9664-46a2-a22c-4b57c3fa8eda" />

This feature correctly identifies histograms, classic and native. It first applies a default sum function with rate, whicle differentiating native and classic. It also allows a user to select a quantile function instead of the sum. 

<img width="1480" height="908" alt="Screenshot 2026-08-19 at 9 27 12 AM" src="https://github.com/user-attachments/assets/d4c44401-46d8-4731-b0cc-78d69a1f40a3" />


https://github.com/user-attachments/assets/2ad21c28-ed22-4672-97d9-3e706e882712




### 📖 Summary of the changes

- Use the most up to date native histogram detection and apply that to breakdown tab panels
- Upon identifying both classic and native histograms, apply default sum with rate functions.
- Allow user to select a histogram quantile function
- Add rudderstack event tracking
- Update docs

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/metrics-drilldown/blob/main/docs/genai.md))

### 🧪 How to test?

1. graft GMD to ops. 
2. [Navigate here](https://ops.grafana-ops.net/a/grafana-metricsdrilldown-app/drilldown?layout=grid&filters-rule=&filters-prefix=&filters-suffix=&filter-firing-alerts=&search_txt=seconds&var-metrics_filters=&var-filters=&metric=adaptive_logs_gateway_request_overhead_duration_seconds&actionView=breakdown&var-groupby=$__all&var-ds=2z9d6ElGk&var-labelsWingman=%28none%29&breakdownLayout=grid&breakdownSearchText=&from=now-1h&to=now&timezone=utc) and see that the breakdown panels shows a default sum(rate) function and legend does not show heatmap response labels like yMax.
3. See the native histogram is correct in the label breakdown.
4. Select a new function , p99 and see that the function changes in the network tab
