### PR TITLE
fix: histogram breakdown values bug in applying function

### DIFF
--- a/src/MetricScene/Breakdown/HistogramBreakdownFnVariable.tsx
+++ b/src/MetricScene/Breakdown/HistogramBreakdownFnVariable.tsx
@@ -19,7 +19,7 @@ export class HistogramBreakdownFnVariable extends CustomVariable {
   constructor() {
     super({
       name: VAR_HISTOGRAM_BREAKDOWN_FN,
-      label: t('breakdown.histogram-fn.label', 'Histogram breakdown function'),
+      label: t('breakdown.histogram-fn.label', 'Histogram function'),
       query: HISTOGRAM_BREAKDOWN_FN_OPTIONS.map(({ label, value }) => `${label} : ${value}`).join(','),
       value: 'sum',
       text: t('breakdown.histogram-fn.default-text', 'Sum'),

--- a/src/MetricScene/Breakdown/LabelBreakdownScene.tsx
+++ b/src/MetricScene/Breakdown/LabelBreakdownScene.tsx
@@ -69,8 +69,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
       });
     }
 
-    this.subscribeToMainPanelMetricType();
-    this.updateBody(groupByVariable);
+    this.subscribeToMainPanelMetricType(groupByVariable);
   }
 
   private getVariable(): QueryVariable {
@@ -91,27 +90,47 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     return sceneGraph.findDescendents(metricScene.state.body, GmdVizPanel)[0];
   }
 
-  private subscribeToMainPanelMetricType() {
+  private subscribeToMainPanelMetricType(groupByVariable: QueryVariable) {
     const mainPanel = this.getMainPanel();
+
+    this.updateBody(groupByVariable);
+
     if (!mainPanel) {
       return;
     }
 
     this._subs.add(
       mainPanel.subscribeToState((newState, prevState) => {
-        if (newState.metricType !== prevState.metricType) {
+        if (
+          newState.metricType !== prevState.metricType ||
+          newState.metricTypeResolved !== prevState.metricTypeResolved
+        ) {
           this.updateBody(this.getVariable());
         }
       })
     );
   }
 
+  // The main panel's metricType starts as a fast sync-heuristic guess (see GmdVizPanel) and only becomes
+  // trustworthy once metricTypeResolved flips true. Building the body before that would bake the wrong
+  // function into the query, which then gets replaced a moment later when the real type resolves -- a
+  // visible flash of the wrong query. So this defers the build until the type is resolved; the mainPanel
+  // subscription above re-triggers it once resolution lands, whatever call site (groupByVariable change,
+  // histogram fn change, activation) skipped it in the meantime.
   private updateBody(groupByVariable: QueryVariable) {
+    const mainPanel = this.getMainPanel();
+    if (mainPanel && !mainPanel.state.metricTypeResolved) {
+      return;
+    }
+
     const { metric: name } = this.state;
     const trail = getTrailFor(this);
-    const type: MetricType = this.getMainPanel()?.state.metricType ?? 'gauge';
+    const type: MetricType = mainPanel?.state.metricType ?? 'gauge';
 
     const metric = { name, type };
+    // Passed to MetricLabelValuesList explicitly: its constructor runs before it's parented in the scene
+    // graph, so it can't look this variable up itself the way its other methods do later.
+    const histogramBreakdownFn = this.getHistogramBreakdownFnVariable().state.value as HistogramBreakdownFn | undefined;
 
     const newBody = groupByVariable.hasAllValue()
       ? new MetricLabelsList({ metric })
@@ -119,6 +138,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
           metric,
           label: groupByVariable.state.value as string,
           binaryQuery: trail.state.binaryQuery,
+          histogramBreakdownFn,
         });
 
     this.setState({ body: newBody, metricType: type });

--- a/src/MetricScene/Breakdown/LabelBreakdownScene.tsx
+++ b/src/MetricScene/Breakdown/LabelBreakdownScene.tsx
@@ -171,7 +171,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
               <div className={styles.leftControls}>
                 <groupByVariable.Component model={groupByVariable} />
                 {isHistogram && (
-                  <Field label={t('breakdown.histogram-fn.label', 'Histogram breakdown function')} className={styles.field}>
+                  <Field label={t('breakdown.histogram-fn.label', 'Histogram function')} className={styles.field}>
                     <histogramBreakdownFnVariable.Component model={histogramBreakdownFnVariable} />
                   </Field>
                 )}

--- a/src/MetricScene/Breakdown/LabelBreakdownScene.tsx
+++ b/src/MetricScene/Breakdown/LabelBreakdownScene.tsx
@@ -111,12 +111,9 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     );
   }
 
