### PR TITLE
feat: add SLO-tracked metric filtering and indicators

### DIFF
--- a/e2e/fixtures/views/MetricsReducerView.ts
+++ b/e2e/fixtures/views/MetricsReducerView.ts
@@ -50,6 +50,14 @@ export class MetricsReducerView extends DrilldownView {
     return this.getByTestId('list-controls');
   }
 
+  getSloTrackedChip() {
+    return this.getListControls().getByRole('button', { name: /SLO-tracked/i });
+  }
+
+  async toggleSloTrackedFilter() {
+    await this.getSloTrackedChip().click();
+  }
+
   async assertListControls() {
     await expect(this.getListControls()).toBeVisible();
     await expect(this.quickSearch.get()).toBeVisible();
@@ -113,6 +121,10 @@ export class MetricsReducerView extends DrilldownView {
 
   selectMetricPanel(panelTitle: string) {
     return this.getPanelByTitle(panelTitle).getByTestId(`select-action-${panelTitle}`).click();
+  }
+
+  getSloTrackedBadge(panelTitle: string) {
+    return this.getPanelByTitle(panelTitle).getByTestId('slo-tracked-badge');
   }
 
   getMetricsGroupByList() {

--- a/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
+++ b/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
@@ -183,7 +183,7 @@ test.describe('SLO-tracked metrics optional integration', () => {
     await metricsReducerView.sidebar.selectGroupByLabel('job');
     await metricsReducerView.assertMetricsGroupByList();
     await expect(metricsReducerView.getSloTrackedChip()).toHaveAttribute('aria-pressed', 'true');
-    await expect(metricsReducerView.getSloTrackedBadge(SECOND_TRACKED_METRIC)).toBeVisible();
+    await expect(metricsReducerView.getSloTrackedBadge(SECOND_TRACKED_METRIC).first()).toBeVisible();
     await expect(metricsReducerView.getPanelByTitle(UNTRACKED_METRIC)).toHaveCount(0);
   });
 

--- a/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
+++ b/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
@@ -179,6 +179,8 @@ test.describe('SLO-tracked metrics optional integration', () => {
     await expect(metricsReducerView.getSloTrackedChip()).toHaveAttribute('aria-pressed', 'true');
     await expect(metricsReducerView.getPanelByTitle(UNTRACKED_METRIC)).toHaveCount(0);
 
+    await metricsReducerView.toggleSloTrackedFilter();
+    await expect(metricsReducerView.getSloTrackedChip()).toHaveAttribute('aria-pressed', 'false');
     await metricsReducerView.sidebar.toggleButton('Group by labels');
     await metricsReducerView.sidebar.selectGroupByLabel('job');
     await metricsReducerView.assertMetricsGroupByList();

--- a/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
+++ b/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
@@ -195,6 +195,7 @@ test.describe('SLO-tracked metrics optional integration', () => {
 
     await expect(metricsReducerView.getSloTrackedChip()).toHaveCount(0);
     await expect(page).not.toHaveURL(/filter-slo-tracked=true/);
+    await metricsReducerView.quickSearch.enterText(UNTRACKED_METRIC);
     await expect(metricsReducerView.getPanelByTitle(UNTRACKED_METRIC)).toBeVisible();
   });
 });

--- a/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
+++ b/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
@@ -33,7 +33,26 @@ async function injectSloPlugin(page: Page) {
     const inject = (bootData: Record<string, any>) => {
       bootData.settings ??= {};
       bootData.settings.apps ??= {};
-      bootData.settings.apps['grafana-slo-app'] = { version: 'test-version' };
+      bootData.settings.apps['grafana-slo-app'] = {
+        id: 'grafana-slo-app',
+        path: '',
+        version: 'test-version',
+        preload: false,
+        angular: { detected: false, hideDeprecation: false },
+        loadingStrategy: 'script',
+        dependencies: {
+          grafanaVersion: '*',
+          plugins: [],
+          extensions: { exposedComponents: [] },
+        },
+        extensions: {
+          addedComponents: [],
+          addedFunctions: [],
+          addedLinks: [],
+          exposedComponents: [],
+          extensionPoints: [],
+        },
+      };
       return bootData;
     };
 

--- a/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
+++ b/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
@@ -179,12 +179,12 @@ test.describe('SLO-tracked metrics optional integration', () => {
     await expect(metricsReducerView.getSloTrackedChip()).toHaveAttribute('aria-pressed', 'true');
     await expect(metricsReducerView.getPanelByTitle(UNTRACKED_METRIC)).toHaveCount(0);
 
-    await metricsReducerView.toggleSloTrackedFilter();
-    await expect(metricsReducerView.getSloTrackedChip()).toHaveAttribute('aria-pressed', 'false');
     await metricsReducerView.sidebar.toggleButton('Group by labels');
     await metricsReducerView.sidebar.selectGroupByLabel('job');
     await metricsReducerView.assertMetricsGroupByList();
+    await expect(metricsReducerView.getSloTrackedChip()).toHaveAttribute('aria-pressed', 'true');
     await expect(metricsReducerView.getSloTrackedBadge(SECOND_TRACKED_METRIC)).toBeVisible();
+    await expect(metricsReducerView.getPanelByTitle(UNTRACKED_METRIC)).toHaveCount(0);
   });
 
   test('clears stale URL filtering when the SLO API fails', async ({ page, metricsReducerView }) => {

--- a/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
+++ b/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
@@ -1,0 +1,181 @@
+import { type Page } from '@playwright/test';
+
+import {
+  GRAFANA_RULER_RULES_URL,
+  SLO_RESOURCE_URL,
+} from '../../../src/MetricsReducer/list-controls/MetricsSorter/fetchers/shared';
+import { expect, test } from '../../fixtures';
+
+const TRACKED_METRIC = 'handler_duration_seconds_count';
+const SECOND_TRACKED_METRIC = 'jaeger_tracer_finished_spans_total';
+const UNTRACKED_METRIC = 'memberlist_client_cas_success_total';
+
+async function enableSloFlag(page: Page) {
+  await page.route('**/ofrep/v1/evaluate/flags', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      json: {
+        flags: [
+          {
+            key: 'drilldown.metrics.slo_tracked_metrics',
+            value: true,
+            variant: 'enabled',
+            reason: 'STATIC',
+          },
+        ],
+      },
+    });
+  });
+}
+
+async function injectSloPlugin(page: Page) {
+  await page.addInitScript(() => {
+    const inject = (bootData: Record<string, any>) => {
+      bootData.settings ??= {};
+      bootData.settings.apps ??= {};
+      bootData.settings.apps['grafana-slo-app'] = { version: 'test-version' };
+      return bootData;
+    };
+
+    const target = window as typeof window & { grafanaBootData?: Record<string, any> };
+    if (target.grafanaBootData) {
+      inject(target.grafanaBootData);
+      return;
+    }
+
+    Object.defineProperty(target, 'grafanaBootData', {
+      configurable: true,
+      set(value: Record<string, any>) {
+        Object.defineProperty(target, 'grafanaBootData', {
+          configurable: true,
+          writable: true,
+          value: inject(value),
+        });
+      },
+    });
+  });
+}
+
+async function stubSloDefinitions(page: Page, status = 200) {
+  await page.route(`**${SLO_RESOURCE_URL}`, async (route) => {
+    if (status !== 200) {
+      await route.fulfill({ status, contentType: 'application/json', json: { message: 'unavailable' } });
+      return;
+    }
+
+    await route.fulfill({
+      contentType: 'application/json',
+      json: {
+        slos: [
+          {
+            uuid: 'slo-burning',
+            destinationDatasource: { uid: 'gdev-prometheus', type: 'prometheus' },
+            query: {
+              type: 'ratio',
+              ratio: {
+                successMetric: { prometheusMetric: TRACKED_METRIC },
+                totalMetric: { prometheusMetric: SECOND_TRACKED_METRIC },
+              },
+            },
+          },
+          {
+            uuid: 'slo-other-datasource',
+            destinationDatasource: { uid: 'other-prometheus', type: 'prometheus' },
+            query: {
+              type: 'freeform',
+              freeform: { query: UNTRACKED_METRIC },
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  await page.route(`**${GRAFANA_RULER_RULES_URL}*`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      json: {
+        status: 'success',
+        data: {
+          groups: [
+            {
+              name: 'slo-burn',
+              rules: [
+                {
+                  type: 'alerting',
+                  name: 'SLO burn',
+                  query: 'grafana_slo_sli_5m > 0',
+                  state: 'firing',
+                  labels: { grafana_slo_uuid: 'slo-burning', grafana_slo_severity: 'critical' },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+  });
+}
+
+test.describe('SLO-tracked metrics optional integration', () => {
+  test('keeps SLO controls hidden when the plugin is absent', async ({ page, metricsReducerView }) => {
+    await enableSloFlag(page);
+    let resourceRequests = 0;
+    await page.route(`**${SLO_RESOURCE_URL}`, async (route) => {
+      resourceRequests++;
+      await route.abort();
+    });
+
+    await metricsReducerView.goto();
+    await metricsReducerView.assertMetricsList();
+
+    await expect(metricsReducerView.getSloTrackedChip()).toHaveCount(0);
+    expect(resourceRequests).toBe(0);
+  });
+
+  test('shows badges, filters the list, and restores URL state for installed SLO', async ({
+    page,
+    metricsReducerView,
+  }) => {
+    await enableSloFlag(page);
+    await injectSloPlugin(page);
+    await stubSloDefinitions(page);
+
+    await metricsReducerView.goto();
+    await expect(metricsReducerView.getSloTrackedChip()).toBeVisible();
+    await expect(metricsReducerView.getSloTrackedChip()).toContainText('SLO-tracked (2)');
+    await metricsReducerView.quickSearch.enterText(TRACKED_METRIC);
+    await expect(metricsReducerView.getSloTrackedChip()).toContainText('SLO-tracked (1)');
+    await expect(metricsReducerView.getSloTrackedBadge(TRACKED_METRIC)).toBeVisible();
+    await metricsReducerView.quickSearch.clear();
+    await expect(metricsReducerView.getSloTrackedChip()).toContainText('SLO-tracked (2)');
+
+    await metricsReducerView.toggleSloTrackedFilter();
+    await expect(metricsReducerView.getPanelByTitle(TRACKED_METRIC)).toBeVisible();
+    await expect(metricsReducerView.getPanelByTitle(SECOND_TRACKED_METRIC)).toBeVisible();
+    await expect(metricsReducerView.getPanelByTitle(UNTRACKED_METRIC)).toHaveCount(0);
+    await expect(page).toHaveURL(/filter-slo-tracked=true/);
+
+    await page.reload();
+    await expect(metricsReducerView.getSloTrackedChip()).toHaveAttribute('aria-pressed', 'true');
+    await expect(metricsReducerView.getPanelByTitle(UNTRACKED_METRIC)).toHaveCount(0);
+
+    await metricsReducerView.sidebar.toggleButton('Group by labels');
+    await metricsReducerView.sidebar.selectGroupByLabel('job');
+    await metricsReducerView.assertMetricsGroupByList();
+    await expect(metricsReducerView.getMetricsGroupByList().getByTestId('slo-tracked-badge').first()).toBeVisible();
+  });
+
+  test('clears stale URL filtering when the SLO API fails', async ({ page, metricsReducerView }) => {
+    await enableSloFlag(page);
+    await injectSloPlugin(page);
+    await stubSloDefinitions(page, 500);
+
+    await metricsReducerView.goto(new URLSearchParams({ 'filter-slo-tracked': 'true' }));
+    await metricsReducerView.assertMetricsList();
+
+    await expect(metricsReducerView.getSloTrackedChip()).toHaveCount(0);
+    await expect(page).not.toHaveURL(/filter-slo-tracked=true/);
+    await expect(metricsReducerView.getPanelByTitle(UNTRACKED_METRIC)).toBeVisible();
+  });
+});

--- a/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
+++ b/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
@@ -7,7 +7,7 @@ import {
 import { expect, test } from '../../fixtures';
 
 const TRACKED_METRIC = 'handler_duration_seconds_count';
-const SECOND_TRACKED_METRIC = 'jaeger_tracer_finished_spans_total';
+const SECOND_TRACKED_METRIC = 'go_gc_cycles_automatic_gc_cycles_total';
 const UNTRACKED_METRIC = 'memberlist_client_cas_success_total';
 
 async function enableSloFlag(page: Page) {
@@ -184,11 +184,7 @@ test.describe('SLO-tracked metrics optional integration', () => {
     await metricsReducerView.sidebar.toggleButton('Group by labels');
     await metricsReducerView.sidebar.selectGroupByLabel('job');
     await metricsReducerView.assertMetricsGroupByList();
-    const trackedMetricGroup = metricsReducerView
-      .getMetricsGroupByList()
-      .getByTestId('job-ride-sharing-app-metrics-group');
-    await trackedMetricGroup.scrollIntoViewIfNeeded();
-    await expect(metricsReducerView.getSloTrackedBadge(TRACKED_METRIC)).toBeVisible();
+    await expect(metricsReducerView.getSloTrackedBadge(SECOND_TRACKED_METRIC)).toBeVisible();
   });
 
   test('clears stale URL filtering when the SLO API fails', async ({ page, metricsReducerView }) => {

--- a/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
+++ b/e2e/tests/metrics-reducer/slo-tracked-metrics.spec.ts
@@ -184,7 +184,11 @@ test.describe('SLO-tracked metrics optional integration', () => {
     await metricsReducerView.sidebar.toggleButton('Group by labels');
     await metricsReducerView.sidebar.selectGroupByLabel('job');
     await metricsReducerView.assertMetricsGroupByList();
-    await expect(metricsReducerView.getMetricsGroupByList().getByTestId('slo-tracked-badge').first()).toBeVisible();
+    const trackedMetricGroup = metricsReducerView
+      .getMetricsGroupByList()
+      .getByTestId('job-ride-sharing-app-metrics-group');
+    await trackedMetricGroup.scrollIntoViewIfNeeded();
+    await expect(metricsReducerView.getSloTrackedBadge(TRACKED_METRIC)).toBeVisible();
   });
 
   test('clears stale URL filtering when the SLO API fails', async ({ page, metricsReducerView }) => {

--- a/src/MetricsReducer/MetricsGroupByList/MetricsGroupByRow.tsx
+++ b/src/MetricsReducer/MetricsGroupByList/MetricsGroupByRow.tsx
@@ -28,6 +28,7 @@ import { GroupsIcon } from 'MetricsReducer/SideBar/custom-icons/GroupsIcon';
 import { ConfigurePanelAction } from 'shared/GmdVizPanel/components/ConfigurePanelAction';
 import { FiringAlertBadge } from 'shared/GmdVizPanel/components/FiringAlertBadge';
 import { SelectAction } from 'shared/GmdVizPanel/components/SelectAction';
+import { SloTrackedBadge } from 'shared/GmdVizPanel/components/SloTrackedBadge';
 import { GmdVizPanel } from 'shared/GmdVizPanel/GmdVizPanel';
 import { VAR_FILTERS } from 'shared/shared';
 import { getTrailFor } from 'shared/utils/utils';
@@ -125,6 +126,7 @@ export class MetricsGroupByRow extends SceneObjectBase<MetricsGroupByRowState> {
                   fixedColorIndex: colorIndex,
                   headerActions: ({ metric }) => [
                     new FiringAlertBadge({ metric: metric.name }),
+                    new SloTrackedBadge({ metric: metric.name }),
                     new SelectAction({ metric: metric.name }),
                     new ConfigurePanelAction({ metric }),
                   ],

--- a/src/MetricsReducer/MetricsList/MetricsList.tsx
+++ b/src/MetricsReducer/MetricsList/MetricsList.tsx
@@ -22,6 +22,7 @@ import { ShowMoreButton } from 'MetricsReducer/components/ShowMoreButton';
 import { LayoutSwitcher, LayoutType, type LayoutSwitcherState } from 'MetricsReducer/list-controls/LayoutSwitcher';
 import { FiringAlertBadge } from 'shared/GmdVizPanel/components/FiringAlertBadge';
 import { SelectAction } from 'shared/GmdVizPanel/components/SelectAction';
+import { SloTrackedBadge } from 'shared/GmdVizPanel/components/SloTrackedBadge';
 import { GmdVizPanel } from 'shared/GmdVizPanel/GmdVizPanel';
 import { getTrailFor } from 'shared/utils/utils';
 
@@ -90,6 +91,7 @@ export class MetricsList extends SceneObjectBase<MetricsListState> {
                   fixedColorIndex: colorIndex,
                   headerActions: ({ metric }) => [
                     new FiringAlertBadge({ metric: metric.name }),
+                    new SloTrackedBadge({ metric: metric.name }),
                     new SelectAction({ metric: metric.name, variant: 'secondary' }),
                   ],
                 },

--- a/src/MetricsReducer/MetricsReducer.tsx
+++ b/src/MetricsReducer/MetricsReducer.tsx
@@ -26,6 +26,7 @@ import { EventSortByChanged } from './list-controls/MetricsSorter/events/EventSo
 import { MetricsSorter, VAR_WINGMAN_SORT_BY, type SortingOption } from './list-controls/MetricsSorter/MetricsSorter';
 import { EventQuickSearchChanged } from './list-controls/QuickSearch/EventQuickSearchChanged';
 import { QuickSearch } from './list-controls/QuickSearch/QuickSearch';
+import { SloTrackedChip } from './list-controls/SloTrackedChip/SloTrackedChip';
 import { EventMetricsVariableActivated } from './metrics-variables/events/EventMetricsVariableActivated';
 import { EventMetricsVariableDeactivated } from './metrics-variables/events/EventMetricsVariableDeactivated';
 import { EventMetricsVariableLoaded } from './metrics-variables/events/EventMetricsVariableLoaded';
@@ -153,14 +154,24 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
         filters[filterSection.state.type] = filterSection.state.selectedGroups.map((g) => g.value);
       }
 
-      // Include firing alert chip state if it is active on initial load (e.g. restored from URL)
+      // Include async chip state when it is already ready. Otherwise the chip publishes
+      // EventFiltersChanged after its datasource-scoped data resolves.
       try {
         const firingAlertChip = sceneGraph.findByKeyAndType(this, 'firing-alert-chip', FiringAlertChip);
         if (firingAlertChip.state.active) {
           filters.firingAlertMetrics = [...firingAlertChip.state.firingAlertMetrics.keys()];
         }
       } catch {
-        // Chip not yet in scene graph — filter will be applied via EventFiltersChanged when chip activates
+        // Chip not yet in scene graph.
+      }
+
+      try {
+        const sloTrackedChip = sceneGraph.findByKeyAndType(this, 'slo-tracked-chip', SloTrackedChip);
+        if (sloTrackedChip.state.active && sloTrackedChip.state.signals.status === 'ready') {
+          filters.sloTrackedMetrics = [...sloTrackedChip.state.signals.trackedMetrics.keys()];
+        }
+      } catch {
+        // Chip not yet in scene graph.
       }
 
       filterEngine.applyFilters(filters, { forceUpdate: true, notify: false });

--- a/src/MetricsReducer/MetricsReducer.tsx
+++ b/src/MetricsReducer/MetricsReducer.tsx
@@ -16,6 +16,7 @@ import React from 'react';
 
 import { LoadQueryScene } from 'shared/savedQueries/LoadQueryScene';
 import { SaveQueryButton } from 'shared/savedQueries/SaveQueryButton';
+import { VAR_DATASOURCE } from 'shared/shared';
 import { reportExploreMetrics } from 'shared/tracking/interactions';
 
 import { NULL_GROUP_BY_VALUE } from './labels/LabelsDataSource';
@@ -167,7 +168,12 @@ export class MetricsReducer extends SceneObjectBase<MetricsReducerState> {
 
       try {
         const sloTrackedChip = sceneGraph.findByKeyAndType(this, 'slo-tracked-chip', SloTrackedChip);
-        if (sloTrackedChip.state.active && sloTrackedChip.state.signals.status === 'ready') {
+        const datasourceUid = sceneGraph.lookupVariable(VAR_DATASOURCE, this)?.getValue()?.toString() ?? '';
+        if (
+          sloTrackedChip.state.active &&
+          sloTrackedChip.state.signals.status === 'ready' &&
+          sloTrackedChip.state.signals.datasourceUid === datasourceUid
+        ) {
           filters.sloTrackedMetrics = [...sloTrackedChip.state.signals.trackedMetrics.keys()];
         }
       } catch {

--- a/src/MetricsReducer/SloTrackedBadge.integration.test.ts
+++ b/src/MetricsReducer/SloTrackedBadge.integration.test.ts
@@ -1,0 +1,55 @@
+import { type SceneCSSGridItem, type SceneObject } from '@grafana/scenes';
+
+import { SloTrackedBadge } from 'shared/GmdVizPanel/components/SloTrackedBadge';
+
+import { MetricsGroupByRow } from './MetricsGroupByList/MetricsGroupByRow';
+import { MetricsList } from './MetricsList/MetricsList';
+
+import type { WithUsageDataPreviewPanel } from './MetricsList/WithUsageDataPreviewPanel';
+
+jest.mock('shared/utils/utils', () => ({
+  getObjectKeys: Object.keys,
+  getTrailFor: () => ({ state: { sourceMetrics: [] } }),
+}));
+
+jest.mock('MetricsReducer/MetricsReducer', () => ({ MetricsReducer: class MetricsReducer {} }));
+
+function getHeaderActions(item: SceneCSSGridItem) {
+  const wrapper = item.state.body as WithUsageDataPreviewPanel;
+  const panel = wrapper.state.vizPanelInGridItem;
+  return panel.state.panelConfig.headerActions({ metric: { name: 'http_requests_total' } } as never) as SceneObject[];
+}
+
+describe('SLO-tracked card action integration', () => {
+  it('includes the badge in ungrouped metric cards', () => {
+    const list = new MetricsList({ variableName: 'metrics' });
+    const item = list.state.body.state.getLayoutChild(
+      { label: 'http_requests_total', value: 'http_requests_total' },
+      0,
+      []
+    ) as SceneCSSGridItem;
+
+    const actions = getHeaderActions(item);
+
+    expect(actions.some((action) => action instanceof SloTrackedBadge)).toBe(true);
+    expect(actions).toHaveLength(3);
+  });
+
+  it('includes the badge in grouped metric cards without replacing existing actions', () => {
+    const row = new MetricsGroupByRow({
+      index: 0,
+      labelName: 'job',
+      labelValue: 'api',
+      labelCardinality: 1,
+    });
+    const item = row.state.body.state.getLayoutChild(
+      { label: 'http_requests_total', value: 'http_requests_total' },
+      0,
+      []
+    ) as SceneCSSGridItem;
+    const actions = getHeaderActions(item);
+
+    expect(actions.some((action) => action instanceof SloTrackedBadge)).toBe(true);
+    expect(actions).toHaveLength(4);
+  });
+});

--- a/src/MetricsReducer/list-controls/ListControls.tsx
+++ b/src/MetricsReducer/list-controls/ListControls.tsx
@@ -18,6 +18,7 @@ import { MetricsSorter } from './MetricsSorter/MetricsSorter';
 import { type CountsProvider } from './QuickSearch/CountsProvider/CountsProvider';
 import { MetricVariableCountsProvider } from './QuickSearch/CountsProvider/MetricVariableCountsProvider';
 import { QuickSearch } from './QuickSearch/QuickSearch';
+import { SloTrackedChip } from './SloTrackedChip/SloTrackedChip';
 
 interface ListControlsState extends SceneObjectState {
   $variables?: SceneVariableSet;
@@ -47,6 +48,10 @@ export class ListControls extends EmbeddedScene {
           new SceneFlexItem({
             width: 'auto',
             body: new FiringAlertChip(),
+          }),
+          new SceneFlexItem({
+            width: 'auto',
+            body: new SloTrackedChip(),
           }),
           new SceneFlexItem({
             width: 'auto',

--- a/src/MetricsReducer/list-controls/MetricsSorter/MetricsSorter.test.tsx
+++ b/src/MetricsReducer/list-controls/MetricsSorter/MetricsSorter.test.tsx
@@ -1,11 +1,85 @@
 import { PREF_KEYS } from 'shared/user-preferences/pref-keys';
 import { userStorage } from 'shared/user-preferences/userStorage';
 
-import { addRecentMetric, getRecentMetrics, sortMetricsWithRecentFirst } from './MetricsSorter';
+import { fetchSloMetricSignals, type SloMetricSignals } from './fetchers/fetchSloMetricSignals';
+import { addRecentMetric, getRecentMetrics, MetricsSorter, sortMetricsWithRecentFirst } from './MetricsSorter';
+
+jest.mock('./fetchers/fetchSloMetricSignals', () => ({
+  fetchSloMetricSignals: jest.fn(),
+}));
+
+jest.mock('./fetchers/fetchFiringAlertMetrics', () => ({
+  fetchFiringAlertRuleSignals: jest.fn(),
+}));
+
+const mockFetchSloMetricSignals = fetchSloMetricSignals as jest.MockedFunction<typeof fetchSloMetricSignals>;
+
+function sloResult(datasourceUid: string, status: SloMetricSignals['status'] = 'ready'): SloMetricSignals {
+  return {
+    datasourceUid,
+    status,
+    trackedMetrics: new Map(),
+    activeBurnMetrics: new Set(),
+  };
+}
 
 describe('MetricsSorter', () => {
   beforeEach(() => {
     userStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('SLO signal cache', () => {
+    it('coalesces concurrent requests and caches a ready-empty result by datasource', async () => {
+      let resolve!: (value: SloMetricSignals) => void;
+      mockFetchSloMetricSignals.mockReturnValue(new Promise((done) => (resolve = done)));
+      const sorter = new MetricsSorter({});
+
+      const first = sorter.getSloMetricSignals('prom-a');
+      const second = sorter.getSloMetricSignals('prom-a');
+      expect(mockFetchSloMetricSignals).toHaveBeenCalledTimes(1);
+
+      resolve(sloResult('prom-a'));
+      await expect(first).resolves.toMatchObject({ status: 'ready' });
+      await expect(second).resolves.toMatchObject({ status: 'ready' });
+      await sorter.getSloMetricSignals('prom-a');
+      expect(mockFetchSloMetricSignals).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache error results so the same datasource can retry', async () => {
+      mockFetchSloMetricSignals
+        .mockResolvedValueOnce(sloResult('prom-a', 'error'))
+        .mockResolvedValueOnce(sloResult('prom-a'));
+      const sorter = new MetricsSorter({});
+
+      await expect(sorter.getSloMetricSignals('prom-a')).resolves.toMatchObject({ status: 'error' });
+      await expect(sorter.getSloMetricSignals('prom-a')).resolves.toMatchObject({ status: 'ready' });
+
+      expect(mockFetchSloMetricSignals).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears an unexpected rejected promise so the same datasource can retry', async () => {
+      mockFetchSloMetricSignals
+        .mockRejectedValueOnce(new Error('unexpected failure'))
+        .mockResolvedValueOnce(sloResult('prom-a'));
+      const sorter = new MetricsSorter({});
+
+      await expect(sorter.getSloMetricSignals('prom-a')).rejects.toThrow('unexpected failure');
+      await expect(sorter.getSloMetricSignals('prom-a')).resolves.toMatchObject({ status: 'ready' });
+
+      expect(mockFetchSloMetricSignals).toHaveBeenCalledTimes(2);
+    });
+
+    it('never reuses membership from another datasource', async () => {
+      mockFetchSloMetricSignals.mockImplementation(async (uid) => sloResult(uid));
+      const sorter = new MetricsSorter({});
+
+      await sorter.getSloMetricSignals('prom-a');
+      await sorter.getSloMetricSignals('prom-b');
+
+      expect(mockFetchSloMetricSignals).toHaveBeenNthCalledWith(1, 'prom-a', expect.any(Function));
+      expect(mockFetchSloMetricSignals).toHaveBeenNthCalledWith(2, 'prom-b', expect.any(Function));
+    });
   });
 
   describe('sortMetricsWithRecentFirst', () => {

--- a/src/MetricsReducer/list-controls/MetricsSorter/MetricsSorter.test.tsx
+++ b/src/MetricsReducer/list-controls/MetricsSorter/MetricsSorter.test.tsx
@@ -1,6 +1,7 @@
 import { PREF_KEYS } from 'shared/user-preferences/pref-keys';
 import { userStorage } from 'shared/user-preferences/userStorage';
 
+import { fetchFiringAlertRuleSignals } from './fetchers/fetchFiringAlertMetrics';
 import { fetchSloMetricSignals, type SloMetricSignals } from './fetchers/fetchSloMetricSignals';
 import { addRecentMetric, getRecentMetrics, MetricsSorter, sortMetricsWithRecentFirst } from './MetricsSorter';
 
@@ -12,6 +13,9 @@ jest.mock('./fetchers/fetchFiringAlertMetrics', () => ({
   fetchFiringAlertRuleSignals: jest.fn(),
 }));
 
+const mockFetchFiringAlertRuleSignals = fetchFiringAlertRuleSignals as jest.MockedFunction<
+  typeof fetchFiringAlertRuleSignals
+>;
 const mockFetchSloMetricSignals = fetchSloMetricSignals as jest.MockedFunction<typeof fetchSloMetricSignals>;
 
 function sloResult(datasourceUid: string, status: SloMetricSignals['status'] = 'ready'): SloMetricSignals {
@@ -27,6 +31,30 @@ describe('MetricsSorter', () => {
   beforeEach(() => {
     userStorage.clear();
     jest.clearAllMocks();
+  });
+
+  describe('firing alert signal cache', () => {
+    it('does not cache acquisition errors so later consumers can retry', async () => {
+      mockFetchFiringAlertRuleSignals
+        .mockResolvedValueOnce({
+          status: 'error',
+          metricCounts: new Map(),
+          firingSloUuids: new Map(),
+          ruleCount: 0,
+        })
+        .mockResolvedValueOnce({
+          status: 'ready',
+          metricCounts: new Map([['up', 1]]),
+          firingSloUuids: new Map(),
+          ruleCount: 1,
+        });
+      const sorter = new MetricsSorter({});
+
+      await expect(sorter.getFiringAlertSignals()).resolves.toMatchObject({ status: 'error' });
+      await expect(sorter.getFiringAlertSignals()).resolves.toMatchObject({ status: 'ready' });
+
+      expect(mockFetchFiringAlertRuleSignals).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('SLO signal cache', () => {
@@ -46,16 +74,24 @@ describe('MetricsSorter', () => {
       expect(mockFetchSloMetricSignals).toHaveBeenCalledTimes(1);
     });
 
-    it('does not cache error results so the same datasource can retry', async () => {
+    it('rate-limits error retries while allowing the same datasource to recover', async () => {
+      jest.useFakeTimers().setSystemTime(1_000);
       mockFetchSloMetricSignals
         .mockResolvedValueOnce(sloResult('prom-a', 'error'))
         .mockResolvedValueOnce(sloResult('prom-a'));
       const sorter = new MetricsSorter({});
 
-      await expect(sorter.getSloMetricSignals('prom-a')).resolves.toMatchObject({ status: 'error' });
-      await expect(sorter.getSloMetricSignals('prom-a')).resolves.toMatchObject({ status: 'ready' });
+      try {
+        await expect(sorter.getSloMetricSignals('prom-a')).resolves.toMatchObject({ status: 'error' });
+        await expect(sorter.getSloMetricSignals('prom-a')).resolves.toMatchObject({ status: 'error' });
+        expect(mockFetchSloMetricSignals).toHaveBeenCalledTimes(1);
 
-      expect(mockFetchSloMetricSignals).toHaveBeenCalledTimes(2);
+        jest.advanceTimersByTime(5_000);
+        await expect(sorter.getSloMetricSignals('prom-a')).resolves.toMatchObject({ status: 'ready' });
+        expect(mockFetchSloMetricSignals).toHaveBeenCalledTimes(2);
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('clears an unexpected rejected promise so the same datasource can retry', async () => {

--- a/src/MetricsReducer/list-controls/MetricsSorter/MetricsSorter.tsx
+++ b/src/MetricsReducer/list-controls/MetricsSorter/MetricsSorter.tsx
@@ -111,6 +111,8 @@ const sortByOptions: VariableValueOption[] = getSortByOptions();
 
 export const VAR_WINGMAN_SORT_BY = 'metrics-reducer-sort-by';
 
+const SLO_SIGNAL_ERROR_RETRY_DELAY_MS = 5_000;
+
 export class MetricsSorter extends SceneObjectBase<MetricsSorterState> {
   initialized = false;
   supportedSortByOptions = new Set<SortingOption>([
@@ -131,7 +133,12 @@ export class MetricsSorter extends SceneObjectBase<MetricsSorterState> {
   };
   private sloSignalCache = new Map<
     string,
-    { data: SloMetricSignals | null; promise: Promise<SloMetricSignals> | null }
+    {
+      data: SloMetricSignals | null;
+      error: SloMetricSignals | null;
+      promise: Promise<SloMetricSignals> | null;
+      retryAfter: number;
+    }
   >();
 
   constructor(state: Partial<MetricsSorterState>) {
@@ -210,12 +217,18 @@ export class MetricsSorter extends SceneObjectBase<MetricsSorterState> {
     if (this.firingAlertCache.promise) {
       return this.firingAlertCache.promise;
     }
-    this.firingAlertCache.promise = fetchFiringAlertRuleSignals().then((data) => {
-      this.firingAlertCache.data = data;
-      this.firingAlertCache.promise = null;
-      return data;
-    });
-    return this.firingAlertCache.promise;
+    const promise = fetchFiringAlertRuleSignals()
+      .then((data) => {
+        if (data.status === 'ready') {
+          this.firingAlertCache.data = data;
+        }
+        return data;
+      })
+      .finally(() => {
+        this.firingAlertCache.promise = null;
+      });
+    this.firingAlertCache.promise = promise;
+    return promise;
   }
 
   public getFiringAlertCounts(): Promise<Map<string, number>> {
@@ -238,12 +251,20 @@ export class MetricsSorter extends SceneObjectBase<MetricsSorterState> {
     if (cached?.promise) {
       return cached.promise;
     }
+    if (cached?.error && Date.now() < cached.retryAfter) {
+      return Promise.resolve(cached.error);
+    }
 
-    const entry = cached ?? { data: null, promise: null };
+    const entry = cached ?? { data: null, error: null, promise: null, retryAfter: 0 };
     const promise = fetchSloMetricSignals(datasourceUid, () => this.getFiringAlertSignals())
       .then((result) => {
-        if (result.status !== 'error') {
+        if (result.status === 'error') {
+          entry.error = result;
+          entry.retryAfter = Date.now() + SLO_SIGNAL_ERROR_RETRY_DELAY_MS;
+        } else {
           entry.data = result;
+          entry.error = null;
+          entry.retryAfter = 0;
         }
         return result;
       })

--- a/src/MetricsReducer/list-controls/MetricsSorter/MetricsSorter.tsx
+++ b/src/MetricsReducer/list-controls/MetricsSorter/MetricsSorter.tsx
@@ -20,9 +20,11 @@ import { userStorage } from 'shared/user-preferences/userStorage';
 
 import { EventSortByChanged } from './events/EventSortByChanged';
 import { type MetricUsageDetails } from './fetchers/fetchDashboardMetrics';
-import { fetchFiringAlertMetrics } from './fetchers/fetchFiringAlertMetrics';
+import { fetchFiringAlertRuleSignals, type FiringAlertRuleSignals } from './fetchers/fetchFiringAlertMetrics';
+import { fetchSloMetricSignals, type SloMetricSignals } from './fetchers/fetchSloMetricSignals';
 import { MetricUsageFetcher, type MetricUsageType } from './MetricUsageFetcher';
-export type SortingOption = 'default' | 'alphabetical' | 'alphabetical-reversed' | 'dashboard-usage' | 'alerting-usage' | 'firing-alerts';
+export type SortingOption =
+  'default' | 'alphabetical' | 'alphabetical-reversed' | 'dashboard-usage' | 'alerting-usage' | 'firing-alerts';
 
 const MAX_RECENT_METRICS = 6;
 const RECENT_METRICS_EXPIRY_DAYS = 30;
@@ -120,10 +122,17 @@ export class MetricsSorter extends SceneObjectBase<MetricsSorterState> {
     'firing-alerts',
   ]);
   private usageFetcher = new MetricUsageFetcher();
-  private firingAlertCache: { data: Map<string, number> | null; promise: Promise<Map<string, number>> | null } = {
+  private firingAlertCache: {
+    data: FiringAlertRuleSignals | null;
+    promise: Promise<FiringAlertRuleSignals> | null;
+  } = {
     data: null,
     promise: null,
   };
+  private sloSignalCache = new Map<
+    string,
+    { data: SloMetricSignals | null; promise: Promise<SloMetricSignals> | null }
+  >();
 
   constructor(state: Partial<MetricsSorterState>) {
     super({
@@ -194,19 +203,23 @@ export class MetricsSorter extends SceneObjectBase<MetricsSorterState> {
     });
   }
 
-  public getFiringAlertCounts(): Promise<Map<string, number>> {
+  public getFiringAlertSignals(): Promise<FiringAlertRuleSignals> {
     if (this.firingAlertCache.data) {
       return Promise.resolve(this.firingAlertCache.data);
     }
     if (this.firingAlertCache.promise) {
       return this.firingAlertCache.promise;
     }
-    this.firingAlertCache.promise = fetchFiringAlertMetrics().then((data) => {
+    this.firingAlertCache.promise = fetchFiringAlertRuleSignals().then((data) => {
       this.firingAlertCache.data = data;
       this.firingAlertCache.promise = null;
       return data;
     });
     return this.firingAlertCache.promise;
+  }
+
+  public getFiringAlertCounts(): Promise<Map<string, number>> {
+    return this.getFiringAlertSignals().then((signals) => signals.metricCounts);
   }
 
   public getFiringAlertCountForMetric(metric: string): Promise<number> {
@@ -215,6 +228,31 @@ export class MetricsSorter extends SceneObjectBase<MetricsSorterState> {
 
   public getFiringAlertCountsAsRecord(): Promise<Record<string, number>> {
     return this.getFiringAlertCounts().then((map) => Object.fromEntries(map));
+  }
+
+  public getSloMetricSignals(datasourceUid: string): Promise<SloMetricSignals> {
+    const cached = this.sloSignalCache.get(datasourceUid);
+    if (cached?.data) {
+      return Promise.resolve(cached.data);
+    }
+    if (cached?.promise) {
+      return cached.promise;
+    }
+
+    const entry = cached ?? { data: null, promise: null };
+    const promise = fetchSloMetricSignals(datasourceUid, () => this.getFiringAlertSignals())
+      .then((result) => {
+        if (result.status !== 'error') {
+          entry.data = result;
+        }
+        return result;
+      })
+      .finally(() => {
+        entry.promise = null;
+      });
+    entry.promise = promise;
+    this.sloSignalCache.set(datasourceUid, entry);
+    return promise;
   }
 
   public static readonly Component = ({ model }: SceneComponentProps<MetricsSorter>) => {

--- a/src/MetricsReducer/list-controls/MetricsSorter/__tests__/MetricsSorterFiringAlerts.test.tsx
+++ b/src/MetricsReducer/list-controls/MetricsSorter/__tests__/MetricsSorterFiringAlerts.test.tsx
@@ -14,7 +14,7 @@ jest.mock('shared/featureFlags/openFeature', () => ({
 }));
 
 jest.mock('../fetchers/fetchFiringAlertMetrics', () => ({
-  fetchFiringAlertMetrics: jest.fn(),
+  fetchFiringAlertRuleSignals: jest.fn(),
 }));
 
 jest.mock('@grafana/scenes', () => {

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchFiringAlertMetrics.test.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchFiringAlertMetrics.test.ts
@@ -134,10 +134,28 @@ describe('fetchFiringAlertMetrics()', () => {
 
       const result = await fetchFiringAlertRuleSignals();
 
+      expect(result.status).toBe('ready');
       expect(result.firingSloUuids.get('slo-1')).toEqual(new Set(['critical', 'warning']));
       expect(result.firingSloUuids.size).toBe(1);
       expect(result.metricCounts.get('grafana_slo_sli_5m')).toBe(1);
       expect(result.metricCounts.get('up')).toBe(1);
+    });
+
+    test('excludes non-firing rules from canonical SLO burn signals', async () => {
+      const { get } = setup();
+      const pendingRule = {
+        ...alertingRule('Pending burn', 'grafana_slo_sli_5m > 0', {
+          grafana_slo_uuid: 'slo-pending',
+          grafana_slo_severity: 'critical',
+        }),
+        state: 'pending',
+      };
+
+      get.mockResolvedValueOnce(buildRulerResponse([{ name: 'slo-group', rules: [pendingRule] }]));
+
+      const result = await fetchFiringAlertRuleSignals();
+
+      expect(result.firingSloUuids.has('slo-pending')).toBe(false);
     });
 
     test('extracts multiple metrics from a single PromQL expression', async () => {
@@ -296,6 +314,17 @@ describe('fetchFiringAlertMetrics()', () => {
   });
 
   describe('error handling', () => {
+    test('marks rule-signal acquisition as failed so richer consumers can retry', async () => {
+      const { get } = setup();
+      get.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await fetchFiringAlertRuleSignals();
+
+      expect(result.status).toBe('error');
+      expect(result.metricCounts.size).toBe(0);
+      expect(result.firingSloUuids.size).toBe(0);
+    });
+
     test('returns empty Map and logs error when API call fails', async () => {
       const { get } = setup();
       get.mockRejectedValueOnce(new Error('Network error'));

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchFiringAlertMetrics.test.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchFiringAlertMetrics.test.ts
@@ -2,7 +2,7 @@ import { getBackendSrv } from '@grafana/runtime';
 
 import { logger } from 'shared/logger/logger';
 
-import { fetchFiringAlertMetrics } from '../fetchFiringAlertMetrics';
+import { fetchFiringAlertMetrics, fetchFiringAlertRuleSignals } from '../fetchFiringAlertMetrics';
 import { GRAFANA_RULER_RULES_URL } from '../shared';
 
 jest.mock('@grafana/runtime');
@@ -39,8 +39,8 @@ function buildRulerResponse(groups: Array<{ name: string; rules: Array<Record<st
   };
 }
 
-function alertingRule(name: string, query: string) {
-  return { type: 'alerting', name, query, state: 'firing', health: 'ok', alerts: [], labels: {}, annotations: {} };
+function alertingRule(name: string, query: string, labels: Record<string, string> = {}) {
+  return { type: 'alerting', name, query, state: 'firing', health: 'ok', alerts: [], labels, annotations: {} };
 }
 
 function recordingRule(name: string, query: string) {
@@ -110,6 +110,36 @@ describe('fetchFiringAlertMetrics()', () => {
       expect(result.get('http_requests_total')).toBe(2);
     });
 
+    test('retains canonical SLO UUID and severity labels independently from metric counts', async () => {
+      const { get } = setup();
+
+      get.mockResolvedValueOnce(
+        buildRulerResponse([
+          {
+            name: 'slo-group',
+            rules: [
+              alertingRule('Fast burn', 'grafana_slo_sli_5m > 0', {
+                grafana_slo_uuid: 'slo-1',
+                grafana_slo_severity: 'critical',
+              }),
+              alertingRule('Slow burn', 'grafana_slo_sli_1h > 0', {
+                grafana_slo_uuid: 'slo-1',
+                grafana_slo_severity: 'warning',
+              }),
+              alertingRule('Unrelated', 'up == 0'),
+            ],
+          },
+        ])
+      );
+
+      const result = await fetchFiringAlertRuleSignals();
+
+      expect(result.firingSloUuids.get('slo-1')).toEqual(new Set(['critical', 'warning']));
+      expect(result.firingSloUuids.size).toBe(1);
+      expect(result.metricCounts.get('grafana_slo_sli_5m')).toBe(1);
+      expect(result.metricCounts.get('up')).toBe(1);
+    });
+
     test('extracts multiple metrics from a single PromQL expression', async () => {
       const { get } = setup();
 
@@ -161,22 +191,29 @@ describe('fetchFiringAlertMetrics()', () => {
       expect(result.get('http_requests_total')).toBe(1);
     });
 
-    test('skips rules with empty query strings', async () => {
+    test('skips empty queries for metric counts but still retains canonical SLO labels', async () => {
       const { get } = setup();
 
       get.mockResolvedValueOnce(
         buildRulerResponse([
           {
             name: 'group-1',
-            rules: [alertingRule('EmptyQuery', ''), alertingRule('ValidRule', 'up == 0')],
+            rules: [
+              alertingRule('EmptyQuery', '', {
+                grafana_slo_uuid: 'slo-with-malformed-query',
+                grafana_slo_severity: 'critical',
+              }),
+              alertingRule('ValidRule', 'up == 0'),
+            ],
           },
         ])
       );
 
-      const result = await fetchFiringAlertMetrics();
+      const result = await fetchFiringAlertRuleSignals();
 
-      expect(result.size).toBe(1);
-      expect(result.get('up')).toBe(1);
+      expect(result.metricCounts.size).toBe(1);
+      expect(result.metricCounts.get('up')).toBe(1);
+      expect(result.firingSloUuids.get('slo-with-malformed-query')).toEqual(new Set(['critical']));
     });
 
     test('returns zero metrics for malformed PromQL that yields no identifiers', async () => {

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchSloMetricSignals.test.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchSloMetricSignals.test.ts
@@ -21,6 +21,7 @@ function setup(slos: unknown[] = []) {
   const get = jest.fn().mockResolvedValue({ slos });
   (getBackendSrv as jest.Mock).mockReturnValue({ get });
   const fetchFiringSignals = jest.fn().mockResolvedValue({
+    status: 'ready',
     metricCounts: new Map(),
     firingSloUuids: new Map(),
     ruleCount: 0,
@@ -197,6 +198,7 @@ describe('fetchSloMetricSignals', () => {
       definition('slo-2', { type: 'freeform', freeform: { query: 'healthy_metric' } }),
     ]);
     fetchFiringSignals.mockResolvedValue({
+      status: 'ready',
       metricCounts: new Map(),
       firingSloUuids: new Map([
         ['slo-1', new Set(['critical'])],
@@ -222,6 +224,34 @@ describe('fetchSloMetricSignals', () => {
     const emptyResult = await fetchSloMetricSignals('prom-a', empty.fetchFiringSignals);
     expect(emptyResult.status).toBe('ready');
     expect(emptyResult.trackedMetrics.size).toBe(0);
+  });
+
+  it.each([{}, null, { slos: {} }])(
+    'returns an error for malformed successful resource response %# instead of treating it as ready-empty',
+    async (response) => {
+      const { get, fetchFiringSignals } = setup();
+      get.mockResolvedValue(response);
+
+      const result = await fetchSloMetricSignals('prom-a', fetchFiringSignals);
+
+      expect(result).toMatchObject({ status: 'error', datasourceUid: 'prom-a' });
+      expect(logger.error).toHaveBeenCalled();
+    }
+  );
+
+  it('returns a retryable error when active-burn signal acquisition fails', async () => {
+    const { fetchFiringSignals } = setup([definition('slo-1', { type: 'freeform', freeform: { query: 'up' } })]);
+    fetchFiringSignals.mockResolvedValue({
+      status: 'error',
+      metricCounts: new Map(),
+      firingSloUuids: new Map(),
+      ruleCount: 0,
+    });
+
+    const result = await fetchSloMetricSignals('prom-a', fetchFiringSignals);
+
+    expect(result).toMatchObject({ status: 'error', datasourceUid: 'prom-a' });
+    expect(result.trackedMetrics.size).toBe(0);
   });
 
   it('returns an explicit retryable error state and non-sensitive telemetry when the resource request fails', async () => {

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchSloMetricSignals.test.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/__tests__/fetchSloMetricSignals.test.ts
@@ -1,0 +1,258 @@
+import { getBackendSrv } from '@grafana/runtime';
+
+import { isSloTrackingEnabled } from 'shared/featureFlags/openFeature';
+import { logger } from 'shared/logger/logger';
+import { reportExploreMetrics } from 'shared/tracking/interactions';
+import { getPluginVersion } from 'shared/utils/getPluginVersion';
+
+import { fetchSloMetricSignals, SLO_RESOURCE_URL } from '../fetchSloMetricSignals';
+
+jest.mock('@grafana/runtime');
+jest.mock('shared/featureFlags/openFeature');
+jest.mock('shared/logger/logger');
+jest.mock('shared/tracking/interactions');
+jest.mock('shared/utils/getPluginVersion');
+
+const mockIsSloTrackingEnabled = isSloTrackingEnabled as jest.MockedFunction<typeof isSloTrackingEnabled>;
+const mockGetPluginVersion = getPluginVersion as jest.MockedFunction<typeof getPluginVersion>;
+const mockReportExploreMetrics = reportExploreMetrics as jest.MockedFunction<typeof reportExploreMetrics>;
+
+function setup(slos: unknown[] = []) {
+  const get = jest.fn().mockResolvedValue({ slos });
+  (getBackendSrv as jest.Mock).mockReturnValue({ get });
+  const fetchFiringSignals = jest.fn().mockResolvedValue({
+    metricCounts: new Map(),
+    firingSloUuids: new Map(),
+    ruleCount: 0,
+  });
+  return { get, fetchFiringSignals };
+}
+
+function definition(uuid: string, query: Record<string, unknown>, datasourceUid = 'prom-a') {
+  return {
+    uuid,
+    query,
+    destinationDatasource: { uid: datasourceUid, type: 'prometheus' },
+  };
+}
+
+describe('fetchSloMetricSignals', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsSloTrackingEnabled.mockResolvedValue(true);
+    mockGetPluginVersion.mockResolvedValue('1.2.3');
+  });
+
+  it('does no plugin, resource, or ruler work when rollout is disabled', async () => {
+    mockIsSloTrackingEnabled.mockResolvedValue(false);
+    const { get, fetchFiringSignals } = setup();
+
+    await expect(fetchSloMetricSignals('prom-a', fetchFiringSignals)).resolves.toMatchObject({ status: 'disabled' });
+
+    expect(mockGetPluginVersion).not.toHaveBeenCalled();
+    expect(get).not.toHaveBeenCalled();
+    expect(fetchFiringSignals).not.toHaveBeenCalled();
+  });
+
+  it('does no resource or ruler work when the SLO plugin is absent', async () => {
+    mockGetPluginVersion.mockResolvedValue(null);
+    const { get, fetchFiringSignals } = setup();
+
+    await expect(fetchSloMetricSignals('prom-a', fetchFiringSignals)).resolves.toMatchObject({
+      status: 'plugin-absent',
+    });
+
+    expect(mockGetPluginVersion).toHaveBeenCalledWith('grafana-slo-app');
+    expect(get).not.toHaveBeenCalled();
+    expect(fetchFiringSignals).not.toHaveBeenCalled();
+  });
+
+  it('extracts every native Prometheus query variant for the selected datasource', async () => {
+    const slos = [
+      definition('ratio', {
+        type: 'ratio',
+        ratio: {
+          successMetric: { prometheusMetric: 'http_requests_total{code=~"2.."}' },
+          totalMetric: { prometheusMetric: 'http_requests_total' },
+        },
+      }),
+      definition('failure-ratio', {
+        type: 'failureRatio',
+        failureRatio: {
+          failureMetric: { prometheusMetric: 'http_errors_total' },
+          totalMetric: { prometheusMetric: 'http_requests_total' },
+        },
+      }),
+      definition('threshold', {
+        type: 'threshold',
+        threshold: { thresholdExpression: 'histogram_quantile(0.9, rate(request_duration_bucket[5m]))' },
+      }),
+      definition('failure-threshold', {
+        type: 'failureThreshold',
+        failureThreshold: { failureThresholdExpression: 'queue_depth > 100' },
+      }),
+      definition('freeform', {
+        type: 'freeform',
+        freeform: { query: 'sum(rate(success_total[5m])) / sum(rate(attempt_total[5m]))' },
+      }),
+    ];
+    const { fetchFiringSignals } = setup(slos);
+
+    const result = await fetchSloMetricSignals('prom-a', fetchFiringSignals);
+
+    expect(result.status).toBe('ready');
+    expect([...result.trackedMetrics.keys()]).toEqual(
+      expect.arrayContaining([
+        'http_requests_total',
+        'http_errors_total',
+        'request_duration_bucket',
+        'queue_depth',
+        'success_total',
+        'attempt_total',
+      ])
+    );
+    expect(result.trackedMetrics.get('http_requests_total')).toEqual(new Set(['ratio', 'failure-ratio']));
+  });
+
+  it('uses resolved, query, then destination datasource identity and excludes other datasources', async () => {
+    const slos = [
+      {
+        ...definition('resolved', {
+          type: 'freeform',
+          freeform: { query: 'resolved_metric', sourceDatasourceUid: 'prom-other' },
+        }),
+        readOnly: { sourceDatasource: { uid: 'prom-a', type: 'prometheus' } },
+      },
+      definition(
+        'query-source',
+        {
+          type: 'freeform',
+          freeform: { query: 'query_metric', sourceDatasourceUid: 'prom-a' },
+        },
+        'prom-other'
+      ),
+      definition('destination-fallback', {
+        type: 'freeform',
+        freeform: { query: 'destination_metric' },
+      }),
+      definition(
+        'excluded',
+        {
+          type: 'freeform',
+          freeform: { query: 'same_name_metric' },
+        },
+        'prom-other'
+      ),
+      {
+        ...definition('non-prometheus', {
+          type: 'freeform',
+          freeform: { query: 'loki_stream' },
+        }),
+        readOnly: { sourceDatasource: { uid: 'prom-a', type: 'loki' } },
+      },
+    ];
+    const { fetchFiringSignals } = setup(slos);
+
+    const result = await fetchSloMetricSignals('prom-a', fetchFiringSignals);
+
+    expect([...result.trackedMetrics.keys()]).toEqual(['resolved_metric', 'query_metric', 'destination_metric']);
+    expect(result.trackedMetrics.has('same_name_metric')).toBe(false);
+  });
+
+  it('accepts only raw Prometheus Grafana queries for the selected datasource', async () => {
+    const slos = [
+      definition('big-tent', {
+        type: 'grafanaQueries',
+        grafanaQueries: {
+          grafanaQueries: [
+            { refId: 'A', expr: 'rate(selected_total[5m])', datasource: { uid: 'prom-a', type: 'prometheus' } },
+            {
+              refId: 'A2',
+              expr: 'rate(aws_selected_total[5m])',
+              datasource: { uid: 'prom-a', type: 'grafana-amazonprometheus-datasource' },
+            },
+            { refId: 'B', expr: 'rate(other_total[5m])', datasource: { uid: 'prom-b', type: 'prometheus' } },
+            { refId: 'C', expr: 'count_over_time({app="api"}[5m])', datasource: { uid: 'loki', type: 'loki' } },
+            { refId: 'D', expression: '$A / 2', type: 'math', datasource: { uid: 'prom-a', type: 'prometheus' } },
+          ],
+        },
+      }),
+    ];
+    const { fetchFiringSignals } = setup(slos);
+
+    const result = await fetchSloMetricSignals('prom-a', fetchFiringSignals);
+
+    expect([...result.trackedMetrics.keys()]).toEqual(['selected_total', 'aws_selected_total']);
+  });
+
+  it('marks every source metric owned by a firing SLO as actively burning', async () => {
+    const { fetchFiringSignals } = setup([
+      definition('slo-1', {
+        type: 'ratio',
+        ratio: {
+          successMetric: { prometheusMetric: 'success_total' },
+          totalMetric: { prometheusMetric: 'requests_total' },
+        },
+      }),
+      definition('slo-2', { type: 'freeform', freeform: { query: 'healthy_metric' } }),
+    ]);
+    fetchFiringSignals.mockResolvedValue({
+      metricCounts: new Map(),
+      firingSloUuids: new Map([
+        ['slo-1', new Set(['critical'])],
+        ['unknown-slo', new Set(['warning'])],
+      ]),
+      ruleCount: 2,
+    });
+
+    const result = await fetchSloMetricSignals('prom-a', fetchFiringSignals);
+
+    expect(result.activeBurnMetrics).toEqual(new Set(['success_total', 'requests_total']));
+    expect(result.trackedMetrics.has('healthy_metric')).toBe(true);
+  });
+
+  it('skips malformed siblings and returns ready-empty for a valid empty response', async () => {
+    const { fetchFiringSignals } = setup([null, {}, { uuid: 1 }, definition('bad', { type: 'ratio', ratio: {} })]);
+
+    const malformedResult = await fetchSloMetricSignals('prom-a', fetchFiringSignals);
+    expect(malformedResult.status).toBe('ready');
+    expect(malformedResult.trackedMetrics.size).toBe(0);
+
+    const empty = setup([]);
+    const emptyResult = await fetchSloMetricSignals('prom-a', empty.fetchFiringSignals);
+    expect(emptyResult.status).toBe('ready');
+    expect(emptyResult.trackedMetrics.size).toBe(0);
+  });
+
+  it('returns an explicit retryable error state and non-sensitive telemetry when the resource request fails', async () => {
+    const { get, fetchFiringSignals } = setup();
+    get.mockRejectedValue(new Error('forbidden'));
+
+    const result = await fetchSloMetricSignals('prom-a', fetchFiringSignals);
+
+    expect(result).toMatchObject({ status: 'error', datasourceUid: 'prom-a' });
+    expect(result.trackedMetrics.size).toBe(0);
+    expect(logger.error).toHaveBeenCalled();
+    expect(mockReportExploreMetrics).toHaveBeenLastCalledWith('slo_metric_signals_fetched', {
+      status: 'error',
+      duration_ms: expect.any(Number),
+      definition_count: 0,
+      metric_count: 0,
+      active_burn_metric_count: 0,
+    });
+    expect(JSON.stringify(mockReportExploreMetrics.mock.calls)).not.toContain('forbidden');
+  });
+
+  it('uses the SLO resource route and silent request options', async () => {
+    const { get, fetchFiringSignals } = setup([]);
+
+    await fetchSloMetricSignals('prom-a', fetchFiringSignals);
+
+    expect(get).toHaveBeenCalledWith(
+      SLO_RESOURCE_URL,
+      undefined,
+      'grafana-metricsdrilldown-app-slo-metric-signals',
+      expect.objectContaining({ showErrorAlert: false, showSuccessAlert: false })
+    );
+  });
+});

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts
@@ -41,16 +41,19 @@ interface Rule {
   duration?: number;
 }
 
+export interface FiringAlertRuleSignals {
+  metricCounts: Map<string, number>;
+  /** SLO UUID → severities found on currently firing rules. */
+  firingSloUuids: Map<string, Set<string>>;
+  ruleCount: number;
+}
+
 /**
- * Fetches currently firing alert rules from Grafana's Prometheus-compatible ruler endpoint
- * and maps them to metric names.
- *
- * Uses the `?state=firing` server-side filter to reduce payload size, and `limit_alerts=0`
- * to skip individual alert instance details.
- *
- * @returns A Map of metric name → count of firing alert rules that reference the metric
+ * Fetches currently firing alert rules from Grafana's Prometheus-compatible ruler endpoint.
+ * The normalized result retains both source metric counts and canonical SLO labels so consumers
+ * can share one ruler request without coupling SLO detection to generated recording metric names.
  */
-export async function fetchFiringAlertMetrics(): Promise<Map<string, number>> {
+export async function fetchFiringAlertRuleSignals(): Promise<FiringAlertRuleSignals> {
   const start = performance.now();
 
   try {
@@ -61,17 +64,17 @@ export async function fetchFiringAlertMetrics(): Promise<Map<string, number>> {
       usageRequestOptions
     );
 
-    const { metricCounts, ruleCount } = parseFiringRules(response);
+    const result = parseFiringRules(response);
     const durationMs = Math.round(performance.now() - start);
 
     reportExploreMetrics('firing_alert_metrics_fetched', {
       status: 'success',
       duration_ms: durationMs,
-      metric_count: metricCounts.size,
-      rule_count: ruleCount,
+      metric_count: result.metricCounts.size,
+      rule_count: result.ruleCount,
     });
 
-    return metricCounts;
+    return result;
   } catch (err) {
     const durationMs = Math.round(performance.now() - start);
 
@@ -88,17 +91,23 @@ export async function fetchFiringAlertMetrics(): Promise<Map<string, number>> {
         'Failed to fetch firing alert rules from Prometheus ruler endpoint'
       ),
     });
-    return new Map();
+    return { metricCounts: new Map(), firingSloUuids: new Map(), ruleCount: 0 };
   }
 }
 
-function parseFiringRules(response: RulerRulesResponse): { metricCounts: Map<string, number>; ruleCount: number } {
+/** @returns A Map of metric name → count of firing alert rules that reference the metric. */
+export async function fetchFiringAlertMetrics(): Promise<Map<string, number>> {
+  return (await fetchFiringAlertRuleSignals()).metricCounts;
+}
+
+function parseFiringRules(response: RulerRulesResponse): FiringAlertRuleSignals {
   const metricCounts = new Map<string, number>();
+  const firingSloUuids = new Map<string, Set<string>>();
   let ruleCount = 0;
 
   const groups = response?.data?.groups;
   if (!Array.isArray(groups)) {
-    return { metricCounts, ruleCount };
+    return { metricCounts, firingSloUuids, ruleCount };
   }
 
   for (const group of groups) {
@@ -106,19 +115,37 @@ function parseFiringRules(response: RulerRulesResponse): { metricCounts: Map<str
       continue;
     }
 
-    const alertingRules = group.rules.filter(
+    const alertingRules = group.rules.filter((rule) => rule.type === 'alerting');
+    const alertingRulesWithQueries = alertingRules.filter(
       (rule): rule is Rule & { name: string; query: string } =>
-        rule.type === 'alerting' && typeof rule.query === 'string' && rule.query !== ''
+        typeof rule.name === 'string' && typeof rule.query === 'string' && rule.query !== ''
     );
 
-    ruleCount += alertingRules.length;
+    ruleCount += alertingRulesWithQueries.length;
 
     for (const rule of alertingRules) {
+      retainSloLabels(rule, firingSloUuids);
+    }
+    for (const rule of alertingRulesWithQueries) {
       countMetricsFromRule(rule, metricCounts);
     }
   }
 
-  return { metricCounts, ruleCount };
+  return { metricCounts, firingSloUuids, ruleCount };
+}
+
+function retainSloLabels(rule: Rule, firingSloUuids: Map<string, Set<string>>): void {
+  const uuid = rule.labels?.grafana_slo_uuid;
+  if (!uuid) {
+    return;
+  }
+
+  const severities = firingSloUuids.get(uuid) ?? new Set<string>();
+  const severity = rule.labels?.grafana_slo_severity;
+  if (severity) {
+    severities.add(severity);
+  }
+  firingSloUuids.set(uuid, severities);
 }
 
 function countMetricsFromRule(rule: Rule & { name: string; query: string }, metricCounts: Map<string, number>): void {

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchFiringAlertMetrics.ts
@@ -42,6 +42,7 @@ interface Rule {
 }
 
 export interface FiringAlertRuleSignals {
+  status: 'ready' | 'error';
   metricCounts: Map<string, number>;
   /** SLO UUID → severities found on currently firing rules. */
   firingSloUuids: Map<string, Set<string>>;
@@ -91,7 +92,7 @@ export async function fetchFiringAlertRuleSignals(): Promise<FiringAlertRuleSign
         'Failed to fetch firing alert rules from Prometheus ruler endpoint'
       ),
     });
-    return { metricCounts: new Map(), firingSloUuids: new Map(), ruleCount: 0 };
+    return { status: 'error', metricCounts: new Map(), firingSloUuids: new Map(), ruleCount: 0 };
   }
 }
 
@@ -107,7 +108,7 @@ function parseFiringRules(response: RulerRulesResponse): FiringAlertRuleSignals 
 
   const groups = response?.data?.groups;
   if (!Array.isArray(groups)) {
-    return { metricCounts, firingSloUuids, ruleCount };
+    return { status: 'ready', metricCounts, firingSloUuids, ruleCount };
   }
 
   for (const group of groups) {
@@ -124,14 +125,16 @@ function parseFiringRules(response: RulerRulesResponse): FiringAlertRuleSignals 
     ruleCount += alertingRulesWithQueries.length;
 
     for (const rule of alertingRules) {
-      retainSloLabels(rule, firingSloUuids);
+      if (rule.state === 'firing') {
+        retainSloLabels(rule, firingSloUuids);
+      }
     }
     for (const rule of alertingRulesWithQueries) {
       countMetricsFromRule(rule, metricCounts);
     }
   }
 
-  return { metricCounts, firingSloUuids, ruleCount };
+  return { status: 'ready', metricCounts, firingSloUuids, ruleCount };
 }
 
 function retainSloLabels(rule: Rule, firingSloUuids: Map<string, Set<string>>): void {

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchSloMetricSignals.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchSloMetricSignals.ts
@@ -81,7 +81,14 @@ export async function fetchSloMetricSignals(
       fetchFiringSignals(),
     ]);
 
-    const definitions = Array.isArray(response?.slos) ? response.slos : [];
+    if (!Array.isArray(response?.slos)) {
+      throw new Error('Unexpected SLO list response');
+    }
+    if (firingSignals.status === 'error') {
+      throw new Error('Failed to acquire active SLO burn signals');
+    }
+
+    const definitions = response.slos;
     const trackedMetrics = extractTrackedMetrics(definitions, datasourceUid);
     const firingUuids = new Set(firingSignals.firingSloUuids.keys());
     const activeBurnMetrics = new Set<string>();

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchSloMetricSignals.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/fetchSloMetricSignals.ts
@@ -1,0 +1,261 @@
+import { t } from '@grafana/i18n';
+import { getBackendSrv } from '@grafana/runtime';
+
+import { ensureErrorObject } from 'App/errorUtils';
+import { isSloTrackingEnabled } from 'shared/featureFlags/openFeature';
+import { logger } from 'shared/logger/logger';
+import { reportExploreMetrics } from 'shared/tracking/interactions';
+import { getPluginVersion } from 'shared/utils/getPluginVersion';
+import { extractMetricNames } from 'shared/utils/utils.promql';
+
+import { fetchFiringAlertRuleSignals, type FiringAlertRuleSignals } from './fetchFiringAlertMetrics';
+import { SLO_PLUGIN_ID, SLO_RESOURCE_URL, usageRequestOptions } from './shared';
+
+export { SLO_PLUGIN_ID, SLO_RESOURCE_URL } from './shared';
+
+export type SloMetricSignalsStatus = 'disabled' | 'plugin-absent' | 'ready' | 'error';
+
+export interface SloMetricSignals {
+  datasourceUid: string;
+  status: SloMetricSignalsStatus;
+  /** Source metric → SLO UUIDs whose definitions reference it. */
+  trackedMetrics: Map<string, Set<string>>;
+  /** Tracked source metrics owned by an SLO with a currently firing burn rule. */
+  activeBurnMetrics: Set<string>;
+}
+
+type FetchFiringSignals = () => Promise<FiringAlertRuleSignals>;
+
+interface SloListResponse {
+  slos?: unknown[];
+}
+
+interface SloDatasource {
+  uid?: string;
+  type?: string;
+}
+
+const PROMETHEUS_DATASOURCE_TYPES = new Set([
+  'prometheus',
+  'mimir',
+  'grafana-amazonprometheus-datasource',
+  'grafana-azureprometheus-datasource',
+]);
+
+function emptyResult(datasourceUid: string, status: SloMetricSignalsStatus): SloMetricSignals {
+  return {
+    datasourceUid,
+    status,
+    trackedMetrics: new Map(),
+    activeBurnMetrics: new Set(),
+  };
+}
+
+/**
+ * Fetches SLO definitions for the selected datasource and joins them to firing burn rules by
+ * `grafana_slo_uuid`. Optional-integration failures are returned as data so the metrics list can
+ * remain usable without treating an error as a valid empty definition list.
+ */
+export async function fetchSloMetricSignals(
+  datasourceUid: string,
+  fetchFiringSignals: FetchFiringSignals = fetchFiringAlertRuleSignals
+): Promise<SloMetricSignals> {
+  const start = performance.now();
+
+  if (!(await isSloTrackingEnabled())) {
+    return reportResult(emptyResult(datasourceUid, 'disabled'), start, 0);
+  }
+
+  if (!(await getPluginVersion(SLO_PLUGIN_ID))) {
+    return reportResult(emptyResult(datasourceUid, 'plugin-absent'), start, 0);
+  }
+
+  try {
+    const [response, firingSignals] = await Promise.all([
+      getBackendSrv().get<SloListResponse>(
+        SLO_RESOURCE_URL,
+        undefined,
+        'grafana-metricsdrilldown-app-slo-metric-signals',
+        usageRequestOptions
+      ),
+      fetchFiringSignals(),
+    ]);
+
+    const definitions = Array.isArray(response?.slos) ? response.slos : [];
+    const trackedMetrics = extractTrackedMetrics(definitions, datasourceUid);
+    const firingUuids = new Set(firingSignals.firingSloUuids.keys());
+    const activeBurnMetrics = new Set<string>();
+
+    for (const [metric, sloUuids] of trackedMetrics) {
+      if ([...sloUuids].some((uuid) => firingUuids.has(uuid))) {
+        activeBurnMetrics.add(metric);
+      }
+    }
+
+    return reportResult(
+      { datasourceUid, status: 'ready', trackedMetrics, activeBurnMetrics },
+      start,
+      definitions.length
+    );
+  } catch (error) {
+    logger.error(ensureErrorObject(error, 'Failed to fetch SLO metric signals'), {
+      message: t('fetch-slo-metric-signals.error', 'Failed to fetch SLO definitions'),
+    });
+    return reportResult(emptyResult(datasourceUid, 'error'), start, 0);
+  }
+}
+
+function reportResult(result: SloMetricSignals, start: number, definitionCount: number): SloMetricSignals {
+  reportExploreMetrics('slo_metric_signals_fetched', {
+    status: result.status,
+    duration_ms: Math.round(performance.now() - start),
+    definition_count: definitionCount,
+    metric_count: result.trackedMetrics.size,
+    active_burn_metric_count: result.activeBurnMetrics.size,
+  });
+  return result;
+}
+
+export function extractTrackedMetrics(definitions: unknown[], datasourceUid: string): Map<string, Set<string>> {
+  const trackedMetrics = new Map<string, Set<string>>();
+
+  for (const definition of definitions) {
+    if (
+      !isRecord(definition) ||
+      typeof definition.uuid !== 'string' ||
+      definition.uuid.length === 0 ||
+      !isRecord(definition.query)
+    ) {
+      continue;
+    }
+
+    const expressions = getDefinitionExpressions(definition, datasourceUid);
+    for (const expression of expressions) {
+      try {
+        for (const metric of extractMetricNames(expression)) {
+          const sloUuids = trackedMetrics.get(metric) ?? new Set<string>();
+          sloUuids.add(definition.uuid);
+          trackedMetrics.set(metric, sloUuids);
+        }
+      } catch (error) {
+        logger.warn(error, {
+          message: t('fetch-slo-metric-signals.parse-error', 'Failed to extract a metric name from an SLO definition'),
+        });
+      }
+    }
+  }
+
+  return trackedMetrics;
+}
+
+function getDefinitionExpressions(definition: Record<string, unknown>, datasourceUid: string): string[] {
+  const query = definition.query as Record<string, unknown>;
+  if (query.type === 'grafanaQueries') {
+    return getGrafanaQueryExpressions(query.grafanaQueries, datasourceUid);
+  }
+
+  const queryType = typeof query.type === 'string' ? query.type : '';
+  const branchValue = query[queryType];
+  const branch = isRecord(branchValue) ? branchValue : undefined;
+  if (!branch || !isMatchingPrometheusDatasource(getSourceDatasource(definition, branch), datasourceUid)) {
+    return [];
+  }
+
+  return getNativeDefinitionExpressions(query.type, branch);
+}
+
+function isMatchingPrometheusDatasource(source: SloDatasource | undefined, datasourceUid: string): boolean {
+  return source?.uid === datasourceUid && (source.type === undefined || isPrometheusDatasourceType(source.type));
+}
+
+function getNativeDefinitionExpressions(type: unknown, branch: Record<string, unknown>): string[] {
+  switch (type) {
+    case 'ratio':
+      return [getPrometheusMetric(branch.successMetric), getPrometheusMetric(branch.totalMetric)].filter(isString);
+    case 'failureRatio':
+      return [getPrometheusMetric(branch.failureMetric), getPrometheusMetric(branch.totalMetric)].filter(isString);
+    case 'threshold':
+      return typeof branch.thresholdExpression === 'string' ? [branch.thresholdExpression] : [];
+    case 'failureThreshold':
+      return typeof branch.failureThresholdExpression === 'string' ? [branch.failureThresholdExpression] : [];
+    case 'freeform':
+      return typeof branch.query === 'string' ? [branch.query] : [];
+    default:
+      return [];
+  }
+}
+
+function getSourceDatasource(
+  definition: Record<string, unknown>,
+  branch: Record<string, unknown>
+): SloDatasource | undefined {
+  const readOnly = isRecord(definition.readOnly) ? definition.readOnly : undefined;
+  const resolvedSource = readOnly && isRecord(readOnly.sourceDatasource) ? readOnly.sourceDatasource : undefined;
+  if (typeof resolvedSource?.uid === 'string') {
+    return {
+      uid: resolvedSource.uid,
+      type: typeof resolvedSource.type === 'string' ? resolvedSource.type : undefined,
+    };
+  }
+  if (typeof branch.sourceDatasourceUid === 'string') {
+    return { uid: branch.sourceDatasourceUid };
+  }
+  const destination = isRecord(definition.destinationDatasource) ? definition.destinationDatasource : undefined;
+  if (typeof destination?.uid !== 'string') {
+    return undefined;
+  }
+  return {
+    uid: destination.uid,
+    type: typeof destination.type === 'string' ? destination.type : undefined,
+  };
+}
+
+function getGrafanaQueryExpressions(value: unknown, datasourceUid: string): string[] {
+  if (!isRecord(value) || !Array.isArray(value.grafanaQueries)) {
+    return [];
+  }
+
+  return value.grafanaQueries.flatMap((query) => {
+    if (!isRecord(query) || typeof query.expr !== 'string' || typeof query.expression === 'string') {
+      return [];
+    }
+
+    const datasource = getGrafanaQueryDatasource(query);
+    if (!datasource || datasource.uid !== datasourceUid || !isPrometheusDatasourceType(datasource.type)) {
+      return [];
+    }
+
+    return [query.expr];
+  });
+}
+
+function getGrafanaQueryDatasource(query: Record<string, unknown>): SloDatasource | undefined {
+  if (isRecord(query.datasource)) {
+    return {
+      uid: typeof query.datasource.uid === 'string' ? query.datasource.uid : undefined,
+      type: typeof query.datasource.type === 'string' ? query.datasource.type : undefined,
+    };
+  }
+
+  if (typeof query.datasourceUid === 'string' && typeof query.datasourceType === 'string') {
+    return { uid: query.datasourceUid, type: query.datasourceType };
+  }
+
+  return undefined;
+}
+
+function isPrometheusDatasourceType(type: string | undefined): boolean {
+  return type !== undefined && PROMETHEUS_DATASOURCE_TYPES.has(type);
+}
+
+function getPrometheusMetric(value: unknown): string | undefined {
+  return isRecord(value) && typeof value.prometheusMetric === 'string' ? value.prometheusMetric : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isString(value: string | undefined): value is string {
+  return typeof value === 'string' && value.length > 0;
+}

--- a/src/MetricsReducer/list-controls/MetricsSorter/fetchers/shared.ts
+++ b/src/MetricsReducer/list-controls/MetricsSorter/fetchers/shared.ts
@@ -6,3 +6,5 @@ export const usageRequestOptions: Partial<BackendSrvRequest> = {
 } as const;
 
 export const GRAFANA_RULER_RULES_URL = '/api/prometheus/grafana/api/v1/rules';
+export const SLO_PLUGIN_ID = 'grafana-slo-app';
+export const SLO_RESOURCE_URL = `/api/plugins/${SLO_PLUGIN_ID}/resources/v1/slo`;

--- a/src/MetricsReducer/list-controls/SloTrackedChip/SloTrackedChip.tsx
+++ b/src/MetricsReducer/list-controls/SloTrackedChip/SloTrackedChip.tsx
@@ -150,6 +150,10 @@ export class SloTrackedChip extends SceneObjectBase<SloTrackedChipState> {
       }
 
       const metricsVariable = sceneGraph.lookupVariable(VAR_METRICS_VARIABLE, this) as MetricsVariable;
+      if (metricsVariable.state.loading) {
+        return undefined;
+      }
+
       const originalOptions = metricsVariable.state.options as MetricOptions;
       const filtersWithoutSlo = { ...filterEngine.getFilters(), sloTrackedMetrics: [] };
       const optionsForCounting = MetricsVariableFilterEngine.getFilteredOptions(originalOptions, filtersWithoutSlo);

--- a/src/MetricsReducer/list-controls/SloTrackedChip/SloTrackedChip.tsx
+++ b/src/MetricsReducer/list-controls/SloTrackedChip/SloTrackedChip.tsx
@@ -1,0 +1,222 @@
+import { css } from '@emotion/css';
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import {
+  sceneGraph,
+  SceneObjectBase,
+  SceneObjectUrlSyncConfig,
+  VariableDependencyConfig,
+  type SceneComponentProps,
+  type SceneObjectState,
+  type SceneObjectUrlValues,
+  type SceneVariable,
+} from '@grafana/scenes';
+import { Button, useStyles2 } from '@grafana/ui';
+import React from 'react';
+
+import { VAR_FILTERED_METRICS_VARIABLE } from 'MetricsReducer/metrics-variables/FilteredMetricsVariable';
+import {
+  VAR_METRICS_VARIABLE,
+  type MetricOptions,
+  type MetricsVariable,
+} from 'MetricsReducer/metrics-variables/MetricsVariable';
+import { MetricsVariableFilterEngine } from 'MetricsReducer/metrics-variables/MetricsVariableFilterEngine';
+import { MetricsReducer } from 'MetricsReducer/MetricsReducer';
+import { VAR_DATASOURCE } from 'shared/shared';
+import { reportExploreMetrics } from 'shared/tracking/interactions';
+
+import { EventFiltersChanged } from '../../SideBar/sections/MetricsFilterSection/EventFiltersChanged';
+import { type SloMetricSignals } from '../MetricsSorter/fetchers/fetchSloMetricSignals';
+import { MetricsSorter } from '../MetricsSorter/MetricsSorter';
+
+const URL_PARAM_KEY = 'filter-slo-tracked';
+
+const INITIAL_SIGNALS: SloMetricSignals = {
+  datasourceUid: '',
+  status: 'disabled',
+  trackedMetrics: new Map(),
+  activeBurnMetrics: new Set(),
+};
+
+interface SloTrackedChipState extends SceneObjectState {
+  active: boolean;
+  signals: SloMetricSignals;
+  matchingCount: number;
+  visible: boolean;
+}
+
+export class SloTrackedChip extends SceneObjectBase<SloTrackedChipState> {
+  private loadGeneration = 0;
+
+  protected _variableDependency = new VariableDependencyConfig(this, {
+    variableNames: [VAR_FILTERED_METRICS_VARIABLE, VAR_DATASOURCE],
+    onReferencedVariableValueChanged: (variable: SceneVariable) => {
+      if (variable.state.name === VAR_DATASOURCE) {
+        void this.loadSignals();
+      } else {
+        this.updateMatchingCount();
+      }
+    },
+  });
+
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: [URL_PARAM_KEY] });
+
+  constructor() {
+    super({
+      key: 'slo-tracked-chip',
+      active: false,
+      signals: INITIAL_SIGNALS,
+      matchingCount: 0,
+      visible: false,
+    });
+
+    this.addActivationHandler(() => {
+      void this.loadSignals();
+    });
+  }
+
+  getUrlState() {
+    return { [URL_PARAM_KEY]: this.state.active ? 'true' : '' };
+  }
+
+  updateFromUrl(values: SceneObjectUrlValues) {
+    const urlValue = values[URL_PARAM_KEY];
+    const shouldBeActive = urlValue === 'true' || urlValue === '1';
+    if (shouldBeActive === this.state.active) {
+      return;
+    }
+
+    this.setState({ active: shouldBeActive });
+    if (this.state.signals.status === 'ready') {
+      this.publishFilterEvent(shouldBeActive);
+    }
+  }
+
+  private async loadSignals() {
+    const generation = ++this.loadGeneration;
+    const wasActive = this.state.active;
+    if (wasActive) {
+      this.publishFilterEvent(false);
+    }
+    this.setState({ visible: false, matchingCount: 0 });
+
+    try {
+      const datasourceUid = this.getDatasourceUid();
+      const metricsSorter = sceneGraph.findByKeyAndType(this, 'metrics-sorter', MetricsSorter);
+      const signals = await metricsSorter.getSloMetricSignals(datasourceUid);
+      if (generation !== this.loadGeneration) {
+        return;
+      }
+
+      if (signals.status !== 'ready') {
+        this.setState({ signals, visible: false, active: false });
+        return;
+      }
+
+      this.setState({ signals, visible: true });
+      const matchingCount = this.updateMatchingCount();
+      if (this.state.active && matchingCount === 0) {
+        this.setState({ active: false });
+        this.publishFilterEvent(false);
+        return;
+      }
+      if (this.state.active) {
+        this.publishFilterEvent(true);
+      }
+    } catch {
+      if (generation !== this.loadGeneration) {
+        return;
+      }
+      this.setState({ signals: INITIAL_SIGNALS, visible: false, active: false });
+    }
+  }
+
+  private getDatasourceUid(): string {
+    return sceneGraph.lookupVariable(VAR_DATASOURCE, this)?.getValue()?.toString() ?? '';
+  }
+
+  private updateMatchingCount(): number | undefined {
+    if (this.state.signals.status !== 'ready' || this.state.signals.trackedMetrics.size === 0) {
+      this.setState({ matchingCount: 0 });
+      return 0;
+    }
+
+    try {
+      const metricsReducer = sceneGraph.getAncestor(this, MetricsReducer);
+      const filterEngine = metricsReducer.state.enginesMap.get(VAR_FILTERED_METRICS_VARIABLE)?.filterEngine;
+      if (!filterEngine) {
+        this.setState({ matchingCount: 0 });
+        return undefined;
+      }
+
+      const metricsVariable = sceneGraph.lookupVariable(VAR_METRICS_VARIABLE, this) as MetricsVariable;
+      const originalOptions = metricsVariable.state.options as MetricOptions;
+      const filtersWithoutSlo = { ...filterEngine.getFilters(), sloTrackedMetrics: [] };
+      const optionsForCounting = MetricsVariableFilterEngine.getFilteredOptions(originalOptions, filtersWithoutSlo);
+      const count = optionsForCounting.filter((option) =>
+        this.state.signals.trackedMetrics.has(option.value as string)
+      ).length;
+      this.setState({ matchingCount: count });
+      return count;
+    } catch {
+      this.setState({ matchingCount: 0 });
+      return undefined;
+    }
+  }
+
+  private publishFilterEvent(active: boolean) {
+    const metricNames = active ? [...this.state.signals.trackedMetrics.keys()] : [];
+    this.publishEvent(new EventFiltersChanged({ type: 'sloTrackedMetrics', filters: metricNames }), true);
+  }
+
+  public toggle = () => {
+    const active = !this.state.active;
+    this.setState({ active });
+    this.publishFilterEvent(active);
+    reportExploreMetrics('slo_tracked_filter_toggled', {
+      action: active ? 'activated' : 'deactivated',
+      matching_count: this.state.matchingCount,
+    });
+  };
+
+  public static readonly Component = ({ model }: SceneComponentProps<SloTrackedChip>) => {
+    const styles = useStyles2(getStyles);
+    const { active, matchingCount, visible } = model.useState();
+
+    if (!visible) {
+      return null;
+    }
+
+    const isEmpty = matchingCount === 0 && !active;
+    return (
+      <Button
+        className={`${styles.chip} ${active ? styles.chipActive : ''} ${isEmpty ? styles.chipEmpty : ''}`}
+        variant={active ? 'primary' : 'secondary'}
+        size="sm"
+        onClick={model.toggle}
+        aria-pressed={active}
+        aria-label={
+          active
+            ? t('slo-tracked-chip.aria-label-active', 'Remove SLO-tracked filter')
+            : t('slo-tracked-chip.aria-label-inactive', 'Filter by SLO-tracked metrics')
+        }
+        disabled={isEmpty}
+        title={
+          isEmpty
+            ? t('slo-tracked-chip.tooltip-empty', 'No SLO-tracked metrics in the current filtered set')
+            : undefined
+        }
+      >
+        {t('slo-tracked-chip.label', 'SLO-tracked ({{count}})', { count: matchingCount })}
+      </Button>
+    );
+  };
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    chip: css({ whiteSpace: 'nowrap', alignSelf: 'center' }),
+    chipActive: css({ fontWeight: theme.typography.fontWeightMedium }),
+    chipEmpty: css({ opacity: 0.5 }),
+  };
+}

--- a/src/MetricsReducer/list-controls/SloTrackedChip/SloTrackedChip.tsx
+++ b/src/MetricsReducer/list-controls/SloTrackedChip/SloTrackedChip.tsx
@@ -38,9 +38,11 @@ const INITIAL_SIGNALS: SloMetricSignals = {
   activeBurnMetrics: new Set(),
 };
 
+type SloTrackedChipSignals = SloMetricSignals | (Omit<SloMetricSignals, 'status'> & { status: 'loading' });
+
 interface SloTrackedChipState extends SceneObjectState {
   active: boolean;
-  signals: SloMetricSignals;
+  signals: SloTrackedChipSignals;
   matchingCount: number;
   visible: boolean;
 }
@@ -94,14 +96,23 @@ export class SloTrackedChip extends SceneObjectBase<SloTrackedChipState> {
 
   private async loadSignals() {
     const generation = ++this.loadGeneration;
+    const datasourceUid = this.getDatasourceUid();
     const wasActive = this.state.active;
     if (wasActive) {
       this.publishFilterEvent(false);
     }
-    this.setState({ visible: false, matchingCount: 0 });
+    this.setState({
+      signals: {
+        datasourceUid,
+        status: 'loading',
+        trackedMetrics: new Map(),
+        activeBurnMetrics: new Set(),
+      },
+      visible: false,
+      matchingCount: 0,
+    });
 
     try {
-      const datasourceUid = this.getDatasourceUid();
       const metricsSorter = sceneGraph.findByKeyAndType(this, 'metrics-sorter', MetricsSorter);
       const signals = await metricsSorter.getSloMetricSignals(datasourceUid);
       if (generation !== this.loadGeneration) {
@@ -109,17 +120,16 @@ export class SloTrackedChip extends SceneObjectBase<SloTrackedChipState> {
       }
 
       if (signals.status !== 'ready') {
+        const shouldClearFilter = wasActive || this.state.active;
         this.setState({ signals, visible: false, active: false });
+        if (shouldClearFilter) {
+          this.publishFilterEvent(false);
+        }
         return;
       }
 
       this.setState({ signals, visible: true });
-      const matchingCount = this.updateMatchingCount();
-      if (this.state.active && matchingCount === 0) {
-        this.setState({ active: false });
-        this.publishFilterEvent(false);
-        return;
-      }
+      this.updateMatchingCount();
       if (this.state.active) {
         this.publishFilterEvent(true);
       }
@@ -127,7 +137,20 @@ export class SloTrackedChip extends SceneObjectBase<SloTrackedChipState> {
       if (generation !== this.loadGeneration) {
         return;
       }
-      this.setState({ signals: INITIAL_SIGNALS, visible: false, active: false });
+      const shouldClearFilter = wasActive || this.state.active;
+      this.setState({
+        signals: {
+          datasourceUid,
+          status: 'error',
+          trackedMetrics: new Map(),
+          activeBurnMetrics: new Set(),
+        },
+        visible: false,
+        active: false,
+      });
+      if (shouldClearFilter) {
+        this.publishFilterEvent(false);
+      }
     }
   }
 
@@ -136,9 +159,12 @@ export class SloTrackedChip extends SceneObjectBase<SloTrackedChipState> {
   }
 
   private updateMatchingCount(): number | undefined {
-    if (this.state.signals.status !== 'ready' || this.state.signals.trackedMetrics.size === 0) {
+    if (this.state.signals.status !== 'ready') {
       this.setState({ matchingCount: 0 });
-      return 0;
+      return undefined;
+    }
+    if (this.state.signals.trackedMetrics.size === 0) {
+      return this.setMatchingCount(0);
     }
 
     try {
@@ -160,12 +186,20 @@ export class SloTrackedChip extends SceneObjectBase<SloTrackedChipState> {
       const count = optionsForCounting.filter((option) =>
         this.state.signals.trackedMetrics.has(option.value as string)
       ).length;
-      this.setState({ matchingCount: count });
-      return count;
+      return this.setMatchingCount(count);
     } catch {
       this.setState({ matchingCount: 0 });
       return undefined;
     }
+  }
+
+  private setMatchingCount(count: number): number {
+    this.setState({ matchingCount: count });
+    if (count === 0 && this.state.active) {
+      this.setState({ active: false });
+      this.publishFilterEvent(false);
+    }
+    return count;
   }
 
   private publishFilterEvent(active: boolean) {

--- a/src/MetricsReducer/list-controls/SloTrackedChip/__tests__/SloTrackedChip.test.tsx
+++ b/src/MetricsReducer/list-controls/SloTrackedChip/__tests__/SloTrackedChip.test.tsx
@@ -36,13 +36,13 @@ function signals(status: SloMetricSignals['status'], metrics: string[] = [], dat
   };
 }
 
-function setup(result: SloMetricSignals, options = ['http_requests_total', 'cpu_usage']) {
+function setup(result: SloMetricSignals, options = ['http_requests_total', 'cpu_usage'], loading = false) {
   const getSloMetricSignals = jest.fn().mockResolvedValue(result);
   mockFindByKeyAndType.mockReturnValue({ getSloMetricSignals });
   mockLookupVariable.mockImplementation((name: string) =>
     name === 'ds'
       ? { getValue: () => result.datasourceUid, state: { name: 'ds' } }
-      : { state: { options: options.map((value) => ({ label: value, value })) } }
+      : { state: { options: options.map((value) => ({ label: value, value })), loading } }
   );
   mockGetAncestor.mockReturnValue({
     state: {
@@ -167,6 +167,22 @@ describe('SloTrackedChip', () => {
       true
     );
     expect(mockReportExploreMetrics).not.toHaveBeenCalled();
+  });
+
+  it('keeps restored URL state while metric options are still loading', async () => {
+    setup(signals('ready', ['http_requests_total']), [], true);
+    const chip = new SloTrackedChip();
+    chip.updateFromUrl({ 'filter-slo-tracked': 'true' });
+    const publish = jest.spyOn(chip, 'publishEvent');
+
+    await activate(chip);
+
+    expect(chip.state.active).toBe(true);
+    expect(chip.getUrlState()).toEqual({ 'filter-slo-tracked': 'true' });
+    expect(publish).toHaveBeenLastCalledWith(
+      expect.objectContaining({ payload: { type: 'sloTrackedMetrics', filters: ['http_requests_total'] } }),
+      true
+    );
   });
 
   it('replaces active membership when the datasource changes without tracking a user toggle', async () => {

--- a/src/MetricsReducer/list-controls/SloTrackedChip/__tests__/SloTrackedChip.test.tsx
+++ b/src/MetricsReducer/list-controls/SloTrackedChip/__tests__/SloTrackedChip.test.tsx
@@ -1,0 +1,222 @@
+import { sceneGraph } from '@grafana/scenes';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { reportExploreMetrics } from 'shared/tracking/interactions';
+
+import { type SloMetricSignals } from '../../MetricsSorter/fetchers/fetchSloMetricSignals';
+import { SloTrackedChip } from '../SloTrackedChip';
+
+jest.mock('shared/tracking/interactions', () => ({ reportExploreMetrics: jest.fn() }));
+
+jest.mock('@grafana/scenes', () => {
+  const actual = jest.requireActual('@grafana/scenes');
+  return {
+    ...actual,
+    sceneGraph: {
+      ...actual.sceneGraph,
+      findByKeyAndType: jest.fn(),
+      getAncestor: jest.fn(),
+      lookupVariable: jest.fn(),
+    },
+  };
+});
+
+const mockFindByKeyAndType = sceneGraph.findByKeyAndType as jest.Mock;
+const mockGetAncestor = sceneGraph.getAncestor as jest.Mock;
+const mockLookupVariable = sceneGraph.lookupVariable as jest.Mock;
+const mockReportExploreMetrics = reportExploreMetrics as jest.Mock;
+
+function signals(status: SloMetricSignals['status'], metrics: string[] = [], datasourceUid = 'prom-a'): SloMetricSignals {
+  return {
+    datasourceUid,
+    status,
+    trackedMetrics: new Map(metrics.map((metric) => [metric, new Set(['slo-1'])])),
+    activeBurnMetrics: new Set(),
+  };
+}
+
+function setup(result: SloMetricSignals, options = ['http_requests_total', 'cpu_usage']) {
+  const getSloMetricSignals = jest.fn().mockResolvedValue(result);
+  mockFindByKeyAndType.mockReturnValue({ getSloMetricSignals });
+  mockLookupVariable.mockImplementation((name: string) =>
+    name === 'ds'
+      ? { getValue: () => result.datasourceUid, state: { name: 'ds' } }
+      : { state: { options: options.map((value) => ({ label: value, value })) } }
+  );
+  mockGetAncestor.mockReturnValue({
+    state: {
+      enginesMap: new Map([
+        [
+          'filtered-metrics-wingman',
+          {
+            filterEngine: {
+              getFilters: () => ({
+                categories: [],
+                prefixes: [],
+                suffixes: [],
+                names: [],
+                firingAlertMetrics: [],
+                sloTrackedMetrics: [],
+              }),
+            },
+          },
+        ],
+      ]),
+    },
+  });
+  return { getSloMetricSignals };
+}
+
+async function activate(chip: SloTrackedChip) {
+  await act(async () => {
+    await (chip as unknown as { loadSignals: () => Promise<void> }).loadSignals();
+  });
+}
+
+describe('SloTrackedChip', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the ready matching count and publishes exact tracked names on user toggle', async () => {
+    setup(signals('ready', ['http_requests_total', 'not-in-list']));
+    const chip = new SloTrackedChip();
+    await activate(chip);
+    const publish = jest.spyOn(chip, 'publishEvent');
+
+    render(<SloTrackedChip.Component model={chip} />);
+    expect(screen.getByText('SLO-tracked (1)')).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: 'Filter by SLO-tracked metrics' });
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(button);
+
+    expect(chip.state.active).toBe(true);
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { type: 'sloTrackedMetrics', filters: ['http_requests_total', 'not-in-list'] },
+      }),
+      true
+    );
+    expect(mockReportExploreMetrics).toHaveBeenCalledWith('slo_tracked_filter_toggled', {
+      action: 'activated',
+      matching_count: 1,
+    });
+  });
+
+  it.each(['disabled', 'plugin-absent', 'error'] as const)('hides and clears stale state for %s', async (status) => {
+    setup(signals(status));
+    const chip = new SloTrackedChip();
+    chip.setState({ active: true });
+    const publish = jest.spyOn(chip, 'publishEvent');
+
+    await activate(chip);
+    const { container } = render(<SloTrackedChip.Component model={chip} />);
+
+    expect(container.firstChild).toBeNull();
+    expect(chip.state.active).toBe(false);
+    expect(chip.getUrlState()).toEqual({ 'filter-slo-tracked': '' });
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { type: 'sloTrackedMetrics', filters: [] } }),
+      true
+    );
+  });
+
+  it('shows a disabled zero-count chip for a ready empty definition list', async () => {
+    setup(signals('ready'));
+    const chip = new SloTrackedChip();
+    await activate(chip);
+
+    render(<SloTrackedChip.Component model={chip} />);
+
+    expect(screen.getByText('SLO-tracked (0)')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'title',
+      'No SLO-tracked metrics in the current filtered set'
+    );
+  });
+
+  it('clears restored state when ready definitions do not match any metric in the selected datasource', async () => {
+    setup(signals('ready', ['not-in-list']));
+    const chip = new SloTrackedChip();
+    chip.updateFromUrl({ 'filter-slo-tracked': 'true' });
+    const publish = jest.spyOn(chip, 'publishEvent');
+
+    await activate(chip);
+
+    expect(chip.state.active).toBe(false);
+    expect(chip.getUrlState()).toEqual({ 'filter-slo-tracked': '' });
+    expect(publish).toHaveBeenLastCalledWith(
+      expect.objectContaining({ payload: { type: 'sloTrackedMetrics', filters: [] } }),
+      true
+    );
+  });
+
+  it('restores URL state only after ready data exists', async () => {
+    setup(signals('ready', ['http_requests_total']));
+    const chip = new SloTrackedChip();
+    chip.updateFromUrl({ 'filter-slo-tracked': 'true' });
+    const publish = jest.spyOn(chip, 'publishEvent');
+
+    expect(publish).not.toHaveBeenCalled();
+    await activate(chip);
+
+    expect(chip.state.active).toBe(true);
+    expect(chip.getUrlState()).toEqual({ 'filter-slo-tracked': 'true' });
+    expect(publish).toHaveBeenLastCalledWith(
+      expect.objectContaining({ payload: { type: 'sloTrackedMetrics', filters: ['http_requests_total'] } }),
+      true
+    );
+    expect(mockReportExploreMetrics).not.toHaveBeenCalled();
+  });
+
+  it('replaces active membership when the datasource changes without tracking a user toggle', async () => {
+    let uid = 'prom-a';
+    const getSloMetricSignals = jest.fn().mockImplementation(async (datasourceUid: string) =>
+      datasourceUid === 'prom-a'
+        ? signals('ready', ['metric_a'], datasourceUid)
+        : signals('ready', ['metric_b'], datasourceUid)
+    );
+    mockFindByKeyAndType.mockReturnValue({ getSloMetricSignals });
+    mockLookupVariable.mockImplementation((name: string) =>
+      name === 'ds'
+        ? { getValue: () => uid, state: { name: 'ds' } }
+        : { state: { options: [{ label: 'metric_a', value: 'metric_a' }, { label: 'metric_b', value: 'metric_b' }] } }
+    );
+    mockGetAncestor.mockReturnValue({
+      state: {
+        enginesMap: new Map([
+          [
+            'filtered-metrics-wingman',
+            {
+              filterEngine: {
+                getFilters: () => ({
+                  categories: [],
+                  prefixes: [],
+                  suffixes: [],
+                  names: [],
+                  firingAlertMetrics: [],
+                  sloTrackedMetrics: [],
+                }),
+              },
+            },
+          ],
+        ]),
+      },
+    });
+    const chip = new SloTrackedChip();
+    chip.setState({ active: true });
+    const publish = jest.spyOn(chip, 'publishEvent');
+
+    await activate(chip);
+    uid = 'prom-b';
+    await activate(chip);
+
+    expect(getSloMetricSignals).toHaveBeenNthCalledWith(1, 'prom-a');
+    expect(getSloMetricSignals).toHaveBeenNthCalledWith(2, 'prom-b');
+    expect(publish).toHaveBeenLastCalledWith(
+      expect.objectContaining({ payload: { type: 'sloTrackedMetrics', filters: ['metric_b'] } }),
+      true
+    );
+    expect(mockReportExploreMetrics).not.toHaveBeenCalled();
+  });
+});

--- a/src/MetricsReducer/list-controls/SloTrackedChip/__tests__/SloTrackedChip.test.tsx
+++ b/src/MetricsReducer/list-controls/SloTrackedChip/__tests__/SloTrackedChip.test.tsx
@@ -27,7 +27,11 @@ const mockGetAncestor = sceneGraph.getAncestor as jest.Mock;
 const mockLookupVariable = sceneGraph.lookupVariable as jest.Mock;
 const mockReportExploreMetrics = reportExploreMetrics as jest.Mock;
 
-function signals(status: SloMetricSignals['status'], metrics: string[] = [], datasourceUid = 'prom-a'): SloMetricSignals {
+function signals(
+  status: SloMetricSignals['status'],
+  metrics: string[] = [],
+  datasourceUid = 'prom-a'
+): SloMetricSignals {
   return {
     datasourceUid,
     status,
@@ -129,10 +133,7 @@ describe('SloTrackedChip', () => {
 
     expect(screen.getByText('SLO-tracked (0)')).toBeInTheDocument();
     expect(screen.getByRole('button')).toBeDisabled();
-    expect(screen.getByRole('button')).toHaveAttribute(
-      'title',
-      'No SLO-tracked metrics in the current filtered set'
-    );
+    expect(screen.getByRole('button')).toHaveAttribute('title', 'No SLO-tracked metrics in the current filtered set');
   });
 
   it('clears restored state when ready definitions do not match any metric in the selected datasource', async () => {
@@ -185,18 +186,121 @@ describe('SloTrackedChip', () => {
     );
   });
 
-  it('replaces active membership when the datasource changes without tracking a user toggle', async () => {
-    let uid = 'prom-a';
-    const getSloMetricSignals = jest.fn().mockImplementation(async (datasourceUid: string) =>
-      datasourceUid === 'prom-a'
-        ? signals('ready', ['metric_a'], datasourceUid)
-        : signals('ready', ['metric_b'], datasourceUid)
+  it('clears a restored active filter when delayed metric options resolve with no matches', async () => {
+    const metricsVariable = {
+      state: { options: [] as Array<{ label: string; value: string }>, loading: true },
+    };
+    setup(signals('ready', ['http_requests_total']), [], true);
+    mockLookupVariable.mockImplementation((name: string) =>
+      name === 'ds' ? { getValue: () => 'prom-a', state: { name: 'ds' } } : metricsVariable
     );
+    const chip = new SloTrackedChip();
+    chip.updateFromUrl({ 'filter-slo-tracked': 'true' });
+    const publish = jest.spyOn(chip, 'publishEvent');
+
+    await activate(chip);
+    expect(chip.state.active).toBe(true);
+
+    metricsVariable.state = {
+      options: [{ label: 'untracked_metric', value: 'untracked_metric' }],
+      loading: false,
+    };
+    act(() => {
+      (chip as unknown as { updateMatchingCount: () => number | undefined }).updateMatchingCount();
+    });
+
+    expect(chip.state.active).toBe(false);
+    expect(chip.getUrlState()).toEqual({ 'filter-slo-tracked': '' });
+    expect(publish).toHaveBeenLastCalledWith(
+      expect.objectContaining({ payload: { type: 'sloTrackedMetrics', filters: [] } }),
+      true
+    );
+  });
+
+  it('replaces ready signals with datasource-scoped loading state before awaiting a reload', async () => {
+    let uid = 'prom-a';
+    let resolveReload!: (value: SloMetricSignals) => void;
+    const getSloMetricSignals = jest
+      .fn()
+      .mockResolvedValueOnce(signals('ready', ['metric_a'], 'prom-a'))
+      .mockReturnValueOnce(new Promise<SloMetricSignals>((resolve) => (resolveReload = resolve)));
     mockFindByKeyAndType.mockReturnValue({ getSloMetricSignals });
     mockLookupVariable.mockImplementation((name: string) =>
       name === 'ds'
         ? { getValue: () => uid, state: { name: 'ds' } }
-        : { state: { options: [{ label: 'metric_a', value: 'metric_a' }, { label: 'metric_b', value: 'metric_b' }] } }
+        : { state: { options: [{ label: 'metric_a', value: 'metric_a' }], loading: false } }
+    );
+    mockGetAncestor.mockReturnValue({
+      state: {
+        enginesMap: new Map([
+          [
+            'filtered-metrics-wingman',
+            {
+              filterEngine: {
+                getFilters: () => ({
+                  categories: [],
+                  prefixes: [],
+                  suffixes: [],
+                  names: [],
+                  firingAlertMetrics: [],
+                  sloTrackedMetrics: [],
+                }),
+              },
+            },
+          ],
+        ]),
+      },
+    });
+    const chip = new SloTrackedChip();
+    chip.setState({ active: true });
+    const publish = jest.spyOn(chip, 'publishEvent');
+
+    await activate(chip);
+    uid = 'prom-b';
+    let reload!: Promise<void>;
+    act(() => {
+      reload = (chip as unknown as { loadSignals: () => Promise<void> }).loadSignals();
+    });
+
+    expect(chip.state.signals).toMatchObject({ datasourceUid: 'prom-b', status: 'loading' });
+    expect(chip.state.signals.trackedMetrics.size).toBe(0);
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { type: 'sloTrackedMetrics', filters: [] } }),
+      true
+    );
+
+    resolveReload(signals('error', [], 'prom-b'));
+    await act(async () => reload);
+
+    expect(chip.state.active).toBe(false);
+    expect(chip.state.signals).toMatchObject({ datasourceUid: 'prom-b', status: 'error' });
+    expect(publish).toHaveBeenLastCalledWith(
+      expect.objectContaining({ payload: { type: 'sloTrackedMetrics', filters: [] } }),
+      true
+    );
+  });
+
+  it('replaces active membership when the datasource changes without tracking a user toggle', async () => {
+    let uid = 'prom-a';
+    const getSloMetricSignals = jest
+      .fn()
+      .mockImplementation(async (datasourceUid: string) =>
+        datasourceUid === 'prom-a'
+          ? signals('ready', ['metric_a'], datasourceUid)
+          : signals('ready', ['metric_b'], datasourceUid)
+      );
+    mockFindByKeyAndType.mockReturnValue({ getSloMetricSignals });
+    mockLookupVariable.mockImplementation((name: string) =>
+      name === 'ds'
+        ? { getValue: () => uid, state: { name: 'ds' } }
+        : {
+            state: {
+              options: [
+                { label: 'metric_a', value: 'metric_a' },
+                { label: 'metric_b', value: 'metric_b' },
+              ],
+            },
+          }
     );
     mockGetAncestor.mockReturnValue({
       state: {

--- a/src/MetricsReducer/list-controls/__tests__/ListControls.test.ts
+++ b/src/MetricsReducer/list-controls/__tests__/ListControls.test.ts
@@ -61,15 +61,33 @@ jest.mock('../FiringAlertChip/FiringAlertChip', () => {
   return { FiringAlertChip: MockFiringAlertChip };
 });
 
+jest.mock('../SloTrackedChip/SloTrackedChip', () => {
+  const { SceneObjectBase } = jest.requireActual('@grafana/scenes');
+  class MockSloTrackedChip extends SceneObjectBase {
+    constructor() {
+      super({ key: 'slo-tracked-chip' });
+    }
+    static readonly Component = () => null;
+  }
+  return { SloTrackedChip: MockSloTrackedChip };
+});
+
 import { sceneGraph } from '@grafana/scenes';
 
 import { FiringAlertChip } from '../FiringAlertChip/FiringAlertChip';
 import { ListControls } from '../ListControls';
+import { SloTrackedChip } from '../SloTrackedChip/SloTrackedChip';
 
 describe('ListControls scene-graph wiring', () => {
   test('FiringAlertChip is present in the scene graph with key "firing-alert-chip"', () => {
     const controls = new ListControls({});
     const chip = sceneGraph.findByKeyAndType(controls, 'firing-alert-chip', FiringAlertChip);
     expect(chip).toBeInstanceOf(FiringAlertChip);
+  });
+
+  test('SloTrackedChip is present in the scene graph with key "slo-tracked-chip"', () => {
+    const controls = new ListControls({});
+    const chip = sceneGraph.findByKeyAndType(controls, 'slo-tracked-chip', SloTrackedChip);
+    expect(chip).toBeInstanceOf(SloTrackedChip);
   });
 });

--- a/src/MetricsReducer/metrics-variables/MetricsVariableFilterEngine.ts
+++ b/src/MetricsReducer/metrics-variables/MetricsVariableFilterEngine.ts
@@ -10,6 +10,7 @@ export type MetricFilters = {
   suffixes: string[];
   names: string[];
   firingAlertMetrics: string[];
+  sloTrackedMetrics: string[];
 };
 
 export class MetricsVariableFilterEngine {
@@ -21,6 +22,7 @@ export class MetricsVariableFilterEngine {
     suffixes: [],
     names: [],
     firingAlertMetrics: [],
+    sloTrackedMetrics: [],
   };
 
   constructor(variable: QueryVariable) {
@@ -64,9 +66,16 @@ export class MetricsVariableFilterEngine {
     }
 
     if (filters.firingAlertMetrics.length > 0) {
-      filteredOptions = MetricsVariableFilterEngine.applyFiringAlertMetricsFilter(
+      filteredOptions = MetricsVariableFilterEngine.applyExactMetricNamesFilter(
         filteredOptions,
         filters.firingAlertMetrics
+      );
+    }
+
+    if (filters.sloTrackedMetrics.length > 0) {
+      filteredOptions = MetricsVariableFilterEngine.applyExactMetricNamesFilter(
+        filteredOptions,
+        filters.sloTrackedMetrics
       );
     }
 
@@ -88,7 +97,8 @@ export class MetricsVariableFilterEngine {
       !updatedFilters.prefixes.length &&
       !updatedFilters.suffixes.length &&
       !updatedFilters.names.length &&
-      !updatedFilters.firingAlertMetrics.length
+      !updatedFilters.firingAlertMetrics.length &&
+      !updatedFilters.sloTrackedMetrics.length
     ) {
       this.filters = updatedFilters;
 
@@ -176,11 +186,8 @@ export class MetricsVariableFilterEngine {
     return filteredOptions;
   }
 
-  private static applyFiringAlertMetricsFilter(
-    options: MetricOptions,
-    firingAlertMetrics: string[]
-  ): MetricOptions {
-    const metricsSet = new Set(firingAlertMetrics);
+  private static applyExactMetricNamesFilter(options: MetricOptions, metricNames: string[]): MetricOptions {
+    const metricsSet = new Set(metricNames);
     return options.filter((option) => metricsSet.has(option.value as string));
   }
 

--- a/src/MetricsReducer/metrics-variables/__tests__/MetricsVariableFilterEngine.test.ts
+++ b/src/MetricsReducer/metrics-variables/__tests__/MetricsVariableFilterEngine.test.ts
@@ -237,11 +237,7 @@ describe('MetricsVariableFilterEngine - firingAlertMetrics filtering', () => {
 
   test('composes with prefixes filter — returns intersection', () => {
     const { engine, setState } = setup();
-    const options = createOptions([
-      'http_requests_total',
-      'http_errors_total',
-      'cpu_usage',
-    ]);
+    const options = createOptions(['http_requests_total', 'http_errors_total', 'cpu_usage']);
 
     engine.setInitOptions(options);
     engine.applyFilters(
@@ -278,10 +274,57 @@ describe('MetricsVariableFilterEngine - firingAlertMetrics filtering', () => {
     engine.setInitOptions(options);
     // forceUpdate: true so the reset path runs even though the engine starts with empty filters
     engine.applyFilters(
-      { categories: [], prefixes: [], suffixes: [], names: [], firingAlertMetrics: [] },
+      { categories: [], prefixes: [], suffixes: [], names: [], firingAlertMetrics: [], sloTrackedMetrics: [] },
       { forceUpdate: true, notify: false }
     );
 
     expect(setState).toHaveBeenCalledWith({ options });
+  });
+});
+
+describe('MetricsVariableFilterEngine - sloTrackedMetrics filtering', () => {
+  test('filters to exact tracked metric names and ignores unknown names', () => {
+    const { engine, setState } = setup();
+    const options = createOptions(['http_requests_total', 'http_errors_total', 'cpu_usage']);
+
+    engine.setInitOptions(options);
+    engine.applyFilters(
+      { sloTrackedMetrics: ['http_requests_total', 'missing_metric'] },
+      { forceUpdate: false, notify: false }
+    );
+
+    expect(setState).toHaveBeenCalledWith({
+      options: [{ label: 'http_requests_total', value: 'http_requests_total' }],
+    });
+  });
+
+  test('composes with prefix, suffix, search, and firing-alert dimensions', () => {
+    const options = createOptions([
+      'http_api_requests_total',
+      'http_web_requests_total',
+      'http_api_errors_total',
+      'cpu_usage',
+    ]);
+    const filtered = MetricsVariableFilterEngine.getFilteredOptions(options, {
+      categories: [],
+      prefixes: ['http'],
+      suffixes: ['total'],
+      names: ['.*api.*'],
+      firingAlertMetrics: ['http_api_requests_total', 'http_web_requests_total'],
+      sloTrackedMetrics: ['http_api_requests_total', 'http_api_errors_total'],
+    });
+
+    expect(filtered).toEqual([{ label: 'http_api_requests_total', value: 'http_api_requests_total' }]);
+  });
+
+  test('clearing the SLO dimension restores the original options', () => {
+    const { engine, setState } = setup();
+    const options = createOptions(['http_requests_total', 'cpu_usage']);
+
+    engine.setInitOptions(options);
+    engine.applyFilters({ sloTrackedMetrics: ['http_requests_total'] }, { forceUpdate: false, notify: false });
+    engine.applyFilters({ sloTrackedMetrics: [] }, { forceUpdate: false, notify: false });
+
+    expect(setState).toHaveBeenLastCalledWith({ options });
   });
 });

--- a/src/locales/en-US/grafana-metricsdrilldown-app.json
+++ b/src/locales/en-US/grafana-metricsdrilldown-app.json
@@ -144,6 +144,10 @@
   "fetch-firing-alert-metrics": {
     "error": "Failed to fetch firing alert rules from Prometheus ruler endpoint"
   },
+  "fetch-slo-metric-signals": {
+    "error": "Failed to fetch SLO definitions",
+    "parse-error": "Failed to extract a metric name from an SLO definition"
+  },
   "filtered-metrics-variable": {
     "label": "Filtered Metrics"
   },
@@ -430,6 +434,17 @@
       "suffix-filters": "Suffix filters",
       "suffix-filters-description": "Filter metrics based on their name suffix"
     }
+  },
+  "slo-tracked-badge": {
+    "tooltip_one": "{{count}} SLO definition references this metric",
+    "tooltip_other": "{{count}} SLO definitions reference this metric"
+  },
+  "slo-tracked-chip": {
+    "aria-label-active": "Remove SLO-tracked filter",
+    "aria-label-inactive": "Filter by SLO-tracked metrics",
+    "label_one": "SLO-tracked ({{count}})",
+    "label_other": "SLO-tracked ({{count}})",
+    "tooltip-empty": "No SLO-tracked metrics in the current filtered set"
   },
   "sort-by": {
     "label": "Sort by",

--- a/src/shared/GmdVizPanel/components/SloTrackedBadge.tsx
+++ b/src/shared/GmdVizPanel/components/SloTrackedBadge.tsx
@@ -1,0 +1,97 @@
+import { css } from '@emotion/css';
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import {
+  sceneGraph,
+  SceneObjectBase,
+  VariableDependencyConfig,
+  type SceneComponentProps,
+  type SceneObjectState,
+} from '@grafana/scenes';
+import { Icon, Tooltip, useStyles2 } from '@grafana/ui';
+import React from 'react';
+
+import { MetricsSorter } from 'MetricsReducer/list-controls/MetricsSorter/MetricsSorter';
+import { VAR_DATASOURCE } from 'shared/shared';
+
+interface SloTrackedBadgeState extends SceneObjectState {
+  metric: string;
+  ownerCount: number;
+  visible: boolean;
+}
+
+export class SloTrackedBadge extends SceneObjectBase<SloTrackedBadgeState> {
+  private loadGeneration = 0;
+
+  protected _variableDependency = new VariableDependencyConfig(this, {
+    variableNames: [VAR_DATASOURCE],
+    onReferencedVariableValueChanged: () => {
+      void this.loadOwnerCount();
+    },
+  });
+
+  constructor({ metric }: { metric: string }) {
+    super({ metric, ownerCount: 0, visible: false });
+    this.addActivationHandler(() => {
+      void this.loadOwnerCount();
+    });
+  }
+
+  private async loadOwnerCount() {
+    const generation = ++this.loadGeneration;
+    this.setState({ ownerCount: 0, visible: false });
+
+    try {
+      const datasourceUid = sceneGraph.lookupVariable(VAR_DATASOURCE, this)?.getValue()?.toString() ?? '';
+      const metricsSorter = sceneGraph.findByKeyAndType(this, 'metrics-sorter', MetricsSorter);
+      const signals = await metricsSorter.getSloMetricSignals(datasourceUid);
+      if (generation !== this.loadGeneration) {
+        return;
+      }
+
+      const ownerCount = signals.status === 'ready' ? (signals.trackedMetrics.get(this.state.metric)?.size ?? 0) : 0;
+      this.setState({ ownerCount, visible: ownerCount > 0 });
+    } catch {
+      if (generation === this.loadGeneration) {
+        this.setState({ ownerCount: 0, visible: false });
+      }
+    }
+  }
+
+  public static readonly Component = ({ model }: SceneComponentProps<SloTrackedBadge>) => {
+    const styles = useStyles2(getStyles);
+    const { ownerCount, visible } = model.useState();
+    if (!visible || ownerCount === 0) {
+      return null;
+    }
+
+    const tooltip = t('slo-tracked-badge.tooltip', '{{count}} SLO definitions reference this metric', {
+      count: ownerCount,
+    });
+
+    return (
+      <Tooltip content={tooltip}>
+        <div className={styles.badge} data-testid="slo-tracked-badge" role="img" aria-label={tooltip}>
+          <span aria-hidden="true">
+            <Icon name="heart" size="sm" />
+          </span>
+        </div>
+      </Tooltip>
+    );
+  };
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    badge: css({
+      display: 'inline-flex',
+      alignItems: 'center',
+      padding: theme.spacing(0, 0.5),
+      borderRadius: theme.shape.radius.pill,
+      backgroundColor: theme.colors.info.transparent,
+      color: theme.colors.info.text,
+      lineHeight: 1,
+      cursor: 'default',
+    }),
+  };
+}

--- a/src/shared/GmdVizPanel/components/__tests__/SloTrackedBadge.test.tsx
+++ b/src/shared/GmdVizPanel/components/__tests__/SloTrackedBadge.test.tsx
@@ -1,0 +1,134 @@
+import { sceneGraph } from '@grafana/scenes';
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { type SloMetricSignals } from 'MetricsReducer/list-controls/MetricsSorter/fetchers/fetchSloMetricSignals';
+
+import { SloTrackedBadge } from '../SloTrackedBadge';
+
+jest.mock('@grafana/scenes', () => {
+  const actual = jest.requireActual('@grafana/scenes');
+  return {
+    ...actual,
+    sceneGraph: {
+      ...actual.sceneGraph,
+      findByKeyAndType: jest.fn(),
+      lookupVariable: jest.fn(),
+    },
+  };
+});
+
+const mockFindByKeyAndType = sceneGraph.findByKeyAndType as jest.Mock;
+const mockLookupVariable = sceneGraph.lookupVariable as jest.Mock;
+
+function signals(status: SloMetricSignals['status'], owners: string[] = []): SloMetricSignals {
+  return {
+    datasourceUid: 'prom-a',
+    status,
+    trackedMetrics: new Map(owners.length ? [['http_requests_total', new Set(owners)]] : []),
+    activeBurnMetrics: new Set(owners.length ? ['http_requests_total'] : []),
+  };
+}
+
+async function activate(badge: SloTrackedBadge) {
+  await act(async () => {
+    await (badge as unknown as { loadOwnerCount: () => Promise<void> }).loadOwnerCount();
+  });
+}
+
+describe('SloTrackedBadge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLookupVariable.mockReturnValue({ getValue: () => 'prom-a' });
+  });
+
+  it('renders one accessible icon with the owning definition count for a tracked metric', async () => {
+    const getSloMetricSignals = jest.fn().mockResolvedValue(signals('ready', ['slo-1', 'slo-2']));
+    mockFindByKeyAndType.mockReturnValue({ getSloMetricSignals });
+    const badge = new SloTrackedBadge({ metric: 'http_requests_total' });
+
+    await activate(badge);
+    render(<SloTrackedBadge.Component model={badge} />);
+
+    expect(screen.getByTestId('slo-tracked-badge')).toHaveAccessibleName('2 SLO definitions reference this metric');
+    expect(screen.getByTestId('slo-tracked-badge').querySelector('svg')?.closest('span')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+    expect(getSloMetricSignals).toHaveBeenCalledWith('prom-a');
+  });
+
+  it('uses the same visual for tracked healthy and actively burning metrics', async () => {
+    mockFindByKeyAndType.mockReturnValue({
+      getSloMetricSignals: jest.fn().mockResolvedValue(signals('ready', ['slo-1'])),
+    });
+    const burning = new SloTrackedBadge({ metric: 'http_requests_total' });
+    await activate(burning);
+    const { unmount } = render(<SloTrackedBadge.Component model={burning} />);
+    expect(screen.getByTestId('slo-tracked-badge')).toBeInTheDocument();
+    unmount();
+
+    const healthySignals = signals('ready', ['slo-1']);
+    healthySignals.activeBurnMetrics.clear();
+    mockFindByKeyAndType.mockReturnValue({ getSloMetricSignals: jest.fn().mockResolvedValue(healthySignals) });
+    const healthy = new SloTrackedBadge({ metric: 'http_requests_total' });
+    await activate(healthy);
+    render(<SloTrackedBadge.Component model={healthy} />);
+    expect(screen.getByTestId('slo-tracked-badge')).toBeInTheDocument();
+  });
+
+  it.each(['disabled', 'plugin-absent', 'error'] as const)('stays hidden for %s integration state', async (status) => {
+    mockFindByKeyAndType.mockReturnValue({ getSloMetricSignals: jest.fn().mockResolvedValue(signals(status)) });
+    const badge = new SloTrackedBadge({ metric: 'http_requests_total' });
+
+    await activate(badge);
+    const { container } = render(<SloTrackedBadge.Component model={badge} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('ignores a stale response after the selected datasource changes', async () => {
+    let datasourceUid = 'prom-a';
+    let resolveFirst!: (value: SloMetricSignals) => void;
+    const firstResult = new Promise<SloMetricSignals>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const getSloMetricSignals = jest
+      .fn()
+      .mockImplementationOnce(() => firstResult)
+      .mockResolvedValueOnce(signals('ready'));
+    mockFindByKeyAndType.mockReturnValue({ getSloMetricSignals });
+    mockLookupVariable.mockImplementation(() => ({ getValue: () => datasourceUid }));
+    const badge = new SloTrackedBadge({ metric: 'http_requests_total' });
+
+    const staleLoad = (badge as unknown as { loadOwnerCount: () => Promise<void> }).loadOwnerCount();
+    datasourceUid = 'prom-b';
+    await activate(badge);
+    resolveFirst(signals('ready', ['slo-1']));
+    await staleLoad;
+    const { container } = render(<SloTrackedBadge.Component model={badge} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('clears tracked state when the selected datasource changes', async () => {
+    let datasourceUid = 'prom-a';
+    const getSloMetricSignals = jest
+      .fn()
+      .mockImplementation(async (uid: string) => (uid === 'prom-a' ? signals('ready', ['slo-1']) : signals('ready')));
+    mockFindByKeyAndType.mockReturnValue({ getSloMetricSignals });
+    mockLookupVariable.mockImplementation(() => ({ getValue: () => datasourceUid }));
+    const badge = new SloTrackedBadge({ metric: 'http_requests_total' });
+
+    await activate(badge);
+    const { container } = render(<SloTrackedBadge.Component model={badge} />);
+    expect(screen.getByTestId('slo-tracked-badge')).toBeVisible();
+
+    datasourceUid = 'prom-b';
+    await activate(badge);
+
+    expect(container.firstChild).toBeNull();
+    expect(getSloMetricSignals).toHaveBeenNthCalledWith(1, 'prom-a');
+    expect(getSloMetricSignals).toHaveBeenNthCalledWith(2, 'prom-b');
+  });
+});

--- a/src/shared/featureFlags/openFeature.test.ts
+++ b/src/shared/featureFlags/openFeature.test.ts
@@ -45,17 +45,20 @@ jest.mock('./tracking', () => ({
 
 describe('evaluateFeatureFlag', () => {
   const getStringValue = jest.fn();
+  const getBooleanValue = jest.fn();
   const addHandler = jest.fn();
   const addHooks = jest.fn();
   let clientMock: any;
 
   beforeEach(() => {
     getStringValue.mockReset();
+    getBooleanValue.mockReset();
     addHandler.mockReset();
     addHooks.mockReset();
 
     clientMock = {
       getStringValue,
+      getBooleanValue,
       addHandler,
       addHooks,
       providerStatus: ClientProviderStatus.READY,
@@ -106,6 +109,15 @@ describe('evaluateFeatureFlag', () => {
 
     // 'excluded' is the default value defined in openFeature.ts for this flag
     await expect(evaluateFeatureFlag('drilldown.metrics.default_open_sidebar')).resolves.toBe('excluded');
+  });
+
+  it('evaluates the SLO tracking flag as a boolean with a disabled default', async () => {
+    getBooleanValue.mockReturnValue(true);
+
+    const result = await evaluateFeatureFlag('drilldown.metrics.slo_tracked_metrics');
+
+    expect(getBooleanValue).toHaveBeenCalledWith('drilldown.metrics.slo_tracked_metrics', false);
+    expect(result).toBe(true);
   });
 
   it('evaluates the sort_by_firing_alerts A/B test flag as a string with the "excluded" default', async () => {

--- a/src/shared/featureFlags/openFeature.ts
+++ b/src/shared/featureFlags/openFeature.ts
@@ -16,6 +16,11 @@ const goffFeatureFlags = {
     values: [true, false] as const,
     defaultValue: false,
   },
+  'drilldown.metrics.slo_tracked_metrics': {
+    valueType: 'boolean',
+    values: [true, false] as const,
+    defaultValue: false,
+  },
   'drilldown.metrics.default_open_sidebar': {
     valueType: 'string',
     values: [
@@ -58,7 +63,13 @@ const goffFeatureFlags = {
  * @param trackingKey - If provided, the feature flag value will be tracked using the given key.
  */
 type FeatureFlag =
-  | { valueType: 'boolean'; values: readonly boolean[]; defaultValue: boolean; trackingKey?: string; featureToggle?: string }
+  | {
+      valueType: 'boolean';
+      values: readonly boolean[];
+      defaultValue: boolean;
+      trackingKey?: string;
+      featureToggle?: string;
+    }
   | {
       valueType: 'object';
       values: readonly JsonValue[];
@@ -228,6 +239,11 @@ export async function evaluateFeatureFlag<T extends keyof typeof goffFeatureFlag
  */
 export async function isFiringAlertsSortingEnabled(): Promise<boolean> {
   return (await evaluateFeatureFlag('drilldown.metrics.sort_by_firing_alerts')) === 'treatment';
+}
+
+/** Whether SLO-tracked metric filtering and indicators are enabled for the current stack. */
+export async function isSloTrackingEnabled(): Promise<boolean> {
+  return evaluateFeatureFlag('drilldown.metrics.slo_tracked_metrics');
 }
 
 /**

--- a/src/shared/tracking/interactions.ts
+++ b/src/shared/tracking/interactions.ts
@@ -224,6 +224,19 @@ type Interactions = {
     metric_count: number;
     rule_count: number;
   };
+  // Datasource-scoped SLO definitions and active-burn metadata have been resolved.
+  slo_metric_signals_fetched: {
+    status: 'disabled' | 'plugin-absent' | 'ready' | 'error';
+    duration_ms: number;
+    definition_count: number;
+    metric_count: number;
+    active_burn_metric_count: number;
+  };
+  // User toggles the SLO-tracked metric filter chip.
+  slo_tracked_filter_toggled: {
+    action: 'activated' | 'deactivated';
+    matching_count: number;
+  };
 };
 
 type OtherEvents = {

--- a/src/shared/utils/getPluginVersion.test.ts
+++ b/src/shared/utils/getPluginVersion.test.ts
@@ -71,5 +71,27 @@ describe('getPluginVersion', () => {
       expect(first).toBe('0.9.0');
       expect(second).toBe('0.9.0');
     });
+
+    it('caches versions independently by plugin id', async () => {
+      mockGetAppPluginVersion = jest.fn().mockImplementation(async (pluginId: string) => `${pluginId}-version`);
+
+      await expect(getPluginVersion('grafana-slo-app')).resolves.toBe('grafana-slo-app-version');
+      await expect(getPluginVersion(PLUGIN_ID)).resolves.toBe(`${PLUGIN_ID}-version`);
+      await expect(getPluginVersion('grafana-slo-app')).resolves.toBe('grafana-slo-app-version');
+
+      expect(mockGetAppPluginVersion).toHaveBeenCalledTimes(2);
+    });
+
+    it('can reset one plugin without invalidating another', async () => {
+      mockGetAppPluginVersion = jest.fn().mockResolvedValueOnce('slo-v1').mockResolvedValueOnce('metrics-v1');
+
+      await getPluginVersion('grafana-slo-app');
+      await getPluginVersion(PLUGIN_ID);
+      resetPluginVersionCache('grafana-slo-app');
+      mockGetAppPluginVersion.mockResolvedValueOnce('slo-v2');
+
+      await expect(getPluginVersion('grafana-slo-app')).resolves.toBe('slo-v2');
+      await expect(getPluginVersion(PLUGIN_ID)).resolves.toBe('metrics-v1');
+    });
   });
 });

--- a/src/shared/utils/getPluginVersion.ts
+++ b/src/shared/utils/getPluginVersion.ts
@@ -2,33 +2,36 @@ import { config } from '@grafana/runtime';
 
 import { PLUGIN_ID } from '../constants/plugin';
 
-let cachedVersion: string | null = null;
-let hasCached = false;
+const versionCache = new Map<string, string | null>();
 
-export function resetPluginVersionCache() {
-  cachedVersion = null;
-  hasCached = false;
+export function resetPluginVersionCache(pluginId?: string) {
+  if (pluginId) {
+    versionCache.delete(pluginId);
+    return;
+  }
+
+  versionCache.clear();
 }
 
-export async function getPluginVersion(): Promise<string | null> {
-  if (hasCached) {
-    return cachedVersion;
+export async function getPluginVersion(pluginId = PLUGIN_ID): Promise<string | null> {
+  if (versionCache.has(pluginId)) {
+    return versionCache.get(pluginId) ?? null;
   }
 
   try {
     const runtime = await import('@grafana/runtime');
 
     if (typeof runtime.getAppPluginVersion === 'function') {
-      cachedVersion = await runtime.getAppPluginVersion(PLUGIN_ID);
-      hasCached = true;
-      return cachedVersion;
+      const version = await runtime.getAppPluginVersion(pluginId);
+      versionCache.set(pluginId, version);
+      return version;
     }
   } catch {
-    // getAppPluginVersion not available (Grafana <12.4.0)
+    // getAppPluginVersion not available (Grafana <12.4.0) or the plugin is not installed.
   }
 
   // eslint-disable-next-line @typescript-eslint/no-deprecated, sonarjs/deprecation -- intentional fallback for Grafana <12.4.0
-  cachedVersion = config.apps?.[PLUGIN_ID]?.version ?? null;
-  hasCached = true;
-  return cachedVersion;
+  const version = config.apps?.[pluginId]?.version ?? null;
+  versionCache.set(pluginId, version);
+  return version;
 }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** #1258, #1265

Resolves #1263
Resolves #1264

Usage Guide:

## Identify an SLO-tracked metric

1. In Grafana, select **Drilldown** and then **Metrics**.
2. Select the Prometheus-compatible data source that contains the metric.
3. Set a time range in which the metric has data.
4. Browse the metric list or enter part of a metric name in **Search metric**.
5. Look for the blue heart indicator beside the metric name. Hover over the indicator to see how many SLO definitions reference the metric.

The number on the **SLO-tracked** chip updates as you apply search terms and sidebar filters. It represents the SLO-tracked metrics in the current filtered set.

![A searched metric with an SLO-tracked indicator and a filtered count of one](./01-search-and-badge.png)

## Filter to SLO-tracked metrics

1. Select the **SLO-tracked (N)** chip beside the search field.
2. Confirm that the chip is highlighted. The metric list now contains only metrics referenced by SLO definitions for the selected data source.
3. Select the chip again to remove the filter.

The filter combines with metric search, label filters, prefix and suffix filters, and other Metrics Drilldown controls. Filters across different controls use AND logic.


<img width="1920" height="1080" alt="03-grouped-slo-metrics" src="https://github.com/user-attachments/assets/cd5cf622-4b82-44c3-be7e-20c7adabfea1" />

## Implementation note

The shared SLO signal fetch also correlates SLO definitions with firing burn-rate rules and exposes the affected source metrics as `activeBurnMetrics`. This prepares the data path for follow-up active-burn indicators; this PR's UI uses the SLO-tracked signal only.
