### PR TITLE
fix(VisualRefresh): Fixes background issue in visual refresh

### DIFF
--- a/src/AppDataTrail/DataTrail.tsx
+++ b/src/AppDataTrail/DataTrail.tsx
@@ -670,7 +670,7 @@ function getStyles(theme: GrafanaTheme2, headerHeight: number, embedded?: boolea
       flexGrow: 1,
       padding: theme.spacing(1, 2),
       position: 'relative',
-      background,
+      background: embedded ? background : undefined,
     }),
     body: css({
       flexGrow: 1,


### PR DESCRIPTION
Fixes an issue with the border radius in visual refresh, the top level DataTrail should not have any background (when not embedded) as it interferes with the page border 
<img width="69" height="42" alt="Screenshot 2026-09-02 at 11 12 13" src="https://github.com/user-attachments/assets/f5fd5789-2292-457e-8779-54d6cd992b54" />