-  // The main panel's metricType starts as a fast sync-heuristic guess (see GmdVizPanel) and only becomes
-  // trustworthy once metricTypeResolved flips true. Building the body before that would bake the wrong
-  // function into the query, which then gets replaced a moment later when the real type resolves -- a
-  // visible flash of the wrong query. So this defers the build until the type is resolved; the mainPanel
-  // subscription above re-triggers it once resolution lands, whatever call site (groupByVariable change,
-  // histogram fn change, activation) skipped it in the meantime.
+  // metricType is a fast sync guess until metricTypeResolved flips true; building the body before then
+  // would briefly query with the wrong function. Wait here -- the mainPanel subscription above re-triggers
+  // this once it resolves, for whichever call site got skipped.
   private updateBody(groupByVariable: QueryVariable) {
     const mainPanel = this.getMainPanel();
     if (mainPanel && !mainPanel.state.metricTypeResolved) {
@@ -128,8 +125,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     const type: MetricType = mainPanel?.state.metricType ?? 'gauge';
 
     const metric = { name, type };
-    // Passed to MetricLabelValuesList explicitly: its constructor runs before it's parented in the scene
-    // graph, so it can't look this variable up itself the way its other methods do later.
+    // See MetricLabelValuesList's constructor for why this is passed explicitly instead of looked up there.
     const histogramBreakdownFn = this.getHistogramBreakdownFnVariable().state.value as HistogramBreakdownFn | undefined;
 
     const newBody = groupByVariable.hasAllValue()

--- a/src/MetricScene/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
+++ b/src/MetricScene/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
@@ -28,6 +28,7 @@ import { QUERY_RESOLUTION } from 'shared/GmdVizPanel/config/query-resolutions';
 import { GmdVizPanel, type HistogramBreakdownFn } from 'shared/GmdVizPanel/GmdVizPanel';
 import { type Metric } from 'shared/GmdVizPanel/matchers/getMetricType';
 import { addCardinalityInfo } from 'shared/GmdVizPanel/types/timeseries/behaviors/addCardinalityInfo';
+import { buildStaticTimeseriesPanel } from 'shared/GmdVizPanel/types/timeseries/buildTimeseriesPanel';
 import { getTimeseriesQueryRunnerParams } from 'shared/GmdVizPanel/types/timeseries/getTimeseriesQueryRunnerParams';
 import { addUnspecifiedLabel } from 'shared/GmdVizPanel/types/timeseries/transformations/addUnspecifiedLabel';
 import { trailDS, VAR_HISTOGRAM_BREAKDOWN_FN } from 'shared/shared';
@@ -61,10 +62,16 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
     metric,
     label,
     binaryQuery,
+    histogramBreakdownFn,
   }: {
     metric: MetricLabelsValuesListState['metric'];
     label: MetricLabelsValuesListState['label'];
     binaryQuery?: string;
+    // Passed in by LabelBreakdownScene (which already has it, for the dropdown) rather than looked up here
+    // via sceneGraph.lookupVariable: this constructor runs before `this` is parented, so the variable isn't
+    // reachable yet. This value drives the query below, which per-value panels render directly from (see
+    // getLayoutChild), so it has to be correct up front, not just for value discovery.
+    histogramBreakdownFn?: HistogramBreakdownFn;
   }) {
     const queryParams = getTimeseriesQueryRunnerParams({
       metric,
@@ -76,6 +83,7 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
         // For a binary (ratio) insight, enumerate values from the grouped binary (sum by(label)(binary))
         // rather than the anchor metric. Requires clean/bare operands so the label survives grouping.
         binaryExpr: binaryQuery,
+        histogramBreakdownFn,
       },
     });
 
