### PR TITLE
fix: remove page chrome from embedded trails

### DIFF
--- a/src/App/Trail.test.tsx
+++ b/src/App/Trail.test.tsx
@@ -1,4 +1,7 @@
-import { getPageNav } from './Trail';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { getPageNav, TrailPage } from './Trail';
 import { MetricScene } from '../MetricScene/MetricScene';
 import { MetricsReducer } from '../MetricsReducer/MetricsReducer';
 
@@ -85,5 +88,28 @@ describe('Trail Component - Breadcrumb Logic Tests', () => {
 
       expect(result).toBeUndefined();
     });
+  });
+});
+
+describe('TrailPage', () => {
+  it('does not add plugin page chrome around embedded trails', () => {
+    const { container } = render(
+      <TrailPage embedded pageNav={undefined}>
+        <div>Embedded metrics</div>
+      </TrailPage>
+    );
+
+    expect(container.firstElementChild).toBe(screen.getByText('Embedded metrics'));
+  });
+
+  it('keeps plugin page chrome around standalone trails', () => {
+    const { container } = render(
+      <TrailPage embedded={false} pageNav={undefined}>
+        <div>Standalone metrics</div>
+      </TrailPage>
+    );
+
+    expect(container.firstElementChild).not.toBe(screen.getByText('Standalone metrics'));
+    expect(container.firstElementChild).toContainElement(screen.getByText('Standalone metrics'));
   });
 });

--- a/src/App/Trail.tsx
+++ b/src/App/Trail.tsx
@@ -62,12 +62,30 @@ export function getPageNav(
   return undefined;
 }
 
+interface TrailPageProps {
+  embedded?: boolean;
+  pageNav: NavModelItem | undefined;
+  children: React.ReactNode;
+}
+
+export function TrailPage({ embedded, pageNav, children }: Readonly<TrailPageProps>) {
+  if (embedded) {
+    return <>{children}</>;
+  }
+
+  return (
+    <PluginPage pageNav={pageNav} layout={PageLayoutType.Custom}>
+      {children}
+    </PluginPage>
+  );
+}
+
 export default function Trail({ trail }: Readonly<TrailProps>) {
   // Register all assistant questions for metrics drilldown
   // Questions are automatically matched based on URL patterns
   useMetricsDrilldownQuestions();
 
-  const { topScene, metric } = trail.useState();
+  const { topScene, metric, embedded } = trail.useState();
   const [currentActionViewName, setCurrentActionViewName] = useState<string>('');
 
   // Subscribe to MetricScene state changes to update breadcrumb
@@ -99,7 +117,7 @@ export default function Trail({ trail }: Readonly<TrailProps>) {
   );
 
   return (
-    <PluginPage pageNav={pageNav} layout={PageLayoutType.Custom}>
+    <TrailPage embedded={embedded} pageNav={pageNav}>
       <UrlSyncContextProvider
         scene={trail}
         createBrowserHistorySteps={true}
@@ -110,6 +128,6 @@ export default function Trail({ trail }: Readonly<TrailProps>) {
           <trail.Component model={trail} />
         </TrailErrorBoundary>
       </UrlSyncContextProvider>
-    </PluginPage>
+    </TrailPage>
   );
 }


### PR DESCRIPTION
## What changed
- render embedded metric trails without the standalone `PluginPage` wrapper
- keep the existing page chrome and breadcrumb behavior for standalone Metrics Drilldown
- cover both embedded and standalone wrapper contracts

This removes the outer page surface that produces the border when exposed Metrics Drilldown components are mounted inside another app.

## Verification
- `pnpm exec jest src/App/Trail.test.tsx --runInBand --forceExit --testTimeout=10000` (11/11 passed)
- `pnpm typecheck`
- `pnpm exec eslint src/App/Trail.tsx src/App/Trail.test.tsx`
- `git diff --check`

Fixes #1410
