### PR TITLE
chore: add frozenLockfile to pnpm workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@ packages:
   - '.'
 
 # https://pnpm.io/supply-chain-security
+# Same as passing --frozen-lockfile on every pnpm install (CI uses this via plugin-ci-workflows too).
+frozenLockfile: true
 # Disable package lifecycle scripts (postinstall, etc.) on install.
 ignoreScripts: true
 # Five days in minutes (5 × 24 × 60).


### PR DESCRIPTION
**What is this feature?**

Adds `frozenLockfile: true` to `pnpm-workspace.yaml` so a local `pnpm install` fails on a lockfile mismatch instead of silently rewriting it.

**Why do we need this feature?**

So local installs match CI's `--frozen-lockfile` behavior and so we have the same setting throughout the drilldown repos.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