@@ -223,6 +231,11 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
     const entry = getTrailFor(this).state.sourceMetrics?.find((s) => s.metricName === metric.name);
     // For a binary (ratio) insight, page filters do not apply, so hide the per-value "Add to filters" action.
     const isBinaryQuery = Boolean(binaryQuery);
+    // Histograms render directly from the frame this list's own shared query already produced (see the
+    // constructor: it's the same by-label, histogram-function-aware query), instead of each panel
+    // reissuing its own independent query. A fresh per-panel query would have to re-derive metric.type from
+    // just a metric name and race its own async resolution, which is exactly the bug this avoids.
+    const isHistogram = metric.type === 'classic-histogram' || metric.type === 'native-histogram';
 
     return new SceneByFrameRepeater({
       // we set the syncYAxis behavior here to ensure that the EventResetSyncYAxis events that are published by SceneByFrameRepeater can be received
@@ -274,35 +287,53 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
         const isEmptyLabelValue = labelValueFromDataFrame.startsWith('<unspecified'); // see the "addUnspecifiedLabel" data transformation
         const labelValue = isEmptyLabelValue ? '' : labelValueFromDataFrame;
 
-        const vizPanel = new GmdVizPanel({
-          metric: metric.name,
-          discardUserPrefs: true,
-          panelOptions: {
-            ...prefMetricConfig?.panelOptions,
-            title: labelValueFromDataFrame,
-            fixedColorIndex: frameIndex,
-            description: '',
-            headerActions: isEmptyLabelValue || isBinaryQuery
-              ? () => []
-              : () => [new AddToFiltersGraphAction({ labelName: label, labelValue })],
-            menu: () => new PanelMenu({ labelName: label }),
-            // publishTimeseriesData is required for the syncYAxis behavior (see MetricLabelsList)
-            // no worries to add it for all panel types here as it will check if the panel is a timeseries
-            // and if the data frame received is a timeseries before acting
-            behaviors: [publishTimeseriesData()],
-          },
-          queryOptions: {
-            ...prefMetricConfig?.queryOptions,
-            // Binary: render the ratio scoped to this value by injecting {label="value"} into both
-            // operands. Otherwise: the single-metric selector filtered to the value.
-            ...(binaryQuery
-              ? { binaryExpr: injectLabelMatcher(binaryQuery, label, labelValue), binaryLegend: labelValueFromDataFrame }
-              : { labelMatchers: [{ key: label, operator: '=', value: labelValue }] }),
-            customRateInterval: entry?.customRateInterval,
-            customFunction: entry?.customFunction,
-            kgMetricType: entry?.metricType,
-          },
-        });
+        const headerActions = isEmptyLabelValue || isBinaryQuery
+          ? () => []
+          : () => [new AddToFiltersGraphAction({ labelName: label, labelValue })];
+
+        const vizPanel = isHistogram
+          ? buildStaticTimeseriesPanel({
+              metric,
+              data,
+              frame,
+              panelConfig: {
+                type: 'timeseries',
+                title: labelValueFromDataFrame,
+                height: PANEL_HEIGHT.M,
+                fixedColorIndex: frameIndex,
+                description: '',
+                headerActions,
+                menu: () => new PanelMenu({ labelName: label }),
+                behaviors: [publishTimeseriesData()],
+              },
+            })
+          : new GmdVizPanel({
+              metric: metric.name,
+              discardUserPrefs: true,
+              panelOptions: {
+                ...prefMetricConfig?.panelOptions,
+                title: labelValueFromDataFrame,
+                fixedColorIndex: frameIndex,
+                description: '',
+                headerActions,
+                menu: () => new PanelMenu({ labelName: label }),
+                // publishTimeseriesData is required for the syncYAxis behavior (see MetricLabelsList)
+                // no worries to add it for all panel types here as it will check if the panel is a timeseries
+                // and if the data frame received is a timeseries before acting
+                behaviors: [publishTimeseriesData()],
+              },
+              queryOptions: {
+                ...prefMetricConfig?.queryOptions,
+                // Binary: render the ratio scoped to this value by injecting {label="value"} into both
+                // operands. Otherwise: the single-metric selector filtered to the value.
+                ...(binaryQuery
+                  ? { binaryExpr: injectLabelMatcher(binaryQuery, label, labelValue), binaryLegend: labelValueFromDataFrame }
+                  : { labelMatchers: [{ key: label, operator: '=', value: labelValue }] }),
+                customRateInterval: entry?.customRateInterval,
+                customFunction: entry?.customFunction,
+                kgMetricType: entry?.metricType,
+              },
+            });
 
         return new SceneCSSGridItem({ body: vizPanel });
       },

--- a/src/MetricScene/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
+++ b/src/MetricScene/Breakdown/MetricLabelValuesList/MetricLabelValuesList.tsx
@@ -67,10 +67,9 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
     metric: MetricLabelsValuesListState['metric'];
     label: MetricLabelsValuesListState['label'];
     binaryQuery?: string;
-    // Passed in by LabelBreakdownScene (which already has it, for the dropdown) rather than looked up here
-    // via sceneGraph.lookupVariable: this constructor runs before `this` is parented, so the variable isn't
-    // reachable yet. This value drives the query below, which per-value panels render directly from (see
-    // getLayoutChild), so it has to be correct up front, not just for value discovery.
+    // Passed by LabelBreakdownScene rather than looked up here: this constructor runs before `this` is
+    // parented, so sceneGraph.lookupVariable can't reach it yet. Drives the query below, which per-value
+    // panels render directly from (see getLayoutChild).
     histogramBreakdownFn?: HistogramBreakdownFn;
   }) {
     const queryParams = getTimeseriesQueryRunnerParams({
@@ -231,10 +230,8 @@ export class MetricLabelValuesList extends SceneObjectBase<MetricLabelsValuesLis
     const entry = getTrailFor(this).state.sourceMetrics?.find((s) => s.metricName === metric.name);
     // For a binary (ratio) insight, page filters do not apply, so hide the per-value "Add to filters" action.
     const isBinaryQuery = Boolean(binaryQuery);
-    // Histograms render directly from the frame this list's own shared query already produced (see the
-    // constructor: it's the same by-label, histogram-function-aware query), instead of each panel
-    // reissuing its own independent query. A fresh per-panel query would have to re-derive metric.type from
-    // just a metric name and race its own async resolution, which is exactly the bug this avoids.
+    // Histogram panels render from this list's own shared query below (see buildStaticTimeseriesPanel)
+    // instead of each reissuing its own.
     const isHistogram = metric.type === 'classic-histogram' || metric.type === 'native-histogram';
 
     return new SceneByFrameRepeater({

--- a/src/shared/GmdVizPanel/GmdVizPanel.tsx
+++ b/src/shared/GmdVizPanel/GmdVizPanel.tsx
@@ -114,10 +114,9 @@ export type QueryOptions = {
 interface GmdVizPanelState extends SceneObjectState {
   metric: string;
   metricType: MetricType;
-  // False until the async metric type detection (metadata fetch, and the native-histogram probe if it
-  // runs) has settled. Consumers that build a query from metricType (e.g. LabelBreakdownScene) should wait
-  // for this instead of using the initial sync-heuristic guess, so they don't fire a query with the wrong
-  // function and then immediately replace it once the real type resolves.
+  // False until metric type detection (metadata fetch, or the native-histogram probe) has settled.
+  // Consumers building a query from metricType (e.g. LabelBreakdownScene) should wait for this rather
+  // than use the initial sync guess.
   metricTypeResolved: boolean;
   panelConfig: PanelConfig;
   queryConfig: QueryConfig;

--- a/src/shared/GmdVizPanel/GmdVizPanel.tsx
+++ b/src/shared/GmdVizPanel/GmdVizPanel.tsx
@@ -114,6 +114,11 @@ export type QueryOptions = {
 interface GmdVizPanelState extends SceneObjectState {
   metric: string;
   metricType: MetricType;
+  // False until the async metric type detection (metadata fetch, and the native-histogram probe if it
+  // runs) has settled. Consumers that build a query from metricType (e.g. LabelBreakdownScene) should wait
+  // for this instead of using the initial sync-heuristic guess, so they don't fire a query with the wrong
+  // function and then immediately replace it once the real type resolves.
+  metricTypeResolved: boolean;
   panelConfig: PanelConfig;
   queryConfig: QueryConfig;
   body?: VizPanel;
@@ -145,6 +150,7 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
       key,
       metric,
       metricType,
+      metricTypeResolved: false,
       panelConfig: {
         type: panelOptions?.type || getPanelTypeForMetricSync(metric, queryOptions?.kgMetricType),
         title: metric,
@@ -201,6 +207,7 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
     const { metric, queryConfig } = this.state;
 
     if (queryConfig.kgMetricType) {
+      this.setState({ metricTypeResolved: true });
       return;
     }
 
@@ -226,9 +233,12 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
     if (metricTypeFromMetadata === 'gauge' && this.state.metricType === 'gauge') {
       const metadata = await getTrailFor(this).getMetadataForMetric(metric); // cached from getMetricType() above
       if (!metadata) {
-        this.detectNativeHistogram(discardPanelTypeUpdates);
+        this.detectNativeHistogram(discardPanelTypeUpdates); // marks metricTypeResolved once the probe settles
+        return;
       }
     }
+
+    this.setState({ metricTypeResolved: true });
   }
 
   /**
@@ -251,6 +261,7 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
       if (cached) {
         this.switchToNativeHistogramHeatmap(discardPanelTypeUpdates);
       }
+      this.setState({ metricTypeResolved: true });
       return;
     }
 
@@ -272,7 +283,7 @@ export class GmdVizPanel extends SceneObjectBase<GmdVizPanelState> {
       }
 
       sub.unsubscribe();
-      this.setState({ $data: undefined }); // remove the temporary probe provider (deactivates the runner)
+      this.setState({ $data: undefined, metricTypeResolved: true }); // remove the temporary probe provider (deactivates the runner)
 
       // A failed or empty probe is inconclusive (e.g. query error, or no data in the current time range):
       // don't cache and don't switch, so the metric can be probed again on a later activation.

--- a/src/shared/GmdVizPanel/types/timeseries/buildTimeseriesPanel.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/buildTimeseriesPanel.ts
@@ -16,6 +16,24 @@ import { addRefId } from './transformations/addRefId';
 import { addUnspecifiedLabel } from './transformations/addUnspecifiedLabel';
 import { sliceSeries } from './transformations/sliceSeries';
 
+// Shared by buildTimeseriesPanel and buildStaticTimeseriesPanel below, which both render one series (or
+// a small number sharing a color) rather than buildGroupByPanel's many-series-per-panel case.
+function applyCommonPanelOptions(
+  builder: ReturnType<typeof PanelBuilders.timeseries>,
+  metric: Metric,
+  panelConfig: PanelConfig
+) {
+  return builder
+    .setTitle(panelConfig.title)
+    .setDescription(panelConfig.description)
+    .setHeaderActions(panelConfig.headerActions({ metric, panelConfig }))
+    .setMenu(panelConfig.menu?.({ metric, panelConfig }))
+    .setShowMenuAlways(Boolean(panelConfig.menu))
+    .setOption('annotations', { multiLane: true })
+    .setOption('legend', panelConfig.legend || { showLegend: true, placement: 'bottom' as LegendPlacement })
+    .setCustomFieldConfig('fillOpacity', 9);
+}
+
 export function buildTimeseriesPanel(options: BuildVizPanelOptions): VizPanel {
   if (options.queryConfig.groupBy) {
     return buildGroupByPanel(options as Required<BuildVizPanelOptions>);
@@ -33,17 +51,9 @@ export function buildTimeseriesPanel(options: BuildVizPanelOptions): VizPanel {
       queries: queryParams.queries,
     });
 
-  const vizPanelBuilder = PanelBuilders.timeseries()
-    .setTitle(panelConfig.title)
-    .setDescription(panelConfig.description)
-    .setHeaderActions(panelConfig.headerActions({ metric, panelConfig }))
-    .setMenu(panelConfig.menu?.({ metric, panelConfig }))
-    .setShowMenuAlways(Boolean(panelConfig.menu))
+  const vizPanelBuilder = applyCommonPanelOptions(PanelBuilders.timeseries(), metric, panelConfig)
     .setData($data)
     .setUnit(unit)
-    .setOption('annotations', { multiLane: true })
-    .setOption('legend', panelConfig.legend || { showLegend: true, placement: 'bottom' as LegendPlacement })
-    .setCustomFieldConfig('fillOpacity', 9)
     .setBehaviors([
       extremeValueFilterBehavior,
       updateColorsWhenQueriesChange(panelConfig.fixedColorIndex),
@@ -72,11 +82,9 @@ export function buildTimeseriesPanel(options: BuildVizPanelOptions): VizPanel {
   return vizPanelBuilder.build();
 }
 
-// Renders one already-fetched frame with no query of its own. For a caller that already ran a query
-// with a correctly-resolved metric.type (e.g. the per-value breakdown grid's shared by-label query) and
-// just wants to display one of its resulting series per panel: reissuing a fresh, independently-typed
-// query per panel would redundantly redo work the caller already has the answer to, and would race its
-// own metric-type resolution from scratch (see MetricLabelValuesList for why that matters for histograms).
+// Renders one already-fetched frame with no query of its own, for a caller whose own shared query (see
+// MetricLabelValuesList) already resolved metric.type correctly. A fresh per-panel query here would redo
+// that work and re-race the same type resolution from scratch.
 export function buildStaticTimeseriesPanel({
   metric,
   panelConfig,
@@ -88,17 +96,9 @@ export function buildStaticTimeseriesPanel({
   data: PanelData;
   frame: DataFrame;
 }): VizPanel {
-  return PanelBuilders.timeseries()
-    .setTitle(panelConfig.title)
-    .setDescription(panelConfig.description)
-    .setHeaderActions(panelConfig.headerActions({ metric, panelConfig }))
-    .setMenu(panelConfig.menu?.({ metric, panelConfig }))
-    .setShowMenuAlways(Boolean(panelConfig.menu))
+  return applyCommonPanelOptions(PanelBuilders.timeseries(), metric, panelConfig)
     .setData(new SceneDataNode({ data: { ...data, series: [frame] } }))
     .setUnit(getUnit(metric.name))
-    .setOption('annotations', { multiLane: true })
-    .setOption('legend', panelConfig.legend || { showLegend: true, placement: 'bottom' as LegendPlacement })
-    .setCustomFieldConfig('fillOpacity', 9)
     .setColor(
       panelConfig.fixedColorIndex !== undefined
         ? { mode: 'fixed', fixedColor: getColorByIndex(panelConfig.fixedColorIndex) }

--- a/src/shared/GmdVizPanel/types/timeseries/buildTimeseriesPanel.ts
+++ b/src/shared/GmdVizPanel/types/timeseries/buildTimeseriesPanel.ts
@@ -1,7 +1,10 @@
-import { PanelBuilders, SceneDataTransformer, SceneQueryRunner, type VizPanel } from '@grafana/scenes';
+import { type DataFrame, type PanelData } from '@grafana/data';
+import { PanelBuilders, SceneDataNode, SceneDataTransformer, SceneQueryRunner, type VizPanel } from '@grafana/scenes';
 import { SortOrder, TooltipDisplayMode, type LegendPlacement } from '@grafana/schema';
 
 import { extremeValueFilterBehavior } from 'shared/GmdVizPanel/behaviors/extremeValueFilterBehavior/extremeValueFilterBehavior';
+import { type PanelConfig } from 'shared/GmdVizPanel/GmdVizPanel';
+import { type Metric } from 'shared/GmdVizPanel/matchers/getMetricType';
 import { trailDS } from 'shared/shared';
 import { getColorByIndex } from 'shared/utils/utils';
 
@@ -67,6 +70,42 @@ export function buildTimeseriesPanel(options: BuildVizPanelOptions): VizPanel {
   }
 
   return vizPanelBuilder.build();
+}
+
+// Renders one already-fetched frame with no query of its own. For a caller that already ran a query
+// with a correctly-resolved metric.type (e.g. the per-value breakdown grid's shared by-label query) and
+// just wants to display one of its resulting series per panel: reissuing a fresh, independently-typed
+// query per panel would redundantly redo work the caller already has the answer to, and would race its
+// own metric-type resolution from scratch (see MetricLabelValuesList for why that matters for histograms).
+export function buildStaticTimeseriesPanel({
+  metric,
+  panelConfig,
+  data,
+  frame,
+}: {
+  metric: Metric;
+  panelConfig: PanelConfig;
+  data: PanelData;
+  frame: DataFrame;
+}): VizPanel {
+  return PanelBuilders.timeseries()
+    .setTitle(panelConfig.title)
+    .setDescription(panelConfig.description)
+    .setHeaderActions(panelConfig.headerActions({ metric, panelConfig }))
+    .setMenu(panelConfig.menu?.({ metric, panelConfig }))
+    .setShowMenuAlways(Boolean(panelConfig.menu))
+    .setData(new SceneDataNode({ data: { ...data, series: [frame] } }))
+    .setUnit(getUnit(metric.name))
+    .setOption('annotations', { multiLane: true })
+    .setOption('legend', panelConfig.legend || { showLegend: true, placement: 'bottom' as LegendPlacement })
+    .setCustomFieldConfig('fillOpacity', 9)
+    .setColor(
+      panelConfig.fixedColorIndex !== undefined
+        ? { mode: 'fixed', fixedColor: getColorByIndex(panelConfig.fixedColorIndex) }
+        : undefined
+    )
+    .setBehaviors(panelConfig.behaviors || [])
+    .build();
 }
 
 export const MAX_SERIES_TO_RENDER_WHEN_GROUPED_BY = 20;


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** <!-- Paste a GitHub issue URL or another pull request URL -->
Resolves https://github.com/grafana/metrics-drilldown/issues/1190

Another bug surfaced in metrics drilldown for histograms. This fixes applying the new histogram breakdown function to label values breakdown, which had been defaulting to show a heatmap.

BEFORE - label value panel is heatmap and not connected to the Histogram function for breakdown
<img width="1147" height="677" alt="Screenshot 2026-08-21 at 1 14 18 PM" src="https://github.com/user-attachments/assets/45caf301-e16c-4a8d-9e6f-0223f1a9fbb5" />



AFTER - Applies the selected histogram breakdown function and shows timeseries panel
<img width="1172" height="728" alt="Screenshot 2026-08-21 at 1 16 16 PM" src="https://github.com/user-attachments/assets/acef6fac-e298-4889-ba7c-7b13497b7f88" />


### 📖 Summary of the changes

- use the selected function from breakdown on label values 
- do not show heatmap panel
- take the query from a label and decompose it to get data for label values

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/metrics-drilldown/blob/main/docs/genai.md))

### 🧪 How to test?

1. graft this branch onto ops.
2. select a histogram metric
3. breakdown by label such as "cluster"
4. see that the label values breakdown uses the selected histogram function and does not show a heatmap panel.
