### PR TITLE
fix(deps): align react-router with Grafana runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-inlinesvg": "^4.2.0",
-    "react-router": "^8.3.0",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^6.30.6",
+    "react-router-dom": "^6.30.6",
     "rxjs": "7.8.2",
     "tslib": "^2.8.1",
     "tsqtsq": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-inlinesvg": "^4.2.0",
-    "react-router": "^6.30.6",
     "react-router-dom": "^6.30.6",
     "rxjs": "7.8.2",
     "tslib": "^2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  react-router: ^8.3.0
-  react-router-dom@^6: ^7.18.1
+  react-router: ^6.30.6
+  react-router-dom@^6: ^6.30.6
   dompurify: ^3.4.12
   lodash: ^4.18.0
   minimatch@^3: ~3.1.4
@@ -60,7 +60,7 @@ importers:
         version: 11.13.5(supports-color@8.1.1)
       '@grafana/assistant':
         specifier: ^0.1.12
-        version: 0.1.18(@grafana/data@13.1.0(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3))(@grafana/runtime@13.1.0(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react@18.3.28)(codemirror@6.0.2)(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3))(@grafana/scenes@7.3.13(62f7396757ed58eaee9db4f852d32e53))(@grafana/ui@13.1.0(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react@18.3.28)(codemirror@6.0.2)(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3))(react@18.3.1)(rxjs@7.8.2)
+        version: 0.1.18(@grafana/data@13.1.0(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3))(@grafana/runtime@13.1.0(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react@18.3.28)(codemirror@6.0.2)(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3))(@grafana/scenes@7.3.13(534ed3efde65fc8f60aeb87a5d37f4ac))(@grafana/ui@13.1.0(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react@18.3.28)(codemirror@6.0.2)(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3))(react@18.3.1)(rxjs@7.8.2)
       '@grafana/data':
         specifier: ^13.0.0
         version: 13.1.0(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3)
@@ -84,7 +84,7 @@ importers:
         version: 13.1.0(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react@18.3.28)(codemirror@6.0.2)(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3)
       '@grafana/scenes':
         specifier: ^7.0.0
-        version: 7.3.13(62f7396757ed58eaee9db4f852d32e53)
+        version: 7.3.13(534ed3efde65fc8f60aeb87a5d37f4ac)
       '@grafana/schema':
         specifier: ^13.0.0
         version: 13.1.0
@@ -119,11 +119,11 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0(react@18.3.1)
       react-router:
-        specifier: ^8.3.0
-        version: 8.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^6.30.6
+        version: 6.30.6(react@18.3.1)
       react-router-dom:
-        specifier: ^7.18.1
-        version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^6.30.6
+        version: 6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rxjs:
         specifier: 7.8.2
         version: 7.8.2
@@ -940,7 +940,7 @@ packages:
       '@grafana/ui': '>=11.6'
       react: ^18.0.0
       react-dom: ^18.0.0
-      react-router-dom: ^7.18.1
+      react-router-dom: ^6.30.6
       rxjs: ^7.8.1
 
   '@grafana/schema@13.1.0':
@@ -3163,9 +3163,6 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  cookie-es@3.1.1:
-    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -5478,22 +5475,18 @@ packages:
     peerDependencies:
       react: '>=15'
 
