### PR TITLE
chore: remove bottom border between filters and quicksearch

### DIFF
--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -673,7 +673,6 @@ function getStyles(theme: GrafanaTheme2, headerHeight: number, trail: DataTrail)
       background,
       zIndex: theme.zIndex.navbarFixed,
       top: headerHeight,
-      borderBottom: `1px solid ${theme.colors.border.weak}`,
     }),
   };
 }


### PR DESCRIPTION
Closes #1398.

Removes the `borderBottom` from the `controls` style in `DataTrail.tsx`, the container holding the data source picker/filters/timepicker, directly above the metrics quicksearch input.

Here's how it was (taken from the original issue):

<img width="2712" height="386" alt="Before: 1px border between the filters row and the quicksearch input" src="https://github.com/user-attachments/assets/72c6f9fa-98b7-40d9-b592-b2c83b51f3b7" />


And here's how it is now:

<img width="1616" height="191" alt="After: no border between the filters row and the quicksearch input" src="https://github.com/user-attachments/assets/9a088cdc-835d-47d5-8fdb-30a85abcb6d5" />

> [!NOTE]
> The "after" screenshot was taken on a local dev instance (Grafana 12.4.0 OSS, `gdev-prometheus`), so it renders with different theme colors and corner radii than the "before" image. I couldn't match the theme used in the issue screenshot against the ones shipped in 12.4.0, so it likely comes from a different Grafana build.
