### PR TITLE
fix: use derived metric type in config presets to fix native histogram bug

### DIFF
--- a/src/shared/GmdVizPanel/GmdVizPanel.tsx
+++ b/src/shared/GmdVizPanel/GmdVizPanel.tsx
@@ -177,7 +177,7 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
     this.checkMetricMetadata(discardPanelTypeUpdates);
   }
 
-  // Metadata can resolve a type the sync heuristic can't guess at all (histogram, summary), not just swap
+  // Metadata can resolve a type the sync heuristic can't guess (currently only native histograms), not just swap
   // between counter and gauge. Only applied from a generic sync guess: a metric already classified more
   // specifically by name (e.g. classic-histogram) shouldn't be reprocessed here.
   private applyMetadataResolvedType(metricType: MetricType, metricTypeFromMetadata: MetricType, discardPanelTypeUpdates: boolean) {

--- a/src/shared/GmdVizPanel/GmdVizPanel.tsx
+++ b/src/shared/GmdVizPanel/GmdVizPanel.tsx
@@ -171,10 +171,30 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
   private async onActivate(discardPanelTypeUpdates: boolean) {
     this.buildVizPanel();
 
-    this.subscribeToStateChanges(discardPanelTypeUpdates);
+    this.subscribeToStateChanges();
     this.subscribeToEvents();
 
     this.checkMetricMetadata(discardPanelTypeUpdates);
+  }
+
+  // Metadata can resolve a type the sync heuristic can't guess at all (histogram, summary), not just swap
+  // between counter and gauge. Only applied from a generic sync guess: a metric already classified more
+  // specifically by name (e.g. classic-histogram) shouldn't be reprocessed here.
+  private applyMetadataResolvedType(metricType: MetricType, metricTypeFromMetadata: MetricType, discardPanelTypeUpdates: boolean) {
+    if (metricType !== 'gauge' && metricType !== 'counter') {
+      return;
+    }
+    if (metricTypeFromMetadata === 'gauge' || metricTypeFromMetadata === 'counter') {
+      return;
+    }
+
+    if (metricTypeFromMetadata === 'native-histogram') {
+      // Also flips panelConfig.type to heatmap (unless the panel type is pinned): a metadata-resolved
+      // native histogram needs the same panel switch the probe already applies.
+      this.switchToNativeHistogramHeatmap(discardPanelTypeUpdates);
+    } else {
+      this.setState({ metricType: metricTypeFromMetadata });
+    }
   }
 
   private async checkMetricMetadata(discardPanelTypeUpdates: boolean) {
@@ -197,10 +217,12 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
       this.setState({ metricType: 'counter' });
     }
 
-    // Native histograms — notably adaptive/aggregated ones — can expose no metadata and cannot be queried
-    // without rate()+aggregation, so the default gauge query returns empty and the metric is mis-typed as a
-    // gauge. When there's no metadata and we still think it's a gauge, run a rated probe query: if it comes
-    // back as a native-histogram (HeatmapCells) frame with data, switch the panel to a heatmap.
+    this.applyMetadataResolvedType(metricType, metricTypeFromMetadata, discardPanelTypeUpdates);
+
+    // A native histogram queried without rate()+aggregation returns no data, so a metric with no metadata
+    // stays mis-typed as a gauge and its default query comes back empty. When there's no metadata and we
+    // still think it's a gauge, run a rated probe query instead: if it comes back as a native-histogram
+    // (HeatmapCells) frame with data, switch the panel to a heatmap.
     if (metricTypeFromMetadata === 'gauge' && this.state.metricType === 'gauge') {
       const metadata = await getTrailFor(this).getMetadataForMetric(metric); // cached from getMetricType() above
       if (!metadata) {
@@ -211,13 +233,13 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
 
   /**
    * Runs a one-shot rated probe query (`sum(rate(metric[interval]))`) to detect a native histogram that
-   * the sync heuristics and metadata both miss (notably adaptive/aggregated native histograms, which
-   * expose no metadata and return empty for the default gauge query).
+   * the sync heuristics and metadata both miss. A native histogram queried without rate()+aggregation
+   * returns no data at all, so this probe deliberately uses a query shape that can actually reveal it.
    *
    * The probe runs on a temporary query runner attached to this panel's `$data` slot so it inherits scene
    * context (time range, variables, datasource). This is safe only because the rendered `body` always owns
    * its own `$data`, so nothing resolves upward to this probe during the probe window. The probe never
-   * renders. Only a native-histogram (HeatmapCells) frame with rows flips the panel to a heatmap — an empty
+   * renders. Only a native-histogram (HeatmapCells) frame with rows flips the panel to a heatmap, an empty
    * result is inconclusive and is neither cached nor acted on.
    */
   private detectNativeHistogram(discardPanelTypeUpdates: boolean) {
@@ -280,7 +302,7 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
     }
 
     // When a caller pinned the panel type (discardPanelTypeUpdates), only correct the metric type and leave
-    // the requested panel type alone — mirroring the data-frame detection path in subscribeToStateChanges().
+    // the requested panel type alone.
     if (discardPanelTypeUpdates) {
       this.setState({ metricType: 'native-histogram' });
       return;
@@ -296,49 +318,7 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
     });
   }
 
-  private subscribeToStateChanges(discardPanelTypeUpdates: boolean) {
-    const { metricType, body } = this.state;
-
-    // in addition to using the metadata fetched in src/helpers/MetricDatasourceHelper.ts to determine if the metric is a native histogram or not,
-    // we give another chance to display it properly by looking into the data frame type received
-    const isKgHistogramHint = this.state.queryConfig.kgMetricType === 'histogram';
-    if (isKgHistogramHint || !['classic-histogram', 'native-histogram'].includes(metricType)) {
-      const bodySub = (body?.state.$data as SceneDataProvider)?.subscribeToState((newState) => {
-        if (newState.data?.state !== LoadingState.Done) {
-          return;
-        }
-
-        // Always unsubscribe on first Done event — prevents multiple firings.
-        bodySub.unsubscribe();
-
-        const dataFrameType = newState.data.series?.[0]?.meta?.type;
-        if (!dataFrameType) {
-          return;
-        }
-
-        if (dataFrameType === DataFrameType.HeatmapCells) {
-          if (this.state.panelConfig.type === 'heatmap') {
-            return;
-          }
-
-          if (discardPanelTypeUpdates) {
-            this.setState({ metricType: 'native-histogram' });
-          } else {
-            this.setState({
-              metricType: 'native-histogram',
-              panelConfig: {
-                description: t('gmd-viz-panel.native-histogram', 'Native Histogram'),
-                ...this.state.panelConfig,
-                type: 'heatmap',
-              },
-            });
-          }
-        }
-      });
-
-      this._subs.add(bodySub);
-    }
-
+  private subscribeToStateChanges() {
     this.subscribeToState((newState, prevState) => {
       if (newState.panelConfig.type !== prevState.panelConfig.type) {
         this.buildVizPanel(); // rebuild the whole panel

--- a/src/shared/GmdVizPanel/__tests__/GmdVizPanel.test.ts
+++ b/src/shared/GmdVizPanel/__tests__/GmdVizPanel.test.ts
@@ -71,19 +71,6 @@ function createProbeRunner() {
   return { runner, subscription, fireDone, fire };
 }
 
-function createMockDataProvider() {
-  let capturedCallback: ((state: any) => void) | undefined;
-  const subscription = { unsubscribe: jest.fn() };
-  const provider = {
-    subscribeToState: jest.fn().mockImplementation((cb: (state: any) => void) => {
-      capturedCallback = cb;
-      return subscription;
-    }),
-  };
-  const fire = (state: any) => capturedCallback?.(state);
-  return { provider, subscription, fire };
-}
-
 describe('GmdVizPanel', () => {
   beforeEach(() => {
     jest.mocked(getMetricType).mockResolvedValue('gauge');
@@ -97,16 +84,14 @@ describe('GmdVizPanel', () => {
   });
 
   describe('checkMetricMetadata', () => {
-    test('does not update state when metadata returns native-histogram (detection is via data frames only)', async () => {
+    test('updates metricType and switches to heatmap when metadata resolves the metric as a native histogram', async () => {
       jest.mocked(getMetricType).mockResolvedValue('native-histogram');
       const panel = createPanel();
-      const initialMetricType = panel.state.metricType;
-      const initialPanelConfig = panel.state.panelConfig;
 
       await (panel as any).checkMetricMetadata();
 
-      expect(panel.state.metricType).toBe(initialMetricType);
-      expect(panel.state.panelConfig).toBe(initialPanelConfig);
+      expect(panel.state.metricType).toBe('native-histogram');
+      expect(panel.state.panelConfig.type).toBe('heatmap');
     });
 
     test('updates metricType from counter to gauge when metadata disagrees', async () => {
@@ -247,100 +232,17 @@ describe('GmdVizPanel', () => {
     });
   });
 
-  describe('subscribeToStateChanges', () => {
-    test('sets metricType and panelConfig.type to heatmap when data frame is HeatmapCells', () => {
-      const { provider, fire } = createMockDataProvider();
-      const panel = createPanel();
-      panel.setState({ body: { state: { $data: provider } } as any });
+  // subscribeToStateChanges no longer does its own native-histogram detection (removed: a query with no
+  // rate() returns no data for a native histogram, so watching the panel's own default-shaped query could
+  // never observe a HeatmapCells frame for exactly the metrics this app cares about). Detection is metadata
+  // plus the rated probe only; see the checkMetricMetadata/detectNativeHistogram tests above.
+  test('subscribeToStateChanges no longer subscribes to the panel body data provider', () => {
+    const panel = createPanel();
+    const provider = { subscribeToState: jest.fn() };
+    panel.setState({ body: { state: { $data: provider } } as any });
 
-      (panel as any).subscribeToStateChanges(false);
+    (panel as any).subscribeToStateChanges();
 
-      fire({
-        data: {
-          state: LoadingState.Done,
-          series: [{ meta: { type: DataFrameType.HeatmapCells } }],
-        },
-      });
-
-      expect(panel.state.metricType).toBe('native-histogram');
-      expect(panel.state.panelConfig.type).toBe('heatmap');
-    });
-
-    test('guard: returns early when panelConfig.type is already heatmap', () => {
-      const { provider, fire } = createMockDataProvider();
-      const panel = createPanel();
-
-      panel.setState({ panelConfig: { ...panel.state.panelConfig, type: 'heatmap' } });
-      panel.setState({ body: { state: { $data: provider } } as any });
-
-      (panel as any).subscribeToStateChanges(false);
-
-      const setStateSpy = jest.spyOn(panel, 'setState');
-      fire({
-        data: {
-          state: LoadingState.Done,
-          series: [{ meta: { type: DataFrameType.HeatmapCells } }],
-        },
-      });
-
-      expect(setStateSpy).not.toHaveBeenCalled();
-    });
-
-    test('unsubscribes after first Done event', () => {
-      const { provider, subscription, fire } = createMockDataProvider();
-      const panel = createPanel();
-      panel.setState({ body: { state: { $data: provider } } as any });
-
-      (panel as any).subscribeToStateChanges(false);
-
-      fire({
-        data: {
-          state: LoadingState.Done,
-          series: [{ meta: { type: 'some-non-heatmap-type' } }],
-        },
-      });
-
-      expect(subscription.unsubscribe).toHaveBeenCalledTimes(1);
-    });
-
-    test('subscribes to data provider even when discardPanelTypeUpdates=true', () => {
-      const { provider } = createMockDataProvider();
-      const panel = createPanel();
-      panel.setState({ body: { state: { $data: provider } } as any });
-
-      (panel as any).subscribeToStateChanges(true);
-
-      expect(provider.subscribeToState).toHaveBeenCalledTimes(1);
-    });
-
-    test('sets metricType but not panelConfig.type when discardPanelTypeUpdates=true and data frame is HeatmapCells', () => {
-      const { provider, fire } = createMockDataProvider();
-      const panel = createPanel();
-      panel.setState({ body: { state: { $data: provider } } as any });
-      const originalPanelType = panel.state.panelConfig.type;
-
-      (panel as any).subscribeToStateChanges(true);
-
-      fire({
-        data: {
-          state: LoadingState.Done,
-          series: [{ meta: { type: DataFrameType.HeatmapCells } }],
-        },
-      });
-
-      expect(panel.state.metricType).toBe('native-histogram');
-      expect(panel.state.panelConfig.type).toBe(originalPanelType);
-    });
-
-    test('does not subscribe when metricType is already native-histogram', () => {
-      jest.mocked(getMetricTypeSync).mockReturnValue('native-histogram' as any);
-      const panel = createPanel();
-      const { provider } = createMockDataProvider();
-      panel.setState({ body: { state: { $data: provider } } as any });
-
-      (panel as any).subscribeToStateChanges(false);
-
-      expect(provider.subscribeToState).not.toHaveBeenCalled();
-    });
+    expect(provider.subscribeToState).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm.tsx
+++ b/src/shared/GmdVizPanel/components/ConfigurePanelForm/ConfigurePanelForm.tsx
@@ -72,12 +72,12 @@ export class ConfigurePanelForm extends SceneObjectBase<ConfigurePanelFormState>
     sceneGraph.getTimeRange(this).setState({ from, to, timeZone, value });
   }
 
-  private async buildBody() {
+  private buildBody() {
     const { metric } = this.state;
     const trail = getTrailFor(this);
     const prefConfig = getPreferredConfigForMetric(metric.name);
     const entry = trail.state.sourceMetrics?.find((s) => s.metricName === metric.name);
-    const presets = await getConfigPresetsForMetric(metric.name, trail, entry?.metricType);
+    const presets = getConfigPresetsForMetric(metric.type);
 
     // if not found in the user preferences, we use the first preset
     // it always works because the presets are organized to always have the default one as the first element (see GmdVizPanel/config/presets)

--- a/src/shared/GmdVizPanel/config/presets/getConfigPresetsForMetric.ts
+++ b/src/shared/GmdVizPanel/config/presets/getConfigPresetsForMetric.ts
@@ -1,6 +1,4 @@
-import { type DataTrail } from 'AppDataTrail/DataTrail';
-import { getMetricType } from 'shared/GmdVizPanel/matchers/getMetricType';
-import { type KgMetricType } from 'shared/GmdVizPanel/matchers/mapKgMetricType';
+import { type MetricType } from 'shared/GmdVizPanel/matchers/getMetricType';
 
 import { DEFAULT_TIMESERIES_AGE_PRESETS } from './config-presets-ages';
 import { DEFAULT_HISTOGRAMS_PRESETS } from './config-presets-histograms';
@@ -9,9 +7,10 @@ import { DEFAULT_STATUS_UP_DOWN_PRESETS } from './config-presets-status-updown';
 import { DEFAULT_TIMESERIES_PRESETS, DEFAULT_TIMESERIES_RATE_PRESETS } from './config-presets-timeseries';
 import { type PanelConfigPreset } from './types';
 
-export async function getConfigPresetsForMetric(metric: string, dataTrail: DataTrail, kgMetricType?: KgMetricType): Promise<PanelConfigPreset[]> {
-  const metricType = await getMetricType(metric, dataTrail, kgMetricType);
-
+// Takes the already-resolved metric type instead of re-deriving it: by the time the configure drawer is
+// open, GmdVizPanel has already resolved the type via metadata and/or the native-histogram probe, and
+// re-deriving here (metadata-only, no probe) would disagree with it. See metrics-drilldown#1228.
+export function getConfigPresetsForMetric(metricType: MetricType): PanelConfigPreset[] {
   switch (metricType) {
     case 'counter':
       return Object.values(DEFAULT_TIMESERIES_RATE_PRESETS);

--- a/src/shared/tracking/interactions.ts
+++ b/src/shared/tracking/interactions.ts
@@ -200,13 +200,13 @@ type Interactions = {
   quick_search_assistant_mode_entered: { from: 'question_mark' | 'tab' | 'button' };
   // User opens the save query modal
   saved_query_save_modal_opened: {};
-  // User successfully saves a query (local storage only — Query Library save has no callback)
+  // User successfully saves a query (local storage only, Query Library save has no callback)
   saved_query_saved: { source: 'local' };
   // User opens the load query modal
   saved_query_load_modal_opened: {};
-  // User toggles between saved queries in the load list (local storage only — Query Library has no callback)
+  // User toggles between saved queries in the load list (local storage only, Query Library has no callback)
   saved_query_toggled: { source: 'local' };
-  // User deletes a saved query (local storage only — Query Library delete has no callback)
+  // User deletes a saved query (local storage only, Query Library delete has no callback)
   saved_query_deleted: { source: 'local' };
   // User loads a saved query (localStorage)
   saved_query_loaded: {};


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** <!-- Paste a GitHub issue URL or another pull request URL -->
Resolves https://github.com/grafana/metrics-drilldown/issues/1228

BROKEN
<img width="1487" height="893" alt="Screenshot 2026-08-19 at 7 47 11 PM" src="https://github.com/user-attachments/assets/fc007895-91be-4194-b1d2-e90fca7c6b77" />

FIXED
<img width="1610" height="889" alt="Screenshot 2026-08-19 at 8 29 57 PM" src="https://github.com/user-attachments/assets/71dfb342-76bd-4eed-a72d-5de8f286938c" />


This is a refactor of the native histogram check. Back in April we [based our check on returned data frames](https://github.com/grafana/metrics-drilldown/issues/1199) but found this failed on some cases where there was no data returned (no activity and no rate function would not return heatmap cells for native histograms). We had to create a new strategy. 

The [new strategy is a pre-query or probe query with rate](https://github.com/grafana/metrics-drilldown/pull/1380), which is more robust. 

Based on this new strategy, this PR uses that probe query metric type to pass into the config presets to correctly show heatmap and quantiles for native histograms.

### 📖 Summary of the changes

- Refactor native histogram detection to use only the probe query strategy.
- Remove the post query data response check for heatmap cells
- Use the metric type in the config presets

Important to acknowledge: The [original issue](https://github.com/grafana/metrics-drilldown/issues/1228) noted a race condition where the presets might show wrongly, the type is changed and a user may be impacted by a race condition. This is a very narrow window now with the new strategy and I have not been able to trigger it. We are leaving this race condition unhandled in this PR because the tradeoff for creating the plumbing is not worth it.

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/metrics-drilldown/blob/main/docs/genai.md))

### 🧪 How to test?

- graft this on to ops
- select a native histogram from the metric list [(link to a native histogram on ops here)](https://ops.grafana-ops.net/a/grafana-metricsdrilldown-app/drilldown?from=now-1h&to=now&timezone=utc&var-metrics_filters=&var-filters=&var-labelsWingman=%28none%29&layout=grid&filters-rule=&filters-prefix=&filters-suffix=&search_txt=%20adaptive_logs_gateway_archival_blocking_duration_seconds&filter-firing-alerts=&var-metrics-reducer-sort-by=default&filters-recent=&var-ds=edprtf91hz01se&var-other_metric_filters=).
- select the metric
- open the config function in the metric view metric panel
- see the config presets are heatmap and quantile