-  react-router-dom@7.18.2:
-    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
-    engines: {node: '>=20.0.0'}
+  react-router-dom@6.30.6:
+    resolution: {integrity: sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=16.8'
+      react-dom: '>=16.8'
 
-  react-router@8.3.0:
-    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
-    engines: {node: '>=22.22.0'}
+  react-router@6.30.6:
+    resolution: {integrity: sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
-      react: '>=19.2.7'
-      react-dom: '>=19.2.7'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
+      react: '>=16.8'
 
   react-select@5.10.2:
     resolution: {integrity: sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==}
@@ -7177,11 +7170,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@grafana/assistant@0.1.18(@grafana/data@13.1.0(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3))(@grafana/runtime@13.1.0(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react@18.3.28)(codemirror@6.0.2)(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3))(@grafana/scenes@7.3.13(62f7396757ed58eaee9db4f852d32e53))(@grafana/ui@13.1.0(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react@18.3.28)(codemirror@6.0.2)(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3))(react@18.3.1)(rxjs@7.8.2)':
+  '@grafana/assistant@0.1.18(@grafana/data@13.1.0(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3))(@grafana/runtime@13.1.0(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react@18.3.28)(codemirror@6.0.2)(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3))(@grafana/scenes@7.3.13(534ed3efde65fc8f60aeb87a5d37f4ac))(@grafana/ui@13.1.0(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react@18.3.28)(codemirror@6.0.2)(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3))(react@18.3.1)(rxjs@7.8.2)':
     dependencies:
       '@grafana/data': 13.1.0(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3)
       '@grafana/runtime': 13.1.0(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react@18.3.28)(codemirror@6.0.2)(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3)
-      '@grafana/scenes': 7.3.13(62f7396757ed58eaee9db4f852d32e53)
+      '@grafana/scenes': 7.3.13(534ed3efde65fc8f60aeb87a5d37f4ac)
       '@grafana/ui': 13.1.0(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react@18.3.28)(codemirror@6.0.2)(eslint@10.0.2(jiti@2.7.0)(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.9.3)
       react: 18.3.1
       rxjs: 7.8.2
@@ -7408,7 +7401,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@grafana/scenes@7.3.13(62f7396757ed58eaee9db4f852d32e53)':
+  '@grafana/scenes@7.3.13(534ed3efde65fc8f60aeb87a5d37f4ac)':
     dependencies:
       '@emotion/css': 11.10.5(@babel/core@8.0.1)(supports-color@8.1.1)
       '@emotion/react': 11.10.5(@babel/core@8.0.1)(@types/react@18.3.28)(react@18.3.1)(supports-color@8.1.1)
@@ -7426,7 +7419,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-grid-layout: 1.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-router-dom: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom: 6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-select: 5.10.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-virtualized-auto-sizer: 1.0.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7505,8 +7498,8 @@ snapshots:
       react-hook-form: 7.71.2(react@18.3.1)
       react-inlinesvg: 4.3.0(react@18.3.1)
       react-loading-skeleton: 3.5.0(react@18.3.1)
-      react-router-dom: 5.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-router-dom-v5-compat: 6.30.3(react-dom@18.3.1(react@18.3.1))(react-router-dom@5.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      react-router-dom: 5.3.4(react@18.3.1)
+      react-router-dom-v5-compat: 6.30.3(react-dom@18.3.1(react@18.3.1))(react-router-dom@5.3.4(react@18.3.1))(react@18.3.1)
       react-select: 5.10.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       react-table: 7.8.0(react@18.3.1)
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9996,8 +9989,6 @@ snapshots:
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
-
-  cookie-es@3.1.1: {}
 
   cookie@0.7.2: {}
 
@@ -12650,40 +12641,37 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-draggable: 4.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-router-dom-v5-compat@6.30.3(react-dom@18.3.1(react@18.3.1))(react-router-dom@5.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+  react-router-dom-v5-compat@6.30.3(react-dom@18.3.1(react@18.3.1))(react-router-dom@5.3.4(react@18.3.1))(react@18.3.1):
     dependencies:
       '@remix-run/router': 1.23.3
       history: 5.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 8.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-router-dom: 5.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router: 6.30.6(react@18.3.1)
+      react-router-dom: 5.3.4(react@18.3.1)
 
-  react-router-dom@5.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@5.3.4(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.28.6
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
       react: 18.3.1
-      react-router: 8.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router: 6.30.6(react@18.3.1)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
-    transitivePeerDependencies:
-      - react-dom
 
-  react-router-dom@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
+      '@remix-run/router': 1.23.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 8.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router: 6.30.6(react@18.3.1)
 
-  react-router@8.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router@6.30.6(react@18.3.1):
     dependencies:
-      cookie-es: 3.1.1
+      '@remix-run/router': 1.23.3
       react: 18.3.1
-    optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
 
   react-select@5.10.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  react-router: ^6.30.6
-  react-router-dom@^6: ^6.30.6
+  react-router@^6: ^6.30.6
   dompurify: ^3.4.12
   lodash: ^4.18.0
   minimatch@^3: ~3.1.4
@@ -940,7 +939,7 @@ packages:
       '@grafana/ui': '>=11.6'
       react: ^18.0.0
       react-dom: ^18.0.0
-      react-router-dom: ^6.30.6
+      react-router-dom: ^6.28.0
       rxjs: ^7.8.1
 
   '@grafana/schema@13.1.0':
@@ -4333,6 +4332,9 @@ packages:
   is-window@1.0.2:
     resolution: {integrity: sha512-uj00kdXyZb9t9RcAUAwMZAnkBUwdYGhYlt7djMXhfyhUCzwNba50tIiBKR7q0l7tdoBtFVw/3JmLY6fI3rmZmg==}
 
+  isarray@0.0.1:
+    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -5111,6 +5113,9 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  path-to-regexp@1.9.0:
+    resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -5481,6 +5486,11 @@ packages:
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
+
+  react-router@5.3.4:
+    resolution: {integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==}
+    peerDependencies:
+      react: '>=15'
 
   react-router@6.30.6:
     resolution: {integrity: sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==}
@@ -11090,7 +11100,7 @@ snapshots:
 
   i18next@23.16.8:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
 
   i18next@25.8.13(typescript@5.9.3):
     dependencies:
@@ -11334,6 +11344,8 @@ snapshots:
       get-intrinsic: 1.3.0
 
   is-window@1.0.2: {}
+
+  isarray@0.0.1: {}
 
   isarray@2.0.5: {}
 
@@ -12308,6 +12320,10 @@ snapshots:
       lru-cache: 11.2.6
       minipass: 7.1.3
 
+  path-to-regexp@1.9.0:
+    dependencies:
+      isarray: 0.0.1
+
   path-type@4.0.0: {}
 
   pbf@4.0.1:
@@ -12657,7 +12673,7 @@ snapshots:
       loose-envify: 1.4.0
       prop-types: 15.8.1
       react: 18.3.1
-      react-router: 6.30.6(react@18.3.1)
+      react-router: 5.3.4(react@18.3.1)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
@@ -12667,6 +12683,19 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-router: 6.30.6(react@18.3.1)
+
+  react-router@5.3.4(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      history: 4.10.1
+      hoist-non-react-statics: 3.3.2
+      loose-envify: 1.4.0
+      path-to-regexp: 1.9.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-is: 16.13.1
+      tiny-invariant: 1.3.3
+      tiny-warning: 1.0.3
 
   react-router@6.30.6(react@18.3.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,9 +117,6 @@ importers:
       react-inlinesvg:
         specifier: ^4.2.0
         version: 4.2.0(react@18.3.1)
-      react-router:
-        specifier: ^6.30.6
-        version: 6.30.6(react@18.3.1)
       react-router-dom:
         specifier: ^6.30.6
         version: 6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,9 +33,9 @@ allowBuilds:
   protobufjs: true
   unrs-resolver: true
 
-# react-router and react-router-dom stay on v6 in package.json until Grafana's
-# upstream router migration lands: https://github.com/grafana/grafana/issues/129933
-# @grafana/ui's v5 compatibility package pins router 6.30.3, so keep only that
+# react-router-dom stays on v6 in package.json until Grafana's upstream router
+# migration lands: https://github.com/grafana/grafana/issues/129933
+# @grafana/ui's v5 compatibility package pins react-router 6.30.3, so keep that
 # transitive v6 line on 6.30.6, which includes the GHSA-jjmj-jmhj-qwj2 backport.
 overrides:
   react-router@^6: ^6.30.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,11 +31,12 @@ allowBuilds:
   protobufjs: true
   unrs-resolver: true
 
+# react-router and react-router-dom stay on v6 in package.json until Grafana's
+# upstream router migration lands: https://github.com/grafana/grafana/issues/129933
+# @grafana/ui's v5 compatibility package pins router 6.30.3, so keep only that
+# transitive v6 line on 6.30.6, which includes the GHSA-jjmj-jmhj-qwj2 backport.
 overrides:
-  # Keep plugin types aligned with Grafana's externalized v6 router. 6.30.6
-  # backports the GHSA-jjmj-jmhj-qwj2 fix without a runtime-major mismatch.
-  react-router: ^6.30.6
-  react-router-dom@^6: ^6.30.6
+  react-router@^6: ^6.30.6
   dompurify: ^3.4.12
   lodash: ^4.18.0
   minimatch@^3: ~3.1.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,13 +32,10 @@ allowBuilds:
   unrs-resolver: true
 
 overrides:
-  react-router: ^8.3.0
-  # @grafana/scenes wants react-router-dom@^6, whose 6.x line ends at 6.30.4 and is
-  # covered by GHSA-jjmj-jmhj-qwj2 (no 6.30.5 was ever published). v7 is a thin
-  # `export * from 'react-router'` shim, so scenes still gets Routes/Route while the
-  # whole tree shares one router core. @grafana/ui pins RRD 5.3.4 exactly, so its
-  # intentional v5 + v5-compat pairing is unaffected by this range override.
-  react-router-dom@^6: ^7.18.1
+  # Keep plugin types aligned with Grafana's externalized v6 router. 6.30.6
+  # backports the GHSA-jjmj-jmhj-qwj2 fix without a runtime-major mismatch.
+  react-router: ^6.30.6
+  react-router-dom@^6: ^6.30.6
   dompurify: ^3.4.12
   lodash: ^4.18.0
   minimatch@^3: ~3.1.4

--- a/src/App/AppErrorBoundary.test.tsx
+++ b/src/App/AppErrorBoundary.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import React, { act } from 'react';
-import { MemoryRouter, useNavigate } from 'react-router';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
 
 import { AppErrorBoundary, isChunkLoadError } from './AppErrorBoundary';
 import { logger } from '../shared/logger/logger';

--- a/src/App/AppErrorBoundary.tsx
+++ b/src/App/AppErrorBoundary.tsx
@@ -3,7 +3,7 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { Button, ErrorBoundary, useStyles2 } from '@grafana/ui';
 import React, { useEffect } from 'react';
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router-dom';
 
 import { ErrorView } from './ErrorView';
 import { logger } from '../shared/logger/logger';

--- a/src/App/ErrorView.tsx
+++ b/src/App/ErrorView.tsx
@@ -3,7 +3,7 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { Collapse, TextLink, useStyles2 } from '@grafana/ui';
 import React, { useCallback, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { HelpControls } from './HelpControls';
 import { InlineBanner } from './InlineBanner';

--- a/src/App/ErrorView.tsx
+++ b/src/App/ErrorView.tsx
@@ -7,6 +7,7 @@ import { useLocation, useNavigate } from 'react-router';
 
 import { HelpControls } from './HelpControls';
 import { InlineBanner } from './InlineBanner';
+import { normalizeInternalPathname } from './routingUtils';
 
 type ErrorViewProps = { error: Error };
 
@@ -25,7 +26,7 @@ export function ErrorView({ error }: Readonly<ErrorViewProps>) {
       .filter((key) => searchParams.has(key))
       .forEach((key) => newSearchParams.set(key, searchParams.get(key)!));
 
-    navigate({ pathname, search: newSearchParams.toString() });
+    navigate({ pathname: normalizeInternalPathname(pathname), search: newSearchParams.toString() });
     window.location.reload();
   }, [navigate, pathname, search]);
 

--- a/src/App/Routes.tsx
+++ b/src/App/Routes.tsx
@@ -1,5 +1,5 @@
 import React, { lazy } from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
 import { ROUTES } from 'shared/constants/routes';
 

--- a/src/App/TrailErrorBoundary.test.tsx
+++ b/src/App/TrailErrorBoundary.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import React, { act } from 'react';
-import { MemoryRouter, useNavigate } from 'react-router';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
 
 import { TrailErrorBoundary } from './TrailErrorBoundary';
 import { logger } from '../shared/logger/logger';

--- a/src/App/TrailErrorBoundary.tsx
+++ b/src/App/TrailErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { ErrorBoundary } from '@grafana/ui';
 import React from 'react';
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router-dom';
 
 import { ErrorView } from './ErrorView';
 import { logger } from '../shared/logger/logger';

--- a/src/App/routingUtils.test.ts
+++ b/src/App/routingUtils.test.ts
@@ -1,0 +1,18 @@
+import { normalizeInternalPathname } from './routingUtils';
+
+describe('normalizeInternalPathname', () => {
+  it.each([
+    ['//evil.example/path', '/evil.example/path'],
+    ['\\\\evil.example\\path', '/evil.example/path'],
+    ['///evil.example/path', '/evil.example/path'],
+  ])('keeps protocol-relative input on an internal path (%s)', (pathname, expected) => {
+    expect(normalizeInternalPathname(pathname)).toBe(expected);
+  });
+
+  it.each([
+    ['/a/grafana-metricsdrilldown-app/drilldown', '/a/grafana-metricsdrilldown-app/drilldown'],
+    ['a/grafana-metricsdrilldown-app/drilldown', '/a/grafana-metricsdrilldown-app/drilldown'],
+  ])('returns a normal path with exactly one leading slash (%s)', (pathname, expected) => {
+    expect(normalizeInternalPathname(pathname)).toBe(expected);
+  });
+});

--- a/src/App/routingUtils.ts
+++ b/src/App/routingUtils.ts
@@ -1,4 +1,5 @@
-// React Router v6 can interpret protocol-relative and backslash-prefixed values as external URLs.
+// React Router 6.30.6 fixes GHSA-jjmj-jmhj-qwj2 but remains affected by
+// GHSA-wrjc-x8rr-h8h6, which can treat backslash-prefixed values as external URLs.
 export function normalizeInternalPathname(pathname: string): string {
   return `/${pathname.replaceAll('\\', '/').replace(/^\/+/, '')}`;
 }

--- a/src/App/routingUtils.ts
+++ b/src/App/routingUtils.ts
@@ -1,0 +1,4 @@
+// React Router v6 can interpret protocol-relative and backslash-prefixed values as external URLs.
+export function normalizeInternalPathname(pathname: string): string {
+  return `/${pathname.replaceAll('\\', '/').replace(/^\/+/, '')}`;
+}


### PR DESCRIPTION
## Summary
- Aligns `react-router` and `react-router-dom` with Grafana's externalized v6 runtime
- Uses published v6.30.6, which backports the GHSA-jjmj-jmhj-qwj2 fix
- Normalizes ErrorView's URL-derived pathname to exactly one leading slash before navigation

## Security rationale
A v7/v8 compile target can mismatch the v6 router supplied by Grafana. GHSA-wrjc-x8rr-h8h6 has no v6 package fix, so the only production `navigate()` call receiving URL-derived input is hardened to remain internal. GHSA-337j-9hxr-rhxg is SSR hydration-only; this browser plugin does not use SSR.

## Test plan
- [x] `pnpm install --no-frozen-lockfile`
- [x] New routing tests: 5/5 pass and Jest exits 0
- [x] Related error-boundary assertions: 24/24 pass; Jest then hit the existing React `MESSAGEPORT` shutdown leak and was terminated after the 600s timeout
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] ESLint and Prettier checks
- [x] `pnpm audit` leaves only GHSA-wrjc and SSR-only GHSA-337j

## Known remaining
- GHSA-wrjc-x8rr-h8h6: no compatible v6 package patch; vulnerable call site hardened
- GHSA-337j-9hxr-rhxg: not applicable to this non-SSR plugin

This PR remains draft pending review.
