### PR TITLE
chore(ci): use GitHub App token broker for cp-update workflow

### DIFF
--- a/.github/workflows/cp-update.yml
+++ b/.github/workflows/cp-update.yml
@@ -5,22 +5,21 @@ on:
   schedule:
     - cron: '0 0 1 * *' # run once a month on the 1st day
 
-# To use the default github token with the following elevated permissions make sure to check:
-# **Allow GitHub Actions to create and approve pull requests** in https://github.com/ORG_NAME/REPO_NAME/settings/actions.
-# Alternatively create a fine-grained personal access token for your repository with
-# `contents: read and write` and `pull requests: read and write` and pass it to the action.
-
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for create-github-app-token OIDC auth
     steps:
-      - uses: grafana/plugin-actions/create-plugin-update@fd00a7eb2dec59a902206c2382c33f6c725819ee # main
-        # Uncomment to use a fine-grained personal access token instead of default github token
-        # (For more info on how to generate the token see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
-        # with:
-        # Make sure to save the token in your repository secrets
-        # token: $
+      - id: get-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1 (2026-06-01)
+        with:
+          github_app: grafana-plugins-platform-bot
+
+      - uses: grafana/plugin-actions/create-plugin-update@18c6da61002740639bf0322e1a756366d98f5b81 # create-plugin-update/v2.0.4 (2026-08-25)
+        with:
+          token: ${{ steps.get-github-token.outputs.token }}
+          node-version: '22'

--- a/.github/workflows/cp-update.yml
+++ b/.github/workflows/cp-update.yml
@@ -22,4 +22,4 @@ jobs:
       - uses: grafana/plugin-actions/create-plugin-update@18c6da61002740639bf0322e1a756366d98f5b81 # create-plugin-update/v2.0.4 (2026-08-25)
         with:
           token: ${{ steps.get-github-token.outputs.token }}
-          node-version: '24'
+          node-version: '22'

--- a/.github/workflows/cp-update.yml
+++ b/.github/workflows/cp-update.yml
@@ -22,4 +22,4 @@ jobs:
       - uses: grafana/plugin-actions/create-plugin-update@18c6da61002740639bf0322e1a756366d98f5b81 # create-plugin-update/v2.0.4 (2026-08-25)
         with:
           token: ${{ steps.get-github-token.outputs.token }}
-          node-version: '22'
+          node-version: '24'


### PR DESCRIPTION
## Summary 📝

- Switch the `cp-update.yml` (Create Plugin Update) workflow to mint a scoped `grafana-plugins-platform-bot` token via `create-github-app-token` instead of the default `GITHUB_TOKEN`, and bump `create-plugin-update` to v2.0.4 with `node-version: '22'`, matching traces-drilldown's workflow (grafana/traces-drilldown#868).

> [!IMPORTANT]
> Merge after grafana/deployment_tools#711686, which adds the `Create Plugin Update` GitHub App config entry for `metrics-drilldown` — without it, the token broker has no permission to mint a token for this workflow and the monthly job will fail.

## Test 🧪

- [x] Diffed the new workflow against traces-drilldown's merged `.github/workflows/cp-update.yml` to confirm identical action pins and permissions
- [x] Confirmed `permissions: {}` at workflow level with explicit `contents: read` / `id-token: write` at job level, required for OIDC app-token auth


